### PR TITLE
Update helicsCLI11App enum

### DIFF
--- a/src/helics/apps/appMain.cpp
+++ b/src/helics/apps/appMain.cpp
@@ -108,10 +108,10 @@ int main (int argc, char *argv[])
 
     switch (ret)
     {
-    case helics::helicsCLI11App::parse_return::help_return:
-    case helics::helicsCLI11App::parse_return::help_all_return:
-    case helics::helicsCLI11App::parse_return::version_return:
-    case helics::helicsCLI11App::parse_return::ok:
+    case helics::helicsCLI11App::parse_output::help_call:
+    case helics::helicsCLI11App::parse_output::help_all_call:
+    case helics::helicsCLI11App::parse_output::version_call:
+    case helics::helicsCLI11App::parse_output::ok:
         return 0;
     default:
         return static_cast<int> (ret);

--- a/src/helics/apps/helics-broker.cpp
+++ b/src/helics/apps/helics-broker.cpp
@@ -50,9 +50,9 @@ int main (int argc, char *argv[])
     {
         switch (res)
         {
-        case helics::helicsCLI11App::parse_return::help_return:
-        case helics::helicsCLI11App::parse_return::help_all_return:
-        case helics::helicsCLI11App::parse_return::version_return:
+        case helics::helicsCLI11App::parse_output::help_call:
+        case helics::helicsCLI11App::parse_output::help_all_call:
+        case helics::helicsCLI11App::parse_output::version_call:
             return 0;
         default:
             return static_cast<int> (res);


### PR DESCRIPTION
### Summary
If merged this pull request will update a few instances of the parse_return enum to parse_output that weren't updated -- not sure why this wasn't causing builds to fail.

### Proposed changes
- parse_return => parse_output in appMain.cpp and helics-broker.cpp files
