### PR TITLE
Install the main swig interface files to datadir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright © 2017-2019, Battelle Memorial Institute; Lawrence Livermore National
 # Security, LLC; Alliance for Sustainable Energy, LLC.  See the top-level NOTICE for additional details. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
@@ -613,7 +613,7 @@ endif()
 install(
     FILES interfaces/helics.i interfaces/output.i
     DESTINATION ${CMAKE_INSTALL_DATADIR}/helics/swig
-    COMPONENT swig-devel
+    COMPONENT swig
 )
 
 
@@ -804,7 +804,7 @@ if(ENABLE_PACKAGE_BUILD)
         java
         octave
         csharp
-	swig-devel
+	swig
         cereal
     )
     if(WIN32)
@@ -838,7 +838,7 @@ if(ENABLE_PACKAGE_BUILD)
     )
     set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for HELICS")
     set(CPACK_COMPONENT_CEREAL_DESCRIPTION "cereal C++11 serialization library [no support for other language interfaces]")
-    set(CPACK_COMPONENT_SWIG-DEVEL_DESCRIPTION "Basic swig interface files for HELICS for building 3rd party language interfaces")
+    set(CPACK_COMPONENT_SWIG_DESCRIPTION "Basic swig interface files for HELICS for building 3rd party language interfaces")
     set(
         CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION
         "additional language interfaces for HELICS"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,7 @@ if(ENABLE_PACKAGE_BUILD)
         java
         octave
         csharp
+	swig-devel
         cereal
     )
     if(WIN32)
@@ -837,6 +838,7 @@ if(ENABLE_PACKAGE_BUILD)
     )
     set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for HELICS")
     set(CPACK_COMPONENT_CEREAL_DESCRIPTION "cereal C++11 serialization library [no support for other language interfaces]")
+    set(CPACK_COMPONENT_SWIG-DEVEL_DESCRIPTION "Basic swig interface files for HELICS for building 3rd party language interfaces")
     set(
         CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION
         "additional language interfaces for HELICS"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,14 @@ if(INTERFACE_BUILD)
     add_subdirectory(interfaces)
 endif()
 
+# add base swig interface files as install option, regardless of current interfaces built
+install(
+    FILES interfaces/helics.i interfaces/output.i
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/helics/swig
+    COMPONENT swig-devel
+)
+
+
 add_subdirectory(docs)
 
 endif(HELICS_ROOT_PROJ)

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -36,6 +36,12 @@ if(ENABLE_SWIG)
   include(${SWIG_USE_FILE})
 endif()
 
+install(
+    FILES helics.i output.i
+    DESTINATION ${CMAKE_INSTALL_DATADIR/helics/swig}
+    COMPONENT swig-devel
+)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories("${HELICS_SOURCE_DIR}/src/helics/shared_api_library")
 include_directories("${HELICS_BINARY_DIR}/src/helics/shared_api_library")

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 install(
     FILES helics.i output.i
-    DESTINATION ${CMAKE_INSTALL_DATADIR/helics/swig}
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/helics/swig
     COMPONENT swig-devel
 )
 

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2017-2019, Battelle Memorial Institute; Lawrence Livermore
 # National Security, LLC; Alliance for Sustainable Energy, LLC.
-# See the top-level NOTICE for additional details. 
+# See the top-level NOTICE for additional details.
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -35,12 +35,6 @@ if(ENABLE_SWIG)
   find_package(SWIG REQUIRED 3.0)
   include(${SWIG_USE_FILE})
 endif()
-
-install(
-    FILES helics.i output.i
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/helics/swig
-    COMPONENT swig-devel
-)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories("${HELICS_SOURCE_DIR}/src/helics/shared_api_library")


### PR DESCRIPTION
### Description
If merged this pull request will install a copy of the main swig interface files needed to create a language wrapper using swig to the helics/swig subfolder of the GNU datadir. This is typically share/helics/swig.

### Proposed changes
- Install the main swig interface files to datadir
