### PR TITLE
add some flag tests for federate level update only on change flag

### DIFF
--- a/src/helics/core/NamedInputInfo.cpp
+++ b/src/helics/core/NamedInputInfo.cpp
@@ -52,7 +52,8 @@ std::shared_ptr<const data_block> NamedInputInfo::getData ()
     return nullptr;
 }
 
-static auto recordComparison = [](const NamedInputInfo::dataRecord &rec1, const NamedInputInfo::dataRecord &rec2) {
+static auto recordComparison = [] (const NamedInputInfo::dataRecord &rec1,
+                                   const NamedInputInfo::dataRecord &rec2) {
     return (rec1.time < rec2.time) ? true : ((rec1.time == rec2.time) ? (rec1.iteration < rec2.iteration) : false);
 };
 
@@ -246,7 +247,7 @@ bool NamedInputInfo::updateTimeInclusive (Time newTime)
 
 bool NamedInputInfo::updateData (dataRecord &&update, int index)
 {
-    if (!only_update_on_change)
+    if (!only_update_on_change || !current_data[index].data)
     {
         current_data[index] = std::move (update);
         return true;


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  

Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g.

This fixes issue #123-->

### Description

<!-- please finish the following statement -->
If merged this pull request will fix a potential issue in the federate level update_only_on_change flag

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- fix potential out of bounds memory issue with the update_only_on_change flag
- add some test cases for federate level flags for only update on change and only transmit on change
