### PR TITLE
Improve external network interface selection reliability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,7 @@ target_include_directories(
         $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/containers>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/concurrency>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/netif>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/utilities>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/utilities/gmlc/utilities>
 

--- a/ThirdParty/netif/gmlc/netif/NetIF.hpp
+++ b/ThirdParty/netif/gmlc/netif/NetIF.hpp
@@ -32,9 +32,15 @@ namespace gmlc
 namespace netif
 {
   #if defined(_WIN32)
-    typedef IF_ADDRS PIP_ADAPTER_ADDRESSES
+    using IF_ADDRS = PIP_ADAPTER_ADDRESSES;
   #else
-    typedef IF_ADDRS struct ifaddrs*
+    using IF_ADDRS = struct ifaddrs*;
+  #endif
+
+  #if defined(_WIN32)
+    using IF_ADDRS_UNICAST = PIP_ADAPTER_UNICAST_ADDRESS;
+  #else
+    using IF_ADDRS_UNICAST = struct ifaddrs *;
   #endif
 
   inline std::string addressToString(struct sockaddr *addr)
@@ -98,7 +104,7 @@ namespace netif
     #endif
   }
 
-  inline auto getSockAddr(IF_ADDRS addr)
+  inline auto getSockAddr(IF_ADDRS_UNICAST addr)
   {
     #if defined(_WIN32)
       return addr->Address.lpSockaddr;
@@ -107,7 +113,7 @@ namespace netif
     #endif
   }
 	
-  inline IF_ADDRS getNextAddress(int family, IF_ADDRS addrs)
+  inline IF_ADDRS_UNICAST getNextAddress(int family, IF_ADDRS_UNICAST addrs)
   {
     #if defined(_WIN32)
       return addrs->Next;
@@ -148,7 +154,7 @@ namespace netif
     getAddresses(family, &allAddrs);
 
 #if defined(_WIN32)
-    IF_ADDRS winAddrs = allAddrs;
+    auto winAddrs = allAddrs;
     while (winAddrs) {
       auto addrs = winAddrs->FirstUnicastAddress;
 #else
@@ -163,7 +169,7 @@ namespace netif
     }
 
 #if defined(_WIN32)
-      winAddrs = getNextAddress(family, winAddrs);
+      winAddrs = winAddrs->Next;
     }
 #endif
 

--- a/ThirdParty/netif/gmlc/netif/NetIF.hpp
+++ b/ThirdParty/netif/gmlc/netif/NetIF.hpp
@@ -43,6 +43,11 @@ namespace netif
     using IF_ADDRS_UNICAST = struct ifaddrs *;
   #endif
 
+  /**
+   * a helper function to convert the IP address in a sockaddr struct to text
+   * @param addr a pointer to a sockaddr struct
+   * @return an IP address in text form, or an empty string if conversion to text failed
+   */
   inline std::string addressToString(struct sockaddr *addr)
   {
     int family = addr->sa_family;
@@ -61,7 +66,11 @@ namespace netif
     inet_ntop(family, src_addr, addr_str, INET6_ADDRSTRLEN);
     return std::string(addr_str);
   }
-	
+
+  /**
+   * a helper function to free the memory allocated to store a set of interface addresses
+   * @param addrs a pointer to the allocated address structure (type depends on OS)
+   */
   inline void freeAddresses(IF_ADDRS addrs)
   {
     #if defined(_WIN32)
@@ -71,6 +80,12 @@ namespace netif
     #endif
   }
 
+  /**
+   * a helper function to get a list of all interface adapters using OS system calls. the returned pointer from addrs must be freed with a call to freeAddresses.
+   * @param family type of adapter addresses to get on Windows; one of AF_INET (IPv4), AF_INET6 (IPv6), or AF_UNSPEC (both)
+   * @param[out] addrs pointer to a pointer to be filled in with the address of the allocated address structure; must be freed when done by calling freeAddresses
+   * @return 0 on success, or -1 if an error occurred
+   */
   inline auto getAddresses(int family, IF_ADDRS* addrs)
   {
     #if defined(_WIN32)
@@ -104,6 +119,11 @@ namespace netif
     #endif
   }
 
+  /**
+   * a helper function to get the underlying socket address structure based on OS
+   * @param addr a pointer to an address structure for an (unicast) interface/adapter
+   * @return a socket address structure containing the IP address information for an interface
+   */
   inline auto getSockAddr(IF_ADDRS_UNICAST addr)
   {
     #if defined(_WIN32)
@@ -113,6 +133,12 @@ namespace netif
     #endif
   }
 	
+  /**
+   * a helper function to get the next interface/adapter address based on OS
+   * @param family specify the type of address desired on non-Windows systems; one of AF_INET (IPv4), AF_INET6 (IPv6), or AF_UNSPEC (both)
+   * @param addrs a pointer to an addresses structure for an interface/adapter list
+   * @return the next interface/adapter in the addresses list (that matches the family given for non-Windows systems), or nullptr if there is no next address
+   */
   inline IF_ADDRS_UNICAST getNextAddress(int family, IF_ADDRS_UNICAST addrs)
   {
     #if defined(_WIN32)
@@ -144,7 +170,12 @@ namespace netif
     return nullptr;
     #endif
   }
-	  
+	 
+  /**
+   * get all addresses associated with network interfaces on the system of the address family given.
+   * @param family the type of IP address to return; one of AF_INET (IPv4), AF_INET6 (IPv6), or AF_UNSPEC (both)
+   * @return a list of addresses as text
+   */
   std::vector<std::string> getInterfaceAddresses(int family)
   {
     std::vector<std::string> result_list;
@@ -179,16 +210,28 @@ namespace netif
     return result_list;
   }
 
+  /**
+   * returns a list of all IPv4 addresses associated with network interfaces on the system.
+   * @return a list of IPv4 addresses as text
+   */
   std::vector<std::string> getInterfaceAddressesV4()
   {
     return getInterfaceAddresses(AF_INET);
   }
-	
+
+  /**
+   * returns a list of all IPv6 addresses associated with network interfaces on the system.
+   * @return a list of IPv6 addresses as text
+   */
   std::vector<std::string> getInterfaceAddressesV6()
   {
     return getInterfaceAddresses(AF_INET6);
   }
 
+  /**
+   * returns a list of all IPv4 and IPv6 addresses associated with network interfaces on the system.
+   * @return a list of IPv4 and IPv6 addresses as text
+   */
   std::vector<std::string> getInterfaceAddressesAll()
   {
     return getInterfaceAddresses(AF_UNSPEC);

--- a/ThirdParty/netif/gmlc/netif/NetIF.hpp
+++ b/ThirdParty/netif/gmlc/netif/NetIF.hpp
@@ -1,0 +1,193 @@
+/*
+Copyright © 2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
+for Sustainable Energy, LLC.  See the top-level NOTICE for additional details.
+All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <stdio.h>
+#include <stdlib.h>
+
+// other platforms might need different headers -- detecting with macros:
+// https://sourceforge.net/p/predef/wiki/OperatingSystems/
+// https://stackoverflow.com/questions/142508/how-do-i-check-os-with-a-preprocessor-directive
+#if defined(_WIN32)
+  #include <winsock2.h>
+  #include <WS2tcpip.h>
+  #include <iphlpapi.h>
+
+  #pragma comment(lib, "IPHLPAPI.lib")
+  #pragma comment(lib, "Ws2_32.lib")
+#else
+  #include <arpa/inet.h>
+  #include <ifaddrs.h>
+#endif
+
+namespace gmlc
+{
+namespace netif
+{
+  inline std::string addressToString(struct sockaddr *addr)
+  {
+    int family = addr->sa_family;
+    char addr_str[INET6_ADDRSTRLEN];
+    void *src_addr = nullptr;
+    switch (family) {
+      case AF_INET:
+        src_addr = &((struct sockaddr_in *)addr)->sin_addr;
+        break;
+      case AF_INET6:
+        src_addr = &((struct sockaddr_in6 *)addr)->sin6_addr;
+        break;
+      default: // Invalid address type for conversion to text
+        return std::string();
+    }
+    inet_ntop(family, src_addr, addr_str, INET6_ADDRSTRLEN);
+    return std::string(addr_str);
+  }
+	
+  template <class A>
+  inline void freeAddresses(A addrs)
+  {
+    #if defined(_WIN32)
+      HeapFree(GetProcessHeap(),0,addrs);
+    #else
+      freeifaddrs(addrs);
+    #endif
+  }
+
+  template <class A>
+  inline auto getAddresses(int family, A* addrs)
+  {
+    #if defined(_WIN32)
+      // Windows API: https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses
+      DWORD rv = 0;
+      ULONG bufLen = 15000; // recommended size from Windows API docs to avoid error
+      ULONG iter = 0;
+      do {
+        *addrs = (IP_ADAPTER_ADDRESSES *)HeapAlloc(GetProcessHeap(),0,bufLen);
+        if (*addrs == NULL) {
+          return -1;
+        }
+
+        rv = GetAdaptersAddresses(family, GAA_FLAG_INCLUDE_PREFIX, NULL, *addrs, &bufLen);
+        if (rv == ERROR_BUFFER_OVERFLOW) {
+          freeAddresses<decltype(*addrs)>(*addrs);
+          *addrs = NULL;
+          bufLen = bufLen*2; // Double buffer length for the next attempt
+        } else {
+          break;
+        }
+        iter++;
+      } while ((rv == ERROR_BUFFER_OVERFLOW) && (iter < 3));
+      if (rv != NO_ERROR) {
+        // May want to change this depending on the type of error
+        return -1;
+      }
+      return 0;
+    #else
+      return getifaddrs(addrs);
+    #endif
+  }
+
+  template <class A>
+  inline auto getSockAddr(A addr)
+  {
+    #if defined(_WIN32)
+      return addr->Address.lpSockaddr;
+    #else
+      return addr->ifa_addr;
+    #endif
+  }
+	
+  template <class A>
+  inline A getNextAddress(int family, A addrs)
+  {
+    #if defined(_WIN32)
+      return addrs->Next;
+    #else
+    auto next = addrs->ifa_next;
+    while (next != NULL) {
+      // Skip entries with a null sockaddr
+      auto next_sockaddr = getSockAddr<decltype(next)>(next);
+      if (next_sockaddr == NULL) {
+        next = next->ifa_next;
+	continue;
+      }
+	    
+      int next_family = next_sockaddr->sa_family;
+      // Skip if the family is not IPv4 or IPv6
+      if (next_family != AF_INET && next_family != AF_INET6) {
+        next = next->ifa_next;
+        continue;
+      }
+      // Skip if a specific IP family was requested and the family doesn't match
+      if ((family == AF_INET || family == AF_INET6) && family != next_family) {
+        next = next->ifa_next;
+        continue;
+      }
+      // An address entry meeting the requirements was found, return it
+      return next;
+    }
+    return nullptr;
+    #endif
+  }
+	  
+  std::vector<std::string> getInterfaceAddresses(int family)
+  {
+    std::vector<std::string> result_list;
+	  
+#if defined(_WIN32)
+    PIP_ADAPTER_ADDRESSES allAddrs = NULL;
+#else
+    struct ifaddrs *allAddrs;
+#endif
+	 
+    getAddresses<decltype(allAddrs)>(family, &allAddrs);
+
+#if defined(_WIN32)
+    PIP_ADAPTER_ADDRESSES winAddrs = allAddrs;
+    while (winAddrs) {
+      auto addrs = winAddrs->FirstUnicastAddress;
+#else
+    auto addrs = allAddrs;
+#endif
+	    
+    for (auto a = addrs; a != NULL; a = getNextAddress<decltype(a)>(family, a)) {
+      std::string ipAddr = addressToString(getSockAddr<decltype(a)>(a));
+      if (!ipAddr.empty()) {
+        result_list.push_back(ipAddr);
+      }
+    }
+
+#if defined(_WIN32)
+      winAddrs = getNextAddress<decltype(winAddrs)>(family, winAddrs);
+    }
+#endif
+
+    if (allAddrs) {
+      freeAddresses<decltype(allAddrs)>(allAddrs);
+    }
+    return result_list;
+  }
+
+  std::vector<std::string> getInterfaceAddressesV4()
+  {
+    return getInterfaceAddresses(AF_INET);
+  }
+	
+  std::vector<std::string> getInterfaceAddressesV6()
+  {
+    return getInterfaceAddresses(AF_INET6);
+  }
+
+  std::vector<std::string> getInterfaceAddressesAll()
+  {
+    return getInterfaceAddresses(AF_UNSPEC);
+  }
+} // namespace netif
+} // namespace gmlc

--- a/src/helics/core/NetworkBrokerData.cpp
+++ b/src/helics/core/NetworkBrokerData.cpp
@@ -355,12 +355,27 @@ std::string getLocalExternalAddressV4 ()
     }
 
     // Pick an interface that isn't an IPv4 loopback address, 127.0.0.1/8
+    // or an IPv4 link-local address, 169.254.0.0/16
+    std::string link_local_addr;
     for (auto addr : interface_addresses)
     {
         if (addr.rfind ("127.", 0) != 0)
         {
-            return addr;
+            if (addr.rfind ("169.254.", 0) != 0)
+            {
+                return addr;
+            }
+            else if (link_local_addr.empty ())
+            {
+                link_local_addr = addr;
+            }
         }
+    }
+
+    // Return a link-local address since no alternatives were found
+    if (!link_local_addr.empty ())
+    {
+        return link_local_addr;
     }
 
     // Very likely that any address returned at this point won't be a working external address
@@ -447,13 +462,28 @@ std::string getLocalExternalAddressV6 ()
         }
     }
 
-    // Pick an interface that isn't an IPv6 loopback address
+    // Pick an interface that isn't the IPv6 loopback address, ::1/128
+	// or an IPv6 link-local address, fe80::/16
+    std::string link_local_addr;
     for (auto addr : interface_addresses)
     {
         if (addr != "::1")
-		{
-            return addr;
-		}
+        {
+            if (addr.rfind ("fe80:", 0) != 0)
+            {
+                return addr;
+            }
+            else if (link_local_addr.empty ())
+            {
+                link_local_addr = addr;
+            }
+        }
+    }
+
+	// No other choices, so return a link local address if one was found
+    if (!link_local_addr.empty ())
+    {
+        return link_local_addr;
     }
 
     // Very likely that any address returned at this point won't be a working external address

--- a/src/helics/core/NetworkBrokerData.cpp
+++ b/src/helics/core/NetworkBrokerData.cpp
@@ -7,8 +7,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "NetworkBrokerData.hpp"
 #include "BrokerFactory.hpp"
-#include "helicsCLI11.hpp"
 #include "gmlc/netif/NetIF.hpp"
+#include "helicsCLI11.hpp"
 
 #include "../common/AsioContextManager.h"
 #include <asio/ip/host_name.hpp>
@@ -354,16 +354,16 @@ std::string getLocalExternalAddressV4 ()
         }
     }
 
-    // Pick an interface that isn't an IPv4 loopback address, 127.0.0.1
+    // Pick an interface that isn't an IPv4 loopback address, 127.0.0.1/8
     for (auto addr : interface_addresses)
     {
-        if (addr != "127.0.0.1")
+        if (addr.rfind ("127.", 0) != 0)
         {
             return addr;
         }
     }
 
-    // Very likely that any address returned at this won't be a working external address
+    // Very likely that any address returned at this point won't be a working external address
     return resolved_address;
 }
 
@@ -450,10 +450,13 @@ std::string getLocalExternalAddressV6 ()
     // Pick an interface that isn't an IPv6 loopback address
     for (auto addr : interface_addresses)
     {
-        return addr;
+        if (addr != "::1")
+		{
+            return addr;
+		}
     }
 
-    // Very likely that any address returned at this won't be a working external address
+    // Very likely that any address returned at this point won't be a working external address
     return resolved_address;
 }
 
@@ -469,7 +472,7 @@ std::string getLocalExternalAddressV6 (const std::string &server)
     asio::ip::tcp::resolver::iterator end;
 
     auto sstring = (it_server == end) ? server : servep.address ().to_string ();
-    auto interface_addresses = gmlc::netif::getInterfaceAddressesV4 ();
+    auto interface_addresses = gmlc::netif::getInterfaceAddressesV6 ();
 
     // Fall-back to resolver addresses if no network interfaces were found
     if (interface_addresses.empty ())

--- a/src/helics/core/NetworkBrokerData.hpp
+++ b/src/helics/core/NetworkBrokerData.hpp
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace helics
 {
@@ -122,11 +123,19 @@ void insertProtocol (std::string &networkAddress, interface_type interfaceT);
 
 /** check if a specified address is v6 or v4
 @return true if the address is a v6 address
-*/
+ */
 bool isipv6 (const std::string &address);
 
-/** get the external ipv4 address of the current computer
+/** create a combined address list with choices in a rough order of priority based on if they appear in both lists, followed by the high priority addresses, and low priority addresses last
+
+@param high addresses that should be considered before low addresses
+@param low addresses that should be considered last
+@return a vector of strings of ip addresses ordered in roughly the priority they should be used
  */
+std::vector<std::string> prioritizeExternalAddresses (std::vector<std::string> high, std::vector<std::string> low);
+
+/** get the external ipv4 address of the current computer
+*/
 std::string getLocalExternalAddressV4 ();
 
 /** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will improve the reliability of the external interface selection when using the resolver could return an incorrect result, such as in emulated networks.

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- Uses OS syscalls to get all network interface addresses
- Makes sure the resolved network interface address exists on the system
- Prioritizes picking addresses that both the OS syscall and resolver returned
- Falls back to picking a non-loopback address if no interface with an address matching the resolved address exists
- Uses resolved addresses that aren't assigned to an interface last
