### PR TITLE
Remove the XCode 8.3 build for PRs to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
     # XCode 8.3, OS X 10.12
     - <<: *osx_base
       name: "XCode 8.3, macOS 10.12"
-      if: (branch = develop AND type IN (pull_request, cron)) OR (branch = master AND type IN (push, pull_request))
+      if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1


### PR DESCRIPTION
### Description
If merged this pull request will stop running the XCode 8.3 build on pull requests to develop due to the Travis issues that require a (very slow +26min) Homebrew update for each build. XCode 8.3 builds will still be run daily for develop, and for pushes and PRs to master.

### Proposed changes
- Remove the XCode 8.3 build for PRs to develop
