### PR TITLE
Set dependent repo build branch to HELICS branch

### DIFF
--- a/scripts/trigger-dependent-ci-builds.sh
+++ b/scripts/trigger-dependent-ci-builds.sh
@@ -3,21 +3,21 @@
 BUILD_MESSAGE="Test ${TRAVIS_REPO_SLUG} ${TRAVIS_COMMIT_RANGE}"
 
 # Trigger HELICS-FMI build
-body='{
-"request": {
-"message":"'
-body+="${BUILD_MESSAGE}"
-body+='",
-"branch":"master"
-}}'
+#body='{
+#"request": {
+#"message":"'
+#body+="${BUILD_MESSAGE}"
+#body+='",
+#"branch":"master"
+#}}'
 
-curl -s -X POST \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json" \
-    -H "Travis-API-Version: 3" \
-    -H "Authorization: token ${HELICSBOT_TRAVIS_ORG_TOKEN}" \
-    -d "$body" \
-    https://api.travis-ci.org/repo/GMLC-TDC%2FHELICS-FMI/requests
+#curl -s -X POST \
+#    -H "Content-Type: application/json" \
+#    -H "Accept: application/json" \
+#    -H "Travis-API-Version: 3" \
+#    -H "Authorization: token ${HELICSBOT_TRAVIS_ORG_TOKEN}" \
+#    -d "$body" \
+#    https://api.travis-ci.org/repo/GMLC-TDC%2FHELICS-FMI/requests
 
 # Takes 2 arguments, a Azure org/project slug and pipeline/build definition id
 trigger_azure_build () {
@@ -40,6 +40,11 @@ trigger_azure_build () {
          -H "Authorization: Basic ${HELICSBOT_AZURE_TOKEN}" \
          -d "$body" \
          https://dev.azure.com/${azure_slug}/_apis/build/builds?api-version=4.1
+    
+    echo "===Triggering Azure build==="
+    echo "Slug: $azure_slug"
+    echo "Definition ID: $def_id"
+    echo "Request body: $body"
 }
 
 ################################

--- a/scripts/trigger-dependent-ci-builds.sh
+++ b/scripts/trigger-dependent-ci-builds.sh
@@ -25,7 +25,7 @@ trigger_azure_build () {
     local def_id=$2
     local body='{
     "definition": {
-    "id": ${def_id}
+    "id": '${def_id}'
     },
     '
     body+='"parameters": "{'${BUILD_PARAMS}'}",'


### PR DESCRIPTION
### Description
If merged this pull request will use the HELICS branch that was just built as the source branch to use in the dependent repository build. This should help make the result reported for builds to master/develop a bit more meaningful (Examples master branch needs updating for the release) and help ensure the master branches in different repositories are compatible.

### Proposed changes
- Test the branch in the dependent repository whose name matches
- Refactor the curl invocation into a bash function
