### PR TITLE
Fix links and name following the HELICS-src to HELICS GitHub repository rename

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,6 +21,7 @@
 * **What is the expected behavior? What is the motivation / use case for changing the behavior?**
 
 
+
 * **What are the steps to reproduce this bug? Please provide a minimal working example of the bug if possible.**
 
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support resources
 
-We have an active [Gitter]((https://gitter.im/GMLC-TDC/HELICS-src) channel
-Our GitHub pages provides a rich set of [documentation](https://gmlc-tdc.github.io/HELICS-src/index.html) including a set of introductory [examples](https://gmlc-tdc.github.io/HELICS-src/introduction/index.html), a [developers guide](https://gmlc-tdc.github.io/HELICS-src/developer-guide/index.html), complete doxygen-auto-produced [API documentation](https://gmlc-tdc.github.io/HELICS-src/doxygen/), There is a [WIKI](https://github.com/GMLC-TDC/HELICS-src/wiki) with some additional information, and [USER GUIDE]() to help you get started. 
+We have an active [Gitter]((https://gitter.im/GMLC-TDC/HELICS) channel
+Our GitHub pages provides a rich set of [documentation](https://helics.readthedocs.io/en/latest/) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/), complete doxygen-auto-produced [API documentation](https://helics.readthedocs.io/en/latest/doxygen/), There is a [WIKI](https://github.com/GMLC-TDC/HELICS/wiki) with some additional information, and [USER GUIDE]() to help you get started. 
 
 We've created a series of roughly 10-minute mini-tutorial videos that discuss various design topics, concepts, and interfaces, including how to use the tool. They can be found on our [YouTube channel](https://www.youtube.com/channel/UCPa81c4BVXEYXt2EShTzbcg).   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,7 +853,7 @@ if(ENABLE_PACKAGE_BUILD)
         set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local")
         set(
             CPACK_NSIS_URL_INFO_ABOUT
-            "https://www.github.com/GMLC-TDC/Helics-src"
+	    "https://www.github.com/GMLC-TDC/HELICS"
         )
         set(CPACK_NSIS_HELP_LINK "https://helics.readthedocs.io/en/latest")
         set(CPACK_NSIS_CONTACT "helicsteam@helics.org")
@@ -863,7 +863,7 @@ if(ENABLE_PACKAGE_BUILD)
         set(CPACK_NSIS_EXECUTABLES_DIRECTORY ${CMAKE_INSTALL_BINDIR})
         set(
             CPACK_NSIS_MENU_LINKS
-            "https://www.github.com/GMLC-TDC/Helics-src"
+	    "https://www.github.com/GMLC-TDC/HELICS"
             "HELICS Github"
             "https://helics.readthedocs.io/en/latest"
             "Helics Documentation"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ contributions must be made under this [LICENSE](LICENSE) in accordance with the 
 
 ##  [Code of Conduct](.github/CODE_OF_CONDUCT.md)
 
-If you just have a question check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
+If you just have a question check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)
 
-and there are a few questions answered on the github [WIKI](https://github.com/GMLC-TDC/HELICS-src/wiki) page for HELICS.
+and there are a few questions answered on the github [WIKI](https://github.com/GMLC-TDC/HELICS/wiki) page for HELICS.
 
 ## How Can I Contribute?
 
@@ -43,8 +43,8 @@ This section guides you through submitting a feature request, or enhancement for
 
 ### Your First Code Contribution
 
-Unsure where to begin contributing to HELICS? You can start by looking for [`help wanted`](https://github.com/GMLC-TDC/HELICS-src/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) [`beginner`](https://github.com/GMLC-TDC/HELICS-src/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+label%3A%22beginner%22) issues:
-Help with documentation and test cases is always welcome.  Take a look at the [code coverage reports](https://codecov.io/gh/GMLC-TDC/HELICS-src) for some ideas on places that need more testing
+Unsure where to begin contributing to HELICS? You can start by looking for [`help wanted`](https://github.com/GMLC-TDC/HELICS/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) [`beginner`](https://github.com/GMLC-TDC/HELICS/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+label%3A%22beginner%22) issues:
+Help with documentation and test cases is always welcome.  Take a look at the [code coverage reports](https://codecov.io/gh/GMLC-TDC/HELICS) for some ideas on places that need more testing
 
 ### Submitting a pull request
 Typically you would want to submit a pull request against the develop branch.  That branch gets merged into master periodically but the develop branch is the active development branch where all the code is tested and merged before making a release.  There is a [Pull request template](.github/PULL_REQUEST_TEMPLATE.md) that will guide you through the needed information.  The pull requests are run through several automated checks in Travis and AppVeyor and for the most part must pass these tests before merging.  The Codacy check is evaluated but not required as the checks are sometimes a bit aggressive.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
   </tr>
   <tr>
   <td>Appveyor</td>
-  <td><a href="https://ci.appveyor.com/project/nightlark/helics/branch/master"><img src="https://ci.appveyor.com/api/projects/status/afpa4mv0kgsjwvtn/branch/master?svg=true" alt="Build Status" /></a></td>
-  <td><a href="https://ci.appveyor.com/project/nightlark/helics/branch/develop"><img src="https://ci.appveyor.com/api/projects/status/afpa4mv0kgsjwvtn/branch/develop?svg=true" alt="Build Status" /></a></td>
+  <td><a href="https://ci.appveyor.com/project/HELICS/helics/branch/master"><img src="https://ci.appveyor.com/api/projects/status/9rnwrtelsa68k5lt/branch/master?svg=true" alt="Build Status" /></a></td>
+  <td><a href="https://ci.appveyor.com/project/HELICS/helics/branch/develop"><img src="https://ci.appveyor.com/api/projects/status/9rnwrtelsa68k5lt/branch/develop?svg=true" alt="Build Status" /></a></td>
   </tr>
   <tr>
   <td>Codacy</td>

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 <img src="docs/img/HELICS_Logo.png" width="400">
 </p>
 
-[![](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
+[![](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)
 [![](https://img.shields.io/badge/docs-ready-blue.svg)](https://helics.readthedocs.io/en/latest)
 [![](https://img.shields.io/conda/pn/gmlc-tdc/helics.svg)](https://anaconda.org/gmlc-tdc/helics/)
-[![Releases](https://img.shields.io/github/tag-date/GMLC-TDC/HELICS-src.svg)](https://github.com/GMLC-TDC/HELICS-src/releases)
-[![](https://img.shields.io/badge/License-BSD-blue.svg)](https://github.com/GMLC-TDC/HELICS-src/blob/master/LICENSE)
+[![Releases](https://img.shields.io/github/tag-date/GMLC-TDC/HELICS.svg)](https://github.com/GMLC-TDC/HELICS/releases)
+[![](https://img.shields.io/badge/License-BSD-blue.svg)](https://github.com/GMLC-TDC/HELICS/blob/master/LICENSE)
 ## Build Status
 <table>
   <tr>
@@ -16,23 +16,23 @@
   </tr>
   <tr>
   <td>Travis CI</td>
-  <td><a href="https://travis-ci.org/GMLC-TDC/HELICS-src"><img src="https://travis-ci.org/GMLC-TDC/HELICS-src.svg?branch=master" alt="Build Status" /></a></td>
-  <td><a href="https://travis-ci.org/GMLC-TDC/HELICS-src"><img src="https://travis-ci.org/GMLC-TDC/HELICS-src.svg?branch=develop" alt="Build Status" /></a></td>
+  <td><a href="https://travis-ci.org/GMLC-TDC/HELICS"><img src="https://travis-ci.org/GMLC-TDC/HELICS.svg?branch=master" alt="Build Status" /></a></td>
+  <td><a href="https://travis-ci.org/GMLC-TDC/HELICS"><img src="https://travis-ci.org/GMLC-TDC/HELICS.svg?branch=develop" alt="Build Status" /></a></td>
   </tr>
   <tr>
   <td>Appveyor</td>
-  <td><a href="https://ci.appveyor.com/project/nightlark/helics-src/branch/master"><img src="https://ci.appveyor.com/api/projects/status/afpa4mv0kgsjwvtn/branch/master?svg=true" alt="Build Status" /></a></td>
-  <td><a href="https://ci.appveyor.com/project/nightlark/helics-src/branch/develop"><img src="https://ci.appveyor.com/api/projects/status/afpa4mv0kgsjwvtn/branch/develop?svg=true" alt="Build Status" /></a></td>
+  <td><a href="https://ci.appveyor.com/project/nightlark/helics/branch/master"><img src="https://ci.appveyor.com/api/projects/status/afpa4mv0kgsjwvtn/branch/master?svg=true" alt="Build Status" /></a></td>
+  <td><a href="https://ci.appveyor.com/project/nightlark/helics/branch/develop"><img src="https://ci.appveyor.com/api/projects/status/afpa4mv0kgsjwvtn/branch/develop?svg=true" alt="Build Status" /></a></td>
   </tr>
   <tr>
   <td>Codacy</td>
-  <td><a href="https://www.codacy.com/app/phlptp/HELICS-src?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=GMLC-TDC/HELICS-src&amp;utm_campaign=Badge_Grade;branch=master"><img src="https://api.codacy.com/project/badge/Grade/83ba19b36b714c729ec3a3d18504505e?branch=master" alt="codacy" /></a></td>
-  <td><a href="https://www.codacy.com/app/phlptp/HELICS-src?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=GMLC-TDC/HELICS-src&amp;utm_campaign=Badge_Grade;branch=develop"><img src="https://api.codacy.com/project/badge/Grade/83ba19b36b714c729ec3a3d18504505e?branch=develop" alt="codacy" /></a></td>
+  <td><a href="https://www.codacy.com/app/phlptp/HELICS?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=GMLC-TDC/HELICS&amp;utm_campaign=Badge_Grade;branch=master"><img src="https://api.codacy.com/project/badge/Grade/83ba19b36b714c729ec3a3d18504505e?branch=master" alt="codacy" /></a></td>
+  <td><a href="https://www.codacy.com/app/phlptp/HELICS?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=GMLC-TDC/HELICS&amp;utm_campaign=Badge_Grade;branch=develop"><img src="https://api.codacy.com/project/badge/Grade/83ba19b36b714c729ec3a3d18504505e?branch=develop" alt="codacy" /></a></td>
   </tr>
   <tr>
   <td>Coverage</td>
-  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/master/graph/badge.svg" alt="codecov" /></a></td>
-  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/develop"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/develop/graph/badge.svg" alt="codecov" /></a></td>
+  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS"><img src="https://codecov.io/gh/GMLC-TDC/HELICS/branch/master/graph/badge.svg" alt="codecov" /></a></td>
+  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS/branch/develop"><img src="https://codecov.io/gh/GMLC-TDC/HELICS/branch/develop/graph/badge.svg" alt="codecov" /></a></td>
   </tr>
 </table>
 
@@ -69,7 +69,7 @@ A [Users guide](https://helics.readthedocs.io/en/latest/user-guide/index.html) f
 
 ## Documentation
 
-Our ReadTheDocs site provides a set of [documentation](https://helics.readthedocs.io/en/latest/index.html) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/index.html), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/index.html), complete doxygen generated [API documentation](https://helics.readthedocs.io/en/latest/doxygen/annotated.html), and more.  A few more questions and answers are available on the [Wiki](https://github.com/GMLC-TDC/HELICS-src/wiki).
+Our ReadTheDocs site provides a set of [documentation](https://helics.readthedocs.io/en/latest/index.html) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/index.html), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/index.html), complete doxygen generated [API documentation](https://helics.readthedocs.io/en/latest/doxygen/annotated.html), and more.  A few more questions and answers are available on the [Wiki](https://github.com/GMLC-TDC/HELICS/wiki).
 
 Additionally, our initial requirements document can be found [here](docs/introduction/original_specification.md), which describes a number of our early design considerations.
 

--- a/config/packaging/mingw-w64-helics/PKGBUILD
+++ b/config/packaging/mingw-w64-helics/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=2.0.0
 pkgrel=1
 pkgdesc="A C++ library for co-simulation"
 arch=('any')
-url="https://github.com/GMLC-TDC/HELICS-src"
+url="https://github.com/GMLC-TDC/HELICS"
 license=('BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 			 "${MINGW_PACKAGE_PREFIX}-swig"
              "${MINGW_PACKAGE_PREFIX}-python3")
 
-source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/GMLC-TDC/HELICS-src/archive/v${pkgver}.tar.gz"
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/GMLC-TDC/HELICS/archive/v${pkgver}.tar.gz"
         001-library-name.patch)
 #sha256sums=('c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6'
  #           'db74c4fb0e5b98a8365a99060166cfff36a7eda97f552cd838b8a7bb9799428a')

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,3 +1,3 @@
 # HELICS 404
 
-Page not found. Please visit the [homepage of HELICS documentation](https://helics.readthedocs.io/en/latest) or contact the developers at [gitter](https://gitter.im/GMLC-TDC/HELICS-src).
+Page not found. Please visit the [homepage of HELICS documentation](https://helics.readthedocs.io/en/latest) or contact the developers at [gitter](https://gitter.im/GMLC-TDC/HELICS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = python -msphinx
-SPHINXPROJ    = HELICS-src
+SPHINXPROJ    = HELICS
 SOURCEDIR     = .
 BUILDDIR      = _build
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,11 +1,11 @@
 # RoadMap
 
-This document contains tentative plans for changes and improvements of note in upcoming versions of the HELICS library.  All dates are approximate and subject to change. See the [projects](https://github.com/GMLC-TDC/HELICS-src/projects) for additional details
+This document contains tentative plans for changes and improvements of note in upcoming versions of the HELICS library.  All dates are approximate and subject to change. See the [projects](https://github.com/GMLC-TDC/HELICS/projects) for additional details
 
 
 ## [2.2] ~ 2019-07-30
 
- - See [HELICS 2.2](https://github.com/GMLC-TDC/HELICS-src/projects/14) for up to date information
+ - See [HELICS 2.2](https://github.com/GMLC-TDC/HELICS/projects/14) for up to date information
  - All features and dates here are tentative and subject to change
 
 ### Features and Improvements

--- a/docs/apps/Echo.md
+++ b/docs/apps/Echo.md
@@ -56,6 +56,6 @@ helics_app echo echo_file.txt --stop 5
 
 The Echo app supports JSON files some examples can be found in
 
-[Echo configuration examples](https://github.com/GMLC-TDC/HELICS-src/tree/master/tests/helics/apps/test_files)
+[Echo configuration examples](https://github.com/GMLC-TDC/HELICS/tree/master/tests/helics/apps/test_files)
 
 the main property of the echo app is the delay time which messages are echoed.

--- a/docs/apps/Player.md
+++ b/docs/apps/Player.md
@@ -62,7 +62,7 @@ helics_player player_file.txt --stop 5
 
 Players support both delimited text files and JSON files some examples can be found in
 
-[Player configuration examples](https://github.com/GMLC-TDC/HELICS-src/tree/master/tests/helics/apps/test_files)
+[Player configuration examples](https://github.com/GMLC-TDC/HELICS/tree/master/tests/helics/apps/test_files)
 
 ## Config File Detail
 

--- a/docs/apps/Recorder.md
+++ b/docs/apps/Recorder.md
@@ -78,7 +78,7 @@ helics_recorder record_file.txt --stop 5
 
 Recorders support both delimited text files and json files some examples can be found in
 
-[Player configuration examples](https://github.com/GMLC-TDC/HELICS-src/tree/master/tests/helics/apps/test_files)
+[Player configuration examples](https://github.com/GMLC-TDC/HELICS/tree/master/tests/helics/apps/test_files)
 
 ## Config File Detail
 

--- a/docs/apps/Source.md
+++ b/docs/apps/Source.md
@@ -55,7 +55,7 @@ helics_player player_file.txt --stop 5
 
 Players support both delimited text files and JSON files some examples can be found in
 
-[Player configuration examples](https://github.com/GMLC-TDC/HELICS-src/tree/master/tests/helics/apps/test_files)
+[Player configuration examples](https://github.com/GMLC-TDC/HELICS/tree/master/tests/helics/apps/test_files)
 
 ## Config File Detail
 

--- a/docs/apps/Tracer.md
+++ b/docs/apps/Tracer.md
@@ -63,7 +63,7 @@ helics_app tracer tracer_file.txt --stop 5
 
 Tracers support both delimited text files and JSON files some examples can be found in, they are otherwise the same as options for recorders.
 
-[Tracer configuration examples](https://github.com/GMLC-TDC/HELICS-src/tree/master/tests/helics/apps/test_files)
+[Tracer configuration examples](https://github.com/GMLC-TDC/HELICS/tree/master/tests/helics/apps/test_files)
 
 ## Config File Detail
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 ﻿#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# HELICS-src documentation build configuration file, created by
+# HELICS documentation build configuration file, created by
 # sphinx-quickstart on Wed Dec 13 12:07:08 2017.
 #
 # This file is execfile()d with the current directory set to its
@@ -107,7 +107,7 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.
-project = 'HELICS-src'
+project = 'HELICS'
 copyright = 'Copyright © 2017-2019,\nBattelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.See the top-level NOTICE for additional details.\nAll rights reserved.\nSPDX-License-Identifier: BSD-3-Clause\n'
 author = 'Philip Top, Jeff Daily, Ryan Mast, Dheepak Krishnamurthy, Andrew Fisher, Himanshu Jain, Bryan Palmintier, Jason Fuller'
 
@@ -178,7 +178,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'HELICS-srcdoc'
+htmlhelp_basename = 'HELICSdoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -204,7 +204,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'HELICS-src.tex', 'HELICS-src Documentation',
+    (master_doc, 'HELICS.tex', 'HELICS Documentation',
      'Philip Top, Jeff Daily, Ryan Mast, Dheepak Krishnamurthy, Andrew Fisher, Himanshu Jain, Bryan Palmintier, Jason Fuller', 'manual'),
 ]
 
@@ -212,7 +212,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, 'helics-src', 'HELICS-src Documentation', [author], 1)]
+man_pages = [(master_doc, 'helics', 'HELICS Documentation', [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -220,7 +220,7 @@ man_pages = [(master_doc, 'helics-src', 'HELICS-src Documentation', [author], 1)
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'HELICS-src', 'HELICS-src Documentation', author, 'HELICS-src', 'One line description of project.', 'Miscellaneous'),
+    (master_doc, 'HELICS', 'HELICS Documentation', author, 'HELICS', 'One line description of project.', 'Miscellaneous'),
 ]
 
 def setup(app):

--- a/docs/developer-guide/continuous-integration.md
+++ b/docs/developer-guide/continuous-integration.md
@@ -9,26 +9,26 @@ Travis-ci runs many of the primary checks  In 3 different stages
 ### Push Tests
 Push tests run on all pushes to any branch in the main repo, there are 4 tests that run regularly
 
- - GCC 6 :  Test the GCC 6.0 compiler and the CI labeled Tests  BOOST 1.61, SWIG, MPI
- - Clang 5:  Test the clang compiler and run the CI labeled Tests, along with python and Java interface generation and Tests Using C++17
+ - GCC 6: Test the GCC 6.0 compiler and the CI labeled Tests  BOOST 1.61, SWIG, MPI
+ - Clang 5: Test the clang compiler and run the CI labeled Tests, along with python and Java interface generation and Tests Using C++17
  - GCC 4.9: Test the oldest supported compiler in GCC,  Test the included interface files(SWIG OFF) for Java and python, and test a packaging build.  The main tests are disabled,  BOOST 1.61
- - XCode 10.2  Test a recent Xcode compiler
+ - XCode 10.2: Test a recent Xcode compiler
 
 ### PR tests and develop branch Tests
- Pull request tests run on every pull request to develop or master, In addition to the previous 4 tests 2 additional tests are run.
- - Clang 3.6  which is the oldest fully supported clang compiler, with boost 1.58 (Build only)
- - XCode 8.3 which is the oldest fully supported Xcode version
+Pull request tests run on every pull request to develop or master, In addition to the previous 4 tests 2 additional tests are run.
+ - Clang 3.6: which is the oldest fully supported clang compiler, with boost 1.58 (Build only)
+ - XCode 8.3:  which is the oldest fully supported Xcode version (not for PRs to develop)
 
 ### Daily Builds on develop
- On the develop branch a few additional tests are run on a daily basis.  These will run an extended set of tests or things like valgrind or clang-sanitizers.  The previous tests are run with an extended set of tests and a few additional tests are run
+On the develop branch a few additional tests are run on a daily basis.  These will run an extended set of tests or things like valgrind or clang-sanitizers.  The previous tests are run with an extended set of tests and a few additional tests are run
 
   - gcc 6.0 valgrind, interface disabled
   - gcc 6.0 Code Coverage, MPI, interfaces disabled
   - clang 5 undefined behavior sanitizer, interfaces disabled
   - clang 5 thread sanitizer, interfaces disabled
 
-
 ## Appveyor tests
   - MSVC 2015 cmake 3.13,  python and java builds and tests, packaging tests for windows
 
 ## Azure tests
+PRs and commits to the master and develop branches that pass the tests on Travis will trigger builds on Azure for several other HELICS related repositories (such as HELICS-Examples). The result of the builds for those repositories will be reported as a comment on the PR (if any) that triggered the build.

--- a/docs/developer-guide/swig.md
+++ b/docs/developer-guide/swig.md
@@ -8,8 +8,8 @@ The easiest way to generate the latest C files for the Python extension is to us
 For example, you can run the following on an OSX machine where you have `swig` installed.
 
 ```bash
-git clone https://github.com/GMLC-TDC/HELICS-src
-cd HELICS-src
+git clone https://github.com/GMLC-TDC/HELICS
+cd HELICS
 mkdir build-osx
 cmake -DBUILD_PYTHON_INTERFACE=ON -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python3.6m/ -DCMAKE_INSTALL_PREFIX=/Users/$(whoami)/local/helics-develop/ .. && make -j 8 && make install
 cd swig/python

--- a/docs/developer-guide/tests.md
+++ b/docs/developer-guide/tests.md
@@ -12,7 +12,7 @@ pip install pytest
 Then run it by doing the following
 
 ```bash
-cd ~/GitRepos/HELICS-src/tests/
+cd ~/GitRepos/HELICS/tests/
 pytest -sv python_helics
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 HELICS documentation
 ====================
 
-[![](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
+[![](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)
 [![](https://img.shields.io/badge/docs-ready-blue.svg)](https://helics.readthedocs.io/en/latest)
 [![](https://img.shields.io/conda/pn/gmlc-tdc/helics.svg)](https://anaconda.org/gmlc-tdc/helics/)
-[![](https://img.shields.io/github/tag-date/GMLC-TDC/HELICS-src.svg)](https://github.com/GMLC-TDC/HELICS-src/releases)
-[![](https://img.shields.io/badge/License-BSD-blue.svg)](https://github.com/GMLC-TDC/HELICS-src/blob/master/LICENSE)
+[![](https://img.shields.io/github/tag-date/GMLC-TDC/HELICS.svg)](https://github.com/GMLC-TDC/HELICS/releases)
+[![](https://img.shields.io/badge/License-BSD-blue.svg)](https://github.com/GMLC-TDC/HELICS/blob/master/LICENSE)
 
 This is the documentation for the Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS). HELICS is an
 open-source cyber-physical-energy co-simulation framework for energy systems, with a strong tie to the electric
@@ -18,7 +18,7 @@ Brief History: HELICS began as the core software development of the Grid Moderni
 
 Motivation: Energy systems and their associated information and communication technology systems are becoming increasingly intertwined. As a result, effectively designing, analyzing, and implementing modern energy systems increasingly relies on advanced modeling that simultaneously captures both the cyber and physical domains in combined simulations. It is designed to increase scalability and portability in modeling advanced features of highly integrated power system and cyber-physical energy systems.
 
-- [Gitter](https://gitter.im/GMLC-TDC/HELICS-src)
+- [Gitter](https://gitter.im/GMLC-TDC/HELICS)
 
 ```eval_rst
 .. toctree::

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -25,7 +25,7 @@ RUN apt update && apt install -y \
 
 WORKDIR /root/develop
 
-RUN git clone https://github.com/GMLC-TDC/HELICS-src.git helics
+RUN git clone https://github.com/GMLC-TDC/HELICS.git helics
 
 WORKDIR /root/develop/helics/build
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -10,7 +10,7 @@ Lines that don’t start with `$` are typically showing the output of the previo
 
 ### Quick start
 
-Get the latest installers from [GitHub Releases](https://github.com/GMLC-TDC/HELICS-src/releases/latest).
+Get the latest installers from [GitHub Releases](https://github.com/GMLC-TDC/HELICS/releases/latest).
 
 OR
 
@@ -24,7 +24,7 @@ conda install -c gmlc-tdc helics
 
 ### Using an installer for your operating system
 
-Download pre-compiled libraries from the [releases page](https://github.com/GMLC-TDC/HELICS-Src/releases/latest) and add them to your path.
+Download pre-compiled libraries from the [releases page](https://github.com/GMLC-TDC/HELICS/releases/latest) and add them to your path.
 The installers come with bindings for Python (3.6), MATLAB, and Java extensions precompiled as part of the installation.
 All you need to do is add the relevant folders to your User's PATH variables.
 
@@ -63,11 +63,11 @@ Alternatively, you can install from source. See the next section for more inform
 
 The following are a few things that could be useful to know before starting out.
 
-Firstly, you can follow HELICS development on our [GitHub](https://github.com/GMLC-TDC/HELICS-src) page.
+Firstly, you can follow HELICS development on our [GitHub](https://github.com/GMLC-TDC/HELICS) page.
 HELICS is open-source. The development team uses `git` for version control, and GitHub to host the code publically.
 The latest HELICS will be on the `develop` branch.
 Tagged releases occur on the `master` branch.
-If you clone the HELICS-src repository, you will be placed in the `master` branch by default.
+If you clone the HELICS repository, you will be placed in the `master` branch by default.
 To switch to the `develop` branch, you can type the following:
 
 ```bash
@@ -82,12 +82,12 @@ git checkout v1.0.1
 
 You will not need a full understanding of how `git` works for installing HELICS, but if you are interested you can find a good `git` resource in [this page](https://git-scm.com/book/en/v2).
 
-Secondly, HELICS-src is a modern C++ cross-platform software application.
+Secondly, HELICS is a modern C++ cross-platform software application.
 One challenge while maintaining the same codebase across multiple operating systems is that we have to ensure that everything installs correctly everywhere.
 The development team uses `CMake` to build HELICS.
 `CMake` is a cross-platform tool designed to build, test and package software.
 Having the latest version of `CMake` can make the build process much smoother.
-`CMake` reads certain files (CMakeLists.txt) from the HELICS-src repository, and creates a bunch of build files.
+`CMake` reads certain files (CMakeLists.txt) from the HELICS repository, and creates a bunch of build files.
 These build files specify how different files depend on each other and when these build files are run, HELICS is built.
 The exact instructions to run on each operating system are given in the individual installation instructions, but one important thing to remember is that these build files are essentially temporary files.
 If you have an issue building HELICS, once you make a change (installing/removing/adding anything), you probably need to delete these temporary files and re-generate them.

--- a/docs/installation/language.md
+++ b/docs/installation/language.md
@@ -94,8 +94,8 @@ $ make clean; make -j 4; make install
 To install HELICS with MATLAB support, you will need to add `BUILD_MATLAB_INTERFACE=ON`.
 
 ```
-git clone https://github.com/GMLC-TDC/HELICS-src
-cd HELICS-src
+git clone https://github.com/GMLC-TDC/HELICS
+cd HELICS
 mkdir build
 cd build
 cmake -DBUILD_MATLAB_INTERFACE=ON -DCMAKE_INSTALL_PREFIX=/Users/$(whoami)/local/helics-develop/ ..
@@ -158,7 +158,7 @@ To do that, you can follow the following instructions.
 Alternatively, you wish to build the MATLAB interface without using CMake, and you can do the following.
 
 ```bash
-cd ~/GitRepos/GMLC-TDC/HELICS-src/swig/
+cd ~/GitRepos/GMLC-TDC/HELICS/swig/
 mex -I../src/helics/shared_api_library ./matlab/helics_wrap.cxx -lhelicsSharedLib -L/path/to/helics_install/lib/helics/
 mv helicsMEX.* matlab/
 ```
@@ -170,8 +170,8 @@ The above instructions will have to be modified slightly to support Windows,  CM
 To install HELICS with Octave support, you will need to add `BUILD_OCTAVE_INTERFACE=ON`.
 
 ```
-git clone https://github.com/GMLC-TDC/HELICS-src
-cd HELICS-src
+git clone https://github.com/GMLC-TDC/HELICS
+cd HELICS
 mkdir build
 cd build
 cmake -DBUILD_OCTAVE_INTERFACE=ON -DCMAKE_INSTALL_PREFIX=/Users/$(whoami)/local/helics-develop/ ..

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -45,8 +45,8 @@ add -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH" to make it wo
 
 ```bash
 
-git clone https://github.com/GMLC-TDC/HELICS-src
-cd HELICS-src
+git clone https://github.com/GMLC-TDC/HELICS
+cd HELICS
 mkdir build
 cd build
 cmake ../

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -63,8 +63,8 @@ Getting and building from source:
 3. Run `make`.
 
 ```bash
-git clone https://github.com/GMLC-TDC/HELICS-src
-cd HELICS-src
+git clone https://github.com/GMLC-TDC/HELICS
+cd HELICS
 mkdir build
 cd build
 cmake ../
@@ -189,8 +189,8 @@ Note: To check if `mex` is in the PATH, type `which mex` and see if it returns a
 </div>
 
 ```
-git clone https://github.com/GMLC-TDC/HELICS-src
-cd HELICS-src
+git clone https://github.com/GMLC-TDC/HELICS
+cd HELICS
 mkdir build-osx
 cd build-osx
 cmake -DBUILD_MATLAB_INTERFACE=ON -DCMAKE_INSTALL_PREFIX=/Users/$(whoami)/local/helics-develop/ ..
@@ -208,17 +208,17 @@ To do that, you can follow the following instructions.
 The below generates the MATLAB interface using SWIG.
 
 ```bash
-cd ~/GitRepos/GMLC-TDC/HELICS-src/interfaces/
+cd ~/GitRepos/GMLC-TDC/HELICS/interfaces/
 mkdir matlab
 swig -I../src/helics/shared_api_library -outdir ./matlab -matlab ./helics.i
 mv helics_wrap.cxx matlab/helicsMEX.cxx
 ```
 
-You can copy these files into the respective `HELICS-src/interfaces/matlab/` folder and run the cmake command above.
+You can copy these files into the respective `HELICS/interfaces/matlab/` folder and run the cmake command above.
 Alternatively, you wish to build the MATLAB interface without using CMake, and you can do the following.
 
 ```bash
-cd ~/GitRepos/GMLC-TDC/HELICS-src/interfaces/
+cd ~/GitRepos/GMLC-TDC/HELICS/interfaces/
 mex -I../src/helics/shared_api_library ./matlab/helics_wrap.cxx -lhelicsSharedLib -L/path/to/helics_install/lib/helics/
 mv helicsMEX.* matlab/
 ```

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -52,15 +52,15 @@ Getting and building from source:
    HELICS.
 
    ```bash
-   git clone https://github.com/GMLC-TDC/HELICS-src.git
+   git clone https://github.com/GMLC-TDC/HELICS.git
    ```
 
 3. Go to the checkedout HELICS project folder (the default folder
-   name is HELICS-src). Create a build folder and open the build
+   name is HELICS). Create a build folder and open the build
    folder. Alternatively, cmake-gui can be used.
 
    ```bash
-   cd HELICS-src
+   cd HELICS
    mkdir build
    cd build
    ```
@@ -97,7 +97,7 @@ Getting and building from source:
 
 ## Windows Installers
 
-Windows installers are available with the different [releases](https://github.com/GMLC-TDC/HELICS-src/releases).  The release includes installers for the Debug version and Release version. As well as a zip file of the install directory. The static libraries included with the installer will work with Visual Studio 2017.
+Windows installers are available with the different [releases](https://github.com/GMLC-TDC/HELICS/releases).  The release includes installers for the Debug version and Release version. As well as a zip file of the install directory. The static libraries included with the installer will work with Visual Studio 2017.
 
 ## Testing
 
@@ -187,9 +187,9 @@ $ export PATH=$PATH:/mingw64/bin
 ### Download HELICS Source Code ###
 Now that the MSYS2 environment has been setup and all prerequisite packages have been installed the source code can be compiled and installed. The HELICS source code can be cloned from GitHub by performing the following:
 ```bash
-$ git clone https://github.com/GMLC-TDC/HELICS-src.git
+$ git clone https://github.com/GMLC-TDC/HELICS.git
 ```
-git will clone the source code into a folder in the current working directory called HELICS-src. This path will be referred to by this guide as HELICS_ROOT_DIR.
+git will clone the source code into a folder in the current working directory called HELICS. This path will be referred to by this guide as HELICS_ROOT_DIR.
 
 ### Compiling HELICS From Source ###
 Change directories to HELICS_ROOT_DIR. Create a directory called helics-build. This can be accomplished by using the mkdir command. cd into this directory. Now type the following:

--- a/docs/introduction/java.md
+++ b/docs/introduction/java.md
@@ -22,7 +22,7 @@ Run the following to compile all Java classes. You will first have to create a `
 ```bash
 javac com/java/helics/helics.java
 javac HelloWorld.java
-java -Djava.library.path="/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:/path/to/GitRepos/HELICS-src/build-osx/swig/java/com/java/helics/:." HelloWorld
+java -Djava.library.path="/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:/path/to/GitRepos/HELICS/build-osx/swig/java/com/java/helics/:." HelloWorld
 ```
 
 You should see the output that is similar to the following.

--- a/docs/introduction/matlab.md
+++ b/docs/introduction/matlab.md
@@ -17,7 +17,7 @@ After installing the mex file will be placed in the matlab folder of the install
 ## Build SWIG MATLAB source
 
 ```bash
-cd ~/GitRepos/GMLC-TDC/HELICS-src/swig/
+cd ~/GitRepos/GMLC-TDC/HELICS/swig/
 mkdir matlab
 swig -I../src/helics/shared_api_library -outdir ./matlab -matlab ./helicsMATLAB.i
 mv helics_wrap.cxx matlab/helicsMEX.cxx
@@ -26,7 +26,7 @@ mv helics_wrap.cxx matlab/helicsMEX.cxx
 ## Compile MATLAB extension
 
 ```bash
-cd ~/GitRepos/GMLC-TDC/HELICS-src/swig/
+cd ~/GitRepos/GMLC-TDC/HELICS/swig/
 mex -I../src/helics/shared_api_library ./matlab/helics_wrap.cxx -lhelicsSharedLib -L/path/to/helics_install/lib/helics/
 mv helicsMEX.* matlab/
 ```

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=HELICS-src
+set SPHINXPROJ=HELICS
 
 if "%1" == "" goto help
 

--- a/docs/user-guide/filters.md
+++ b/docs/user-guide/filters.md
@@ -26,7 +26,7 @@ To demonstrate the effects of filters, let's take the same model we were working
 
 ![Ex. 1c message topology](../img/Ex1c_Message_topology.png)
 
-[The JSON configuration file](https://github.com/GMLC-TDC/HELICS-src/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1c/EV_Controller/Control.json) adds a new `filter` section that implements the filtering:
+[The JSON configuration file](https://github.com/GMLC-TDC/HELICS/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1c/EV_Controller/Control.json) adds a new `filter` section that implements the filtering:
 
 ```
 ...
@@ -62,7 +62,7 @@ To demonstrate the effects of filters, let's take the same model we were working
 * **`operation`** - Defines the type of filtering operation that will be applied to messages. As of v2.0, the supported types are: `delay`, `timedelay`, `randomdelay`, `randomdrop`, `reroute`, `redirect`, `clone`, `cloning`, and `custom`. Further details on filter types can be found [here](../configuration/Filters.md).
 * **`properties`** - Each filter type has specific parameters that define how it operates. In this case, one of those parameters is the amount each message will be delayed, in seconds.
 
-Let's run [this co-simulation](https://github.com/GMLC-TDC/HELICS-src/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1c/) and capture the same data as last time for direct comparison: total substation load and EV charging behavior, both as a function of time.
+Let's run [this co-simulation](https://github.com/GMLC-TDC/HELICS/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1c/) and capture the same data as last time for direct comparison: total substation load and EV charging behavior, both as a function of time.
 
 ![Ex. 1c total feeder load](../img/Ex1c_Feeder_consumption.png)
 

--- a/docs/user-guide/message_federates.md
+++ b/docs/user-guide/message_federates.md
@@ -89,7 +89,7 @@ The message topology (including the endpoints) and the not very interesting brok
 ![Ex. 1b message topology](../img/Ex1b_Broker_topology.png)
 
 
-Taking these assumptions and specifications, it is not too difficult to write a simple charge controller as a Python script. And just by opening the [JSON configuration file](https://github.com/GMLC-TDC/HELICS-src/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1b/EV_Controller/Control.json) we can learn important details about how the controller works.
+Taking these assumptions and specifications, it is not too difficult to write a simple charge controller as a Python script. And just by opening the [JSON configuration file](https://github.com/GMLC-TDC/HELICS/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1b/EV_Controller/Control.json) we can learn important details about how the controller works.
 
 
 ```
@@ -138,7 +138,7 @@ Taking these assumptions and specifications, it is not too difficult to write a 
 ```
 The first thing to note is the the EV controller has been written as a combination federate, having both endpoints for receiving/sending messages and subscriptions to HELICS values. The HELICS values that the controller has subscribed to give the controller access to both the total load of the feeder (`totalLoad`, presumably) as well as the charging power for each of the individual EVs being controlled (six in total).
 
-Looking at the [GridLAB-D JSON configuration file](https://github.com/GMLC-TDC/HELICS-src/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1b/Distribution/IEEE_123_feeder_0.json) confirms this:
+Looking at the [GridLAB-D JSON configuration file](https://github.com/GMLC-TDC/HELICS/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1b/Distribution/IEEE_123_feeder_0.json) confirms this:
 
 ```
 {
@@ -206,7 +206,7 @@ Looking at the [GridLAB-D JSON configuration file](https://github.com/GMLC-TDC/H
 GridLAB-D is publishing out the total load on the feeder as well as the individual EV charging loads. It also has endpoints set up for each of the EV chargers to receive messages from the controller. Based on the strings in the `info` field it appears that the received messages are used to define the EV charge power.
 
 
-Running [the example](https://github.com/GMLC-TDC/HELICS-src/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1b/) and looking at the results, as the total load on the feeder exceeded the pre-defined maximum loading of the feeder (red line in the graph), the EV controller disconnected an additional EV load. Conversely, as the load dipped to the lower limit (green line), the controller reconnected the EV load. Looking at a graph of the EV charge power for each EV shows the timing of the EV charging for each load.
+Running [the example](https://github.com/GMLC-TDC/HELICS/tree/319de2b125fe5e36818f0434ac3d0a82ccc46534/examples/user_guide_examples/Example_1b/) and looking at the results, as the total load on the feeder exceeded the pre-defined maximum loading of the feeder (red line in the graph), the EV controller disconnected an additional EV load. Conversely, as the load dipped to the lower limit (green line), the controller reconnected the EV load. Looking at a graph of the EV charge power for each EV shows the timing of the EV charging for each load.
 
 ![Ex. 1b total feeder load](../img/Ex1b_Feeder_consumption.png)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,14 +14,14 @@ cd /path/to/helics_install/bin
 
 ```bash
 cd /path/to/helics_install/bin
-./helics_player /path/to/HELICS-src/examples/example1.player
+./helics_player /path/to/HELICS/examples/example1.player
 ```
 
 4. Run the following in the last window
 
 ```bash
 cd /path/to/helics_install/bin
-./helics_recorder /path/to/HELICS-src/examples/example1.recorder -o output.log
+./helics_recorder /path/to/HELICS/examples/example1.recorder -o output.log
 ```
 
 This will run a 24 second (simulation time) co-simulation between a "player" federate that reads data from a file and a "recorder" federate that records selected data to a file (output.log).

--- a/src/docs/mainpage.dox
+++ b/src/docs/mainpage.dox
@@ -10,7 +10,7 @@ Brief History: HELICS began as the core software development of the Grid Moderni
 Motivation: Energy systems and their associated information and communication technology systems are becoming increasingly intertwined. As a result, effectively designing, analyzing, and implementing modern energy systems increasingly relies on advanced modeling that simultaneously captures both the cyber and physical domains in combined simulations. It is designed to increase scalability and portability in modeling advanced features of highly integrated power system and cyber-physical energy systems.
 
 \section related Informational Pages
-- <a href="https://github.com/GMLC-TDC/HELICS-src/blob/master/README.md">Github Readme</a>
-- <a href="https://github.com/GMLC-TDC/HELICS-src/blob/master/LICENSE">LICENSE</a>
-- <a href="https://github.com/GMLC-TDC/HELICS-src/blob/master/NOTICE">NOTICE</a>
+- <a href="https://github.com/GMLC-TDC/HELICS/blob/master/README.md">Github Readme</a>
+- <a href="https://github.com/GMLC-TDC/HELICS/blob/master/LICENSE">LICENSE</a>
+- <a href="https://github.com/GMLC-TDC/HELICS/blob/master/NOTICE">NOTICE</a>
  */


### PR DESCRIPTION
### Description
If merged this pull request will update links and the other occurrences of HELICS-src to HELICS in the docs and other files after the renaming of the repository on GitHub. A build of the docs for this branch is accessible at https://helics.readthedocs.io/en/update-helics-src-url/

### Proposed changes
- Updates HELICS-src -> HELICS name in text/markdown files in the repository
- Fixes links following the change
