### PR TITLE
Fix matlab startup so it works with older versions of Matlab

### DIFF
--- a/interfaces/matlab/helicsStartup.m
+++ b/interfaces/matlab/helicsStartup.m
@@ -1,5 +1,5 @@
 function success = helicsStartup(helicsLibPath)
-% HELICSSTARTUP configures MATLAB for HELICS use 
+% HELICSSTARTUP configures MATLAB for HELICS use
 
 if nargin < 1
     %If not specified use our location, which should have required lib once
@@ -16,10 +16,14 @@ libraryName = '';
 
 %TODO: vectorize (make MATLAB-esque)
 for i=1:numel(listing)
-    if endsWith(listing(i).name, '.h')
+    [~, ~, ext]=fileparts(listing(i).name);
+    if isequal(ext, '.h')
         continue;
     end
-    if endsWith(listing(i).name, '.lib')
+    if isequal(ext, '.lib')
+        continue;
+    end
+     if isequal(ext, '.a')
         continue;
     end
     libraryName = listing(i).name;
@@ -31,10 +35,14 @@ if isempty(libraryName)
     listing = dir(fullfile(directory, '*helicsSharedLibd.*'));
     
     for i=1:numel(listing)
-        if endsWith(listing(i).name, '.h')
+        [~, ~, ext]=fileparts(listing(i).name);
+        if isequal(ext, '.h')
             continue;
         end
-        if endsWith(listing(i).name, '.lib')
+        if isequal(ext, '.lib')
+            continue;
+        end
+        if isequal(ext, '.a')
             continue;
         end
         libraryName = listing(i).name;
@@ -43,7 +51,10 @@ if isempty(libraryName)
 end
 
 if (~isempty(libraryName))
-    loadlibrary(GetFullPath(fullfile(helicsLibPath, libraryName)));
+    [~,name]=fileparts(libraryName);
+    if ~libisloaded(name)
+        loadlibrary(GetFullPath(fullfile(helicsLibPath, libraryName)));
+    end
 else
     disp('Unable to find library for HELICS')
 end


### PR DESCRIPTION
 and doesn't make a warning when used repeatedly

<!--
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.

e.g.

This fixes issue #123
-->

- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository (BSD 3 clause)

### Description

<!-- please finish the following statement -->
If merged this pull request will fix the helicsStartup matlab script so it works on older versions of matlab and doesn't generate some warnings on repeated use.  
