### PR TITLE
Add a link to the HELICS GitHub repo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A list of optional component that are not included in HELICS but are optionally 
 
 ## Source Repo
 
-The HELICS source code is hosted on GitHub: https://github.com/GMLC-TDC/HELICS-src
+The HELICS source code is hosted on GitHub: https://github.com/GMLC-TDC/HELICS
 
 ## Release
 HELICS is distributed under the terms of the BSD-3 clause license. All new

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ A list of optional component that are not included in HELICS but are optionally 
 
 [1] B. Palmintier, D. Krishnamurthy, P. Top, S. Smith, J. Daily, and J. Fuller, “Design of the HELICS High-Performance Transmission-Distribution-Communication-Market Co-Simulation Framework,” in *Proc. of the 2017 Workshop on Modeling and Simulation of Cyber-Physical Energy Systems*, Pittsburgh, PA, 2017. [pre-print](https://www.nrel.gov/docs/fy17osti/67928.pdf) [published](https://ieeexplore.ieee.org/document/8064542/)
 
+## Source Repo
+
+The HELICS source code is hosted on GitHub: https://github.com/GMLC-TDC/HELICS-src
 
 ## Release
 HELICS is distributed under the terms of the BSD-3 clause license. All new


### PR DESCRIPTION
### Description
If merged this pull request will add a link back to the HELICS GitHub repository in the README. Just in case someone gets a tarball of the code and wants to know where it came from.

### Proposed changes
- Add a link back to the HELICS GitHub repo in the README
