### PR TITLE
New message api

### DIFF
--- a/interfaces/helics.i
+++ b/interfaces/helics.i
@@ -25,6 +25,8 @@
 %ignore helicsErrorInitialize;
 %ignore helicsErrorClear;
 %ignore helics_error;
+%ignore helicsMessageGetRawDataPointer
+%ignore helicsMessageAllocatePayload
 
 %include "../helics_enums.h"
 %include "api-data.h"

--- a/interfaces/helics.i
+++ b/interfaces/helics.i
@@ -26,7 +26,7 @@
 %ignore helicsErrorClear;
 %ignore helics_error;
 %ignore helicsMessageGetRawDataPointer;
-%ignore helicsMessageAllocatePayload;
+%ignore helicsMessageResize;
 
 %include "../helics_enums.h"
 %include "api-data.h"

--- a/interfaces/helics.i
+++ b/interfaces/helics.i
@@ -25,8 +25,8 @@
 %ignore helicsErrorInitialize;
 %ignore helicsErrorClear;
 %ignore helics_error;
-%ignore helicsMessageGetRawDataPointer
-%ignore helicsMessageAllocatePayload
+%ignore helicsMessageGetRawDataPointer;
+%ignore helicsMessageAllocatePayload;
 
 %include "../helics_enums.h"
 %include "api-data.h"

--- a/interfaces/matlab/matlab_maps.i
+++ b/interfaces/matlab/matlab_maps.i
@@ -34,6 +34,9 @@ static void throwHelicsMatlabError(helics_error *err) {
   case   helics_error_execution_failure:
   mexErrMsgIdAndTxt( "helics:execution_failure", err->message);
 	break;
+  case   helics_error_insufficient_space:
+    mexErrMsgIdAndTxt( "helics:insufficient_space", err->message);
+	break;
   case   helics_error_other:
   case   helics_error_external_type:
   default:
@@ -254,5 +257,24 @@ static void throwHelicsMatlabError(helics_error *err) {
 }
 
 %typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+ if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3);
+}
+
+// typemap for raw message data functions
+%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+  $3=&($2);
+}
+
+%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+   if ($1) free($1);
+}
+
+// Set argument to NULL before any conversion occurs
+%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+    $2=helicsMessageGetRawDataSize(arg1)+2;
+    $1 =  malloc($2);
+}
+
+%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
  if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3);
 }

--- a/interfaces/octave/octave_maps.i
+++ b/interfaces/octave/octave_maps.i
@@ -26,6 +26,8 @@ switch (err->error_code)
     return "helics:invalid_function_call";
   case   helics_error_execution_failure:
 	return "helics:execution_failure";
+  case   helics_error_insufficient_space:
+	return "helics:insufficient_space";
   case   helics_error_other:
   case   helics_error_external_type:
   default:
@@ -213,5 +215,24 @@ static octave_value throwHelicsOctaveError(helics_error *err) {
 }
 
 %typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+ if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3);
+}
+
+// typemap for raw data message functions
+%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+  $3=&($2);
+}
+
+%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+   if ($1) free($1);
+}
+
+// Set argument to NULL before any conversion occurs
+%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+    $2=helicsMessageGetRawDataSize(arg1)+2;
+    $1 =  malloc($2);
+}
+
+%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
  if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3);
 }

--- a/interfaces/python2/python_maps2.i
+++ b/interfaces/python2/python_maps2.i
@@ -201,6 +201,49 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
   $result = SWIG_Python_AppendOutput($result, o2);
 }
 
+
+
+// typemap for raw data output function
+%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+  $3=&($2);
+}
+
+%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+   if ($1) free($1);
+}
+
+// Set argument to NULL before any conversion occurs
+%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+    $2=helicsInputGetValueSize(arg1)+2;
+    $1 =  malloc($2);
+}
+
+%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+  PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
+  $result = SWIG_Python_AppendOutput($result, o2);
+}
+
+
+// typemap for raw message data output
+%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+  $3=&($2);
+}
+
+%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+   if ($1) free($1);
+}
+
+// Set argument to NULL before any conversion occurs
+%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+    $2=helicsMessageGetRawDataSize(arg1)+2;
+    $1 =  malloc($2);
+}
+
+%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
+  PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
+  $result = SWIG_Python_AppendOutput($result, o2);
+}
+
 %apply (char *STRING, size_t LENGTH) { (const void *data, int inputDataLength) };
 
 %apply (char *outputString, int maxStringLen, int *actualLength) {(void *data, int maxDatalen, int *actualSize)};

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -173,6 +173,10 @@ class Federate
   @return the granted time step*/
     Time requestNextStep () { return requestTime (timeZero); }
 
+    /** request a time advancement by a certain amount
+    @return the granted time step*/
+    Time requestTimeAdvance (Time timeDelta) { return requestTime (currentTime + timeDelta); }
+
     /** request a time advancement
     @param nextInternalTimeStep the next requested time step
     @param iterate a requested iteration mode
@@ -244,7 +248,7 @@ class Federate
     A string indicating the source of the message and another string with the actual message
     */
     void
-    setLoggingCallback (const std::function<void(int, const std::string &, const std::string &)> &logFunction);
+    setLoggingCallback (const std::function<void (int, const std::string &, const std::string &)> &logFunction);
 
     /** make a query of the core
     @details this call is blocking until the value is returned which make take some time depending on the size of

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -150,6 +150,7 @@ extern "C"
         helics_error_invalid_function_call =
           (-10), /*!< the call made was invalid in the present state of the calling object*/
         helics_error_execution_failure = (-14), /*!< the function execution has failed*/
+        helics_error_insufficient_space = (-18), /*!< insufficient space is available to store requested data*/
         helics_error_other = -101, /*!< the function produced a helics error of some other type */
         helics_error_external_type = -203 /*!< an unknown non-helics error was produced*/
     } helics_error_types;

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -644,6 +644,25 @@ helics_time helicsFederateRequestTime (helics_federate fed, helics_time requestT
     }
 }
 
+helics_time helicsFederateRequestTimeAdvance (helics_federate fed, helics_time timeDelta, helics_error *err)
+{
+    auto fedObj = getFed (fed, err);
+    if (fedObj == nullptr)
+    {
+        return helics_time_invalid;
+    }
+    try
+    {
+        auto timeret = fedObj->requestTimeAdvance (timeDelta);
+        return (timeret < helics::Time::maxVal ()) ? static_cast<double> (timeret) : helics_time_maxtime;
+    }
+    catch (...)
+    {
+        helicsErrorHandler (err);
+        return helics_time_invalid;
+    }
+}
+
 helics_time helicsFederateRequestNextStep (helics_federate fed, helics_error *err)
 {
     auto fedObj = getFed (fed, err);

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -112,6 +112,12 @@ extern "C"
     @param[in,out] err a pointer to an error object for catching errors
     */
     HELICS_EXPORT void helicsEndpointSendMessage (helics_endpoint endpoint, helics_message *message, helics_error *err);
+    /** send a message object from a specific endpoint
+    @param endpoint the endpoint to send the data from
+    @param message the actual message to send
+    @param[in,out] err a pointer to an error object for catching errors
+    */
+    HELICS_EXPORT void helicsEndpointSendMessageObject (helics_endpoint endpoint, helics_message_object message, helics_error *err);
 
     /** subscribe an endpoint to a publication
     @param endpoint the endpoint to use
@@ -144,6 +150,11 @@ extern "C"
     @return a message object*/
     HELICS_EXPORT helics_message helicsEndpointGetMessage (helics_endpoint endpoint);
 
+    /** receive a packet from a particular endpoint
+    @param[in] endpoint the identifier for the endpoint
+    @return a message object*/
+    HELICS_EXPORT helics_message_object helicsEndpointGetMessageObject (helics_endpoint endpoint);
+
     /** receive a communication message for any endpoint in the federate
     @details the return order will be in order of endpoint creation then order of arrival
     all messages for the first endpoint, then all for the second, and so on
@@ -151,6 +162,30 @@ extern "C"
     @return a unique_ptr to a Message object containing the message data*/
     HELICS_EXPORT helics_message helicsFederateGetMessage (helics_federate fed);
 
+    /** receive a communication message for any endpoint in the federate
+    @details the return order will be in order of endpoint creation then order of arrival
+    all messages for the first endpoint, then all for the second, and so on
+    within a single endpoint the messages are ordered by time, then source_id, then order of arrival
+    @return a helics_message_object which references the data in the message*/
+    HELICS_EXPORT helics_message_object helicsFederateGetMessageObject (helics_federate fed);
+
+    /** create a new empty message object
+    @return a helics_message_object containing the message data*/
+    HELICS_EXPORT helics_message_object helicsFederateCreateMessageObject (helics_federate fed, helics_error *err);
+    /** clear all message from a federate
+    @details this clears messages retrieved through helicsFederateGetMessage or helicsFederateGetMessageObject
+    @param endpoint  the endpoint object to operate on
+    */
+    HELICS_EXPORT void helicsFederateClearMessages (helics_federate fed);
+    /** clear all message from an endpoint
+    @param endpoint  the endpoint object to operate on
+    */
+    HELICS_EXPORT void helicsEndpointClearMessages (helics_endpoint endpoint);
+
+    /** get the last retrieved message from a federate*/
+    HELICS_EXPORT helics_message_object helicsFederateGetLastMessage (helics_federate fed);
+    /** get the last retrieved message from an endpoint*/
+    HELICS_EXPORT helics_message_object helicsEndpointGetLastMessage (helics_endpoint endpoint);
     /** get the type specified for an endpoint
     @param endpoint  the endpoint object in question
     @return the defined type of the endpoint
@@ -189,6 +224,24 @@ extern "C"
     @param option integer code for the option to set /ref helics_handle_options
     */
     HELICS_EXPORT helics_bool helicsEndpointGetOption (helics_endpoint end, int option);
+
+    HELICS_EXPORT const char *helicsMessageGetSource (helics_message_object message);
+    HELICS_EXPORT const char *helicsMessageGetDestination (helics_message_object message);
+    HELICS_EXPORT const char *helicsMessageGetOriginalSource (helics_message_object message);
+    HELICS_EXPORT const char *helicsMessageGetOriginalDestination (helics_message_object message);
+    HELICS_EXPORT helics_time helicsMessageGetTime (helics_message_object message);
+    HELICS_EXPORT const char *helicsMessageGetString (helics_message_object message);
+
+    HELICS_EXPORT int helicsMessageGetRawDataSize (helics_message_object message);
+
+    /** get the raw data for a message object
+    @param message a message object to get the data for
+    @param[out] data the memory location of the data
+    @param maxlen the maximum size of information that data can hold
+    @param[out] actualSize  the actual length of data copied to data
+    @param[in,out] err a pointer to an error object for catching errors
+    */
+    HELICS_EXPORT void helicsMessageGetRawData (helics_message_object message, void *data, int maxlen, int *actualSize, helics_error *err);
 
 #ifdef __cplusplus
 } /* end of extern "C" { */

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -156,25 +156,27 @@ extern "C"
     HELICS_EXPORT helics_message_object helicsEndpointGetMessageObject (helics_endpoint endpoint);
 
     /** receive a communication message for any endpoint in the federate
-    @details the return order will be in order of endpoint creation then order of arrival
-    all messages for the first endpoint, then all for the second, and so on
+    @details the return order will be in order of endpoint creation.
+    So all messages that are available for the first endpoint, then all for the second, and so on
     within a single endpoint the messages are ordered by time, then source_id, then order of arrival
     @return a unique_ptr to a Message object containing the message data*/
     HELICS_EXPORT helics_message helicsFederateGetMessage (helics_federate fed);
 
     /** receive a communication message for any endpoint in the federate
-    @details the return order will be in order of endpoint creation then order of arrival
-    all messages for the first endpoint, then all for the second, and so on
+     @details the return order will be in order of endpoint creation.
+    So all messages that are available for the first endpoint, then all for the second, and so on
     within a single endpoint the messages are ordered by time, then source_id, then order of arrival
     @return a helics_message_object which references the data in the message*/
     HELICS_EXPORT helics_message_object helicsFederateGetMessageObject (helics_federate fed);
 
     /** create a new empty message object
+	@details, the message is empty and isValid will return false since there is no data associated with the message yet. 
     @return a helics_message_object containing the message data*/
     HELICS_EXPORT helics_message_object helicsFederateCreateMessageObject (helics_federate fed, helics_error *err);
-    /** clear all message from a federate
+    
+	/** clear all stored messages from a federate
     @details this clears messages retrieved through helicsFederateGetMessage or helicsFederateGetMessageObject
-    @param endpoint  the endpoint object to operate on
+    @param fed the federate to clear the message for
     */
     HELICS_EXPORT void helicsFederateClearMessages (helics_federate fed);
     /** clear all message from an endpoint
@@ -182,10 +184,6 @@ extern "C"
     */
     HELICS_EXPORT void helicsEndpointClearMessages (helics_endpoint endpoint);
 
-    /** get the last retrieved message from a federate*/
-    HELICS_EXPORT helics_message_object helicsFederateGetLastMessage (helics_federate fed);
-    /** get the last retrieved message from an endpoint*/
-    HELICS_EXPORT helics_message_object helicsEndpointGetLastMessage (helics_endpoint endpoint);
     /** get the type specified for an endpoint
     @param endpoint  the endpoint object in question
     @return the defined type of the endpoint
@@ -207,7 +205,8 @@ extern "C"
     @param end the filter to query
     @return a string with the info field string*/
     HELICS_EXPORT const char *helicsEndpointGetInfo (helics_endpoint end);
-    /** set the data in the info field for an filter
+    
+	/** set the data in the info field for an filter
     @param end the endpoint to query
     @param info the string to set
     @param[in,out] err an error object to fill out in case of an error*/
@@ -288,7 +287,7 @@ extern "C"
 
     /** get a pointer to the raw data of a message
     @param message a message object to get the data for
-    @return a pointer to the raw data in memory
+    @return a pointer to the raw data in memory, the pointer may be NULL if the message is not a valid message
     */
     HELICS_EXPORT void *helicsMessageGetRawDataPointer (helics_message_object message);
     /** a check if the message contains a valid payload

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -225,6 +225,12 @@ extern "C"
     */
     HELICS_EXPORT helics_bool helicsEndpointGetOption (helics_endpoint end, int option);
 
+    /**
+    * \defgroup message operation functions
+    @details functions for working with helics message envelopes
+    * @{
+    */
+
     HELICS_EXPORT const char *helicsMessageGetSource (helics_message_object message);
     HELICS_EXPORT const char *helicsMessageGetDestination (helics_message_object message);
     HELICS_EXPORT const char *helicsMessageGetOriginalSource (helics_message_object message);
@@ -256,12 +262,15 @@ extern "C"
     HELICS_EXPORT void helicsMessageSetOriginalSource (helics_message_object message, const char *src, helics_error *err);
     HELICS_EXPORT void helicsMessageSetOriginalDestination (helics_message_object message, const char *dest, helics_error *err);
     HELICS_EXPORT void helicsMessageSetTime (helics_message_object message, helics_time time, helics_error *err);
-    HELICS_EXPORT void helicsMessageAllocatePayload (helics_message_object message, int newSize, helics_error *err);
+    HELICS_EXPORT void helicsMessageResize (helics_message_object message, int newSize, helics_error *err);
+    HELICS_EXPORT void helicsMessageReserve (helics_message_object message, int reserveSize, helics_error *err);
     HELICS_EXPORT void helicsMessageSetMessageID (helics_message_object message, int32_t messageID, helics_error *err);
     HELICS_EXPORT void helicsMessageSetFlags (helics_message_object message, uint16_t flags, helics_error *err);
-    HELICS_EXPORT void helicsMessageSetMessage (helics_message_object message, const char *str, helics_error *err);
-    HELICS_EXPORT void
-    helicsMessageSetMessageData (helics_message_object message, const void *data, int inputDataLength, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetString (helics_message_object message, const char *str, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetData (helics_message_object message, const void *data, int inputDataLength, helics_error *err);
+    HELICS_EXPORT void helicsMessageAppendData (helics_message_object message, const void *data, int inputDataLength, helics_error *err);
+
+    /**@}*/
 #ifdef __cplusplus
 } /* end of extern "C" { */
 #endif

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -230,15 +230,51 @@ extern "C"
     @details functions for working with helics message envelopes
     * @{
     */
-
+    /** get the source endpoint of a message
+    @param message the message object in question
+    @return a string with the source endpoint
+    */
     HELICS_EXPORT const char *helicsMessageGetSource (helics_message_object message);
+    /** get the destination endpoint of a message
+    @param message the message object in question
+    @return a string with the destination endpoint
+    */
     HELICS_EXPORT const char *helicsMessageGetDestination (helics_message_object message);
+    /** get the original source endpoint of a message, the source may have modified by filters or other actions
+    @param message the message object in question
+    @return a string with the source of a message
+    */
     HELICS_EXPORT const char *helicsMessageGetOriginalSource (helics_message_object message);
+    /** get the original destination endpoint of a message, the destination may have been modified by filters or other actions
+    @param message the message object in question
+    @return a string with the original destination of a message
+    */
     HELICS_EXPORT const char *helicsMessageGetOriginalDestination (helics_message_object message);
+    /** get the helics time associated with a message
+    @param message the message object in question
+    @return the time associated with a message
+    */
     HELICS_EXPORT helics_time helicsMessageGetTime (helics_message_object message);
+    /** get the payload of a message as a string
+    @param message the message object in question
+    @return a string representing the payload of a message
+    */
     HELICS_EXPORT const char *helicsMessageGetString (helics_message_object message);
+    /** get the messageID of a message
+    @param message the message object in question
+    @return the messageID
+    */
     HELICS_EXPORT int helicsMessageGetMessageID (helics_message_object message);
-    HELICS_EXPORT uint16_t helicsMessageGetFlags (helics_message_object message);
+    /** check if a flag is set on a message
+    @param message the message object in question
+    @param flag the flag to check should be between [0,15]
+    @return the flags associated with a message
+    */
+    HELICS_EXPORT helics_bool helicsMessageCheckFlag (helics_message_object message, int flag);
+    /** get the size of the data payload in bytes
+    @param message the message object in question
+    @return the size of the data payload
+    */
     HELICS_EXPORT int helicsMessageGetRawDataSize (helics_message_object message);
 
     /** get the raw data for a message object
@@ -252,22 +288,82 @@ extern "C"
 
     /** get a pointer to the raw data of a message
     @param message a message object to get the data for
-
+    @return a pointer to the raw data in memory
     */
     HELICS_EXPORT void *helicsMessageGetRawDataPointer (helics_message_object message);
-
+    /** a check if the message contains a valid payload
+    @param message the message object in question
+    @return true if the message contains a payload
+    */
     HELICS_EXPORT helics_bool helicsMessageIsValid (helics_message_object message);
+    /** set the source of a message
+    @param message the message object in question
+    @param src a string containing the source
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetSource (helics_message_object message, const char *src, helics_error *err);
+    /** set the destination of a message
+    @param message the message object in question
+    @param dest a string containing the new destination
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetDestination (helics_message_object message, const char *dest, helics_error *err);
+    /** set the original source of a message
+    @param message the message object in question
+    @param src a string containing the new original source
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetOriginalSource (helics_message_object message, const char *src, helics_error *err);
+    /** set the original destination of a message
+    @param message the message object in question
+    @param dest a string containing the new original source
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetOriginalDestination (helics_message_object message, const char *dest, helics_error *err);
+    /** set the delivery time for a message
+    @param message the message object in question
+    @param time the time the message should be delivered
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetTime (helics_message_object message, helics_time time, helics_error *err);
+    /** resize the data buffer for a message
+    @details the message data buffer will be resized there is no guarantees on what is in the buffer in newly allocated space
+    if the allocated space is not sufficient new allocations will occur
+    @param message the message object in question
+    @param newSize the new size in bytes of the buffer
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageResize (helics_message_object message, int newSize, helics_error *err);
+    /** reserve space in a buffer but don't actually resize
+    @details the message data buffer will be reserved but not resized
+    @param message the message object in question
+    @param newSize the new size in bytes of the buffer
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageReserve (helics_message_object message, int reserveSize, helics_error *err);
+    /** set the message ID for the message
+    @details normally this is not needed and the core of HELICS will adjust as needed
+    @param message the message object in question
+    @param messageID a new message ID
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetMessageID (helics_message_object message, int32_t messageID, helics_error *err);
-    HELICS_EXPORT void helicsMessageSetFlags (helics_message_object message, uint16_t flags, helics_error *err);
+    /** clear the flags of a message
+    @param message the message object in question*/
+    HELICS_EXPORT void helicsMessageClearFlags (helics_message_object message);
+    /** set a flag on a message
+    @param message the message object in question
+    @param flag an index of a flag to set on the message
+    @param[in,out] err an error object to fill out in case of an error*/
+    HELICS_EXPORT void helicsMessageSetFlagOption (helics_message_object message, int flag, helics_bool flagValue, helics_error *err);
+    /** set the data payload of a message as a string
+    @param message the message object in question
+    @param str a string containing the message data
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetString (helics_message_object message, const char *str, helics_error *err);
+    /** set the data payload of a message as raw data
+    @param message the message object in question
+    @param data a string containing the message data
+    @param inputDataLength  the length of the data to input
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageSetData (helics_message_object message, const void *data, int inputDataLength, helics_error *err);
+    /** append data to the payload
+    @param message the message object in question
+    @param data a string containing the message data to append
+    @param inputDataLength  the length of the data to input
+    @param[in,out] err an error object to fill out in case of an error*/
     HELICS_EXPORT void helicsMessageAppendData (helics_message_object message, const void *data, int inputDataLength, helics_error *err);
 
     /**@}*/

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -231,7 +231,8 @@ extern "C"
     HELICS_EXPORT const char *helicsMessageGetOriginalDestination (helics_message_object message);
     HELICS_EXPORT helics_time helicsMessageGetTime (helics_message_object message);
     HELICS_EXPORT const char *helicsMessageGetString (helics_message_object message);
-
+    HELICS_EXPORT int helicsMessageGetMessageID (helics_message_object message);
+    HELICS_EXPORT uint16_t helicsMessageGetFlags (helics_message_object message);
     HELICS_EXPORT int helicsMessageGetRawDataSize (helics_message_object message);
 
     /** get the raw data for a message object
@@ -243,6 +244,24 @@ extern "C"
     */
     HELICS_EXPORT void helicsMessageGetRawData (helics_message_object message, void *data, int maxlen, int *actualSize, helics_error *err);
 
+    /** get a pointer to the raw data of a message
+    @param message a message object to get the data for
+
+    */
+    HELICS_EXPORT void *helicsMessageGetRawDataPointer (helics_message_object message);
+
+    HELICS_EXPORT helics_bool helicsMessageIsValid (helics_message_object message);
+    HELICS_EXPORT void helicsMessageSetSource (helics_message_object message, const char *src, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetDestination (helics_message_object message, const char *dest, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetOriginalSource (helics_message_object message, const char *src, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetOriginalDestination (helics_message_object message, const char *dest, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetTime (helics_message_object message, helics_time time, helics_error *err);
+    HELICS_EXPORT void helicsMessageAllocatePayload (helics_message_object message, int newSize, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetMessageID (helics_message_object message, int32_t messageID, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetFlags (helics_message_object message, uint16_t flags, helics_error *err);
+    HELICS_EXPORT void helicsMessageSetMessage (helics_message_object message, const char *str, helics_error *err);
+    HELICS_EXPORT void
+    helicsMessageSetMessageData (helics_message_object message, const void *data, int inputDataLength, helics_error *err);
 #ifdef __cplusplus
 } /* end of extern "C" { */
 #endif

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -788,7 +788,7 @@ int32_t helicsMessageGetMessageID (helics_message_object message)
 {
     if (message == nullptr)
     {
-        return helics_time_invalid;
+        return 0;
     }
     helics::Message *mess = reinterpret_cast<helics::Message *> (message);
     return mess->messageID;
@@ -798,7 +798,7 @@ uint16_t helicsMessageGetFlags (helics_message_object message)
 {
     if (message == nullptr)
     {
-        return helics_time_invalid;
+        return 0;
     }
     helics::Message *mess = reinterpret_cast<helics::Message *> (message);
     return mess->flags;
@@ -840,7 +840,7 @@ void helicsMessageGetRawData (helics_message_object message, void *data, int max
         return;
     }
     helics::Message *mess = reinterpret_cast<helics::Message *> (message);
-    if (mess->data.size () > maxMessagelen)
+    if (static_cast<int> (mess->data.size ()) > maxMessagelen)
     {
         *actualSize = 0;
         if (err != nullptr)

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -948,7 +948,7 @@ void helicsMessageSetTime (helics_message_object message, helics_time time, heli
     mess->time = time;
 }
 
-void helicsMessageAllocatePayload (helics_message_object message, int newSize, helics_error *err)
+void helicsMessageResize (helics_message_object message, int newSize, helics_error *err)
 {
     if (message == nullptr)
     {
@@ -961,6 +961,21 @@ void helicsMessageAllocatePayload (helics_message_object message, int newSize, h
     }
     helics::Message *mess = reinterpret_cast<helics::Message *> (message);
     mess->data.resize (newSize);
+}
+
+void helicsMessageReserve (helics_message_object message, int reservedSize, helics_error *err)
+{
+    if (message == nullptr)
+    {
+        if (err != nullptr)
+        {
+            err->error_code = helics_error_invalid_argument;
+            err->message = invalidMessageObject;
+        }
+        return;
+    }
+    helics::Message *mess = reinterpret_cast<helics::Message *> (message);
+    mess->data.reserve (reservedSize);
 }
 
 void helicsMessageSetMessageID (helics_message_object message, int32_t messageID, helics_error *err)
@@ -993,7 +1008,7 @@ void helicsMessageSetFlags (helics_message_object message, uint16_t flags, helic
     mess->flags = flags;
 }
 
-void helicsMessageSetMessage (helics_message_object message, const char *str, helics_error *err)
+void helicsMessageSetString (helics_message_object message, const char *str, helics_error *err)
 {
     if (message == nullptr)
     {
@@ -1008,7 +1023,7 @@ void helicsMessageSetMessage (helics_message_object message, const char *str, he
     mess->data = AS_STRING (str);
 }
 
-void helicsMessageSetMessageData (helics_message_object message, const void *data, int inputDataLength, helics_error *err)
+void helicsMessageSetData (helics_message_object message, const void *data, int inputDataLength, helics_error *err)
 {
     if (message == nullptr)
     {
@@ -1021,4 +1036,19 @@ void helicsMessageSetMessageData (helics_message_object message, const void *dat
     }
     helics::Message *mess = reinterpret_cast<helics::Message *> (message);
     mess->data.assign (static_cast<const char *> (data), inputDataLength);
+}
+
+void helicsMessageAppendData (helics_message_object message, const void *data, int inputDataLength, helics_error *err)
+{
+    if (message == nullptr)
+    {
+        if (err != nullptr)
+        {
+            err->error_code = helics_error_invalid_argument;
+            err->message = invalidMessageObject;
+        }
+        return;
+    }
+    helics::Message *mess = reinterpret_cast<helics::Message *> (message);
+    mess->data.append (static_cast<const char *> (data), inputDataLength);
 }

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -181,7 +181,7 @@ void helicsEndpointSetDefaultDestination (helics_endpoint endpoint, const char *
     {
         return;
     }
-    CHECK_NULL_STRING (dest, void ());
+    CHECK_NULL_STRING (dest, void());
     try
     {
         endObj->endPtr->setDefaultDestination (dest);
@@ -376,7 +376,7 @@ void helicsEndpointSubscribe (helics_endpoint endpoint, const char *key, helics_
     {
         return;
     }
-    CHECK_NULL_STRING (key, void ());
+    CHECK_NULL_STRING (key, void());
     try
     {
         endObj->endPtr->subscribe (key);
@@ -572,6 +572,7 @@ void helicsEndpointClearMessages (helics_endpoint endpoint)
     endObj->messages.clear ();
 }
 
+/* this function has been removed but may be added back in the future
 helics_message_object helicsFederateGetLastMessage (helics_federate fed)
 {
     auto fedObj = helics::getFedObject (fed, nullptr);
@@ -601,6 +602,7 @@ helics_message_object helicsEndpointGetLastMessage (helics_endpoint endpoint)
     }
     return nullptr;
 }
+*/
 
 bool checkOutArgString (const char *outputString, int maxlen, helics_error *err)
 {

--- a/src/helics/shared_api_library/api-data.h
+++ b/src/helics/shared_api_library/api-data.h
@@ -39,6 +39,8 @@ extern "C"
     typedef void *helics_federate_info;
     /** opaque object representing a query*/
     typedef void *helics_query;
+    /** opaque object representing a message*/
+    typedef void *helics_message_object;
 
     /** time definition used in the C interface to helics*/
     typedef double helics_time;
@@ -98,6 +100,7 @@ extern "C"
 
     /**
      *  Message_t mapped to a c compatible structure
+     * @details this will be deprecated in HELICS 2.3 and removed in HELICS 3.0
      */
     typedef struct helics_message
     {

--- a/src/helics/shared_api_library/helics.h
+++ b/src/helics/shared_api_library/helics.h
@@ -555,6 +555,14 @@ extern "C"
     invalid*/
     HELICS_EXPORT helics_time helicsFederateRequestTime (helics_federate fed, helics_time requestTime, helics_error *err);
 
+    /** request the next time for federate execution
+    @param fed the federate to make the request of
+    @param requestTime the next requested time
+    @param[in,out] err an error object that will contain an error code and string if any error occurred during the execution of the function
+    @return the time granted to the federate, will return helics_time_maxtime if the simulation has terminated
+    invalid*/
+    HELICS_EXPORT helics_time helicsFederateRequestTimeAdvance (helics_federate fed, helics_time timeDelta, helics_error *err);
+
     /** request the next time step for federate execution
     @details feds should have setup the period or minDelta for this to work well but it will request the next time step which is the current
     time plus the minimum time step

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -81,7 +81,7 @@ class FedObject
     int index = -2;
     int valid = 0;
     std::shared_ptr<Federate> fedptr;
-    std::unique_ptr<Message> lastMessage;
+    std::vector<std::unique_ptr<Message>> messages;
     std::vector<std::unique_ptr<InputObject>> inputs;
     std::vector<std::unique_ptr<PublicationObject>> pubs;
     std::vector<std::unique_ptr<EndpointObject>> epts;
@@ -116,7 +116,7 @@ class EndpointObject
   public:
     Endpoint *endPtr = nullptr;
     std::shared_ptr<MessageFederate> fedptr;
-    std::unique_ptr<Message> lastMessage;
+    std::vector<std::unique_ptr<Message>> messages;
     int valid = 0;
 };
 

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -197,6 +197,11 @@ BOOST_AUTO_TEST_CASE (message_object_tests)
 
     CE (mFed1State = helicsFederateGetState (mFed1, &err));
     BOOST_CHECK (mFed1State == helics_federate_state::helics_state_finalize);
+
+    helicsMessageSetFlagOption (M, 7, helics_true, &err);
+    BOOST_CHECK (helicsMessageCheckFlag (M, 7) == helics_true);
+    helicsMessageClearFlags (M);
+    BOOST_CHECK (helicsMessageCheckFlag (M, 7) == helics_false);
 }
 
 BOOST_DATA_TEST_CASE (message_federate_send_receive_2fed, bdata::make (core_types), core_type)

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -113,6 +113,46 @@ BOOST_DATA_TEST_CASE (message_federate_send_receive, bdata::make (core_types_sim
     BOOST_CHECK (mFed1State == helics_federate_state::helics_state_finalize);
 }
 
+BOOST_DATA_TEST_CASE (message_federate_send_receive_mobj, bdata::make (core_types_simple), core_type)
+{
+    SetupTest (helicsCreateMessageFederate, core_type, 1);
+    auto mFed1 = GetFederateAt (0);
+
+    auto epid = helicsFederateRegisterEndpoint (mFed1, "ep1", NULL, &err);
+    auto epid2 = helicsFederateRegisterGlobalEndpoint (mFed1, "ep2", "random", &err);
+    BOOST_CHECK_EQUAL (err.error_code, helics_ok);
+    CE (helicsFederateSetTimeProperty (mFed1, helics_property_time_delta, 1.0, &err));
+
+    CE (helicsFederateEnterExecutingMode (mFed1, &err));
+
+    CE (helics_federate_state mFed1State = helicsFederateGetState (mFed1, &err));
+    BOOST_CHECK (mFed1State == helics_state_execution);
+    std::string data (500, 'a');
+
+    CE (helicsEndpointSendEventRaw (epid, "ep2", data.c_str (), 500, 0.0, &err));
+    helics_time time;
+    CE (time = helicsFederateRequestTime (mFed1, 1.0, &err));
+    BOOST_CHECK_EQUAL (time, 1.0);
+
+    auto res = helicsFederateHasMessage (mFed1);
+    BOOST_CHECK (res);
+    res = helicsEndpointHasMessage (epid);
+    BOOST_CHECK (res == false);
+    res = helicsEndpointHasMessage (epid2);
+    BOOST_CHECK (res);
+
+    auto M = helicsEndpointGetMessageObject (epid2);
+    // BOOST_REQUIRE (M);
+    BOOST_REQUIRE_EQUAL (helicsMessageGetRawDataSize (M), 500);
+
+    char *rdata = static_cast<char *> (helicsMessageGetRawDataPointer (M));
+    BOOST_CHECK_EQUAL (rdata[245], 'a');
+    CE (helicsFederateFinalize (mFed1, &err));
+
+    CE (mFed1State = helicsFederateGetState (mFed1, &err));
+    BOOST_CHECK (mFed1State == helics_federate_state::helics_state_finalize);
+}
+
 BOOST_DATA_TEST_CASE (message_federate_send_receive_2fed, bdata::make (core_types), core_type)
 {
     // extraBrokerArgs = "--loglevel=4";

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -153,6 +153,52 @@ BOOST_DATA_TEST_CASE (message_federate_send_receive_mobj, bdata::make (core_type
     BOOST_CHECK (mFed1State == helics_federate_state::helics_state_finalize);
 }
 
+BOOST_AUTO_TEST_CASE (message_object_tests)
+{
+    SetupTest (helicsCreateMessageFederate, "test", 1);
+    auto mFed1 = GetFederateAt (0);
+
+    auto epid = helicsFederateRegisterEndpoint (mFed1, "ep1", NULL, &err);
+    auto epid2 = helicsFederateRegisterGlobalEndpoint (mFed1, "ep2", "random", &err);
+    BOOST_CHECK_EQUAL (err.error_code, helics_ok);
+    CE (helicsFederateSetTimeProperty (mFed1, helics_property_time_delta, 1.0, &err));
+
+    CE (helicsFederateEnterExecutingMode (mFed1, &err));
+
+    CE (helics_federate_state mFed1State = helicsFederateGetState (mFed1, &err));
+    BOOST_CHECK (mFed1State == helics_state_execution);
+    std::string data (500, 'a');
+
+    auto M = helicsFederateCreateMessageObject (mFed1, nullptr);
+    helicsMessageSetDestination (M, "ep2", nullptr);
+    BOOST_CHECK_EQUAL (helicsMessageGetDestination (M), "ep2");
+    helicsMessageSetData (M, data.data (), 500, &err);
+    helicsMessageSetTime (M, 0.0, &err);
+
+    CE (helicsEndpointSendMessageObject (epid, M, &err));
+    helics_time time;
+    CE (time = helicsFederateRequestTime (mFed1, 1.0, &err));
+    BOOST_CHECK_EQUAL (time, 1.0);
+
+    auto res = helicsFederateHasMessage (mFed1);
+    BOOST_CHECK (res);
+    res = helicsEndpointHasMessage (epid);
+    BOOST_CHECK (res == false);
+    res = helicsEndpointHasMessage (epid2);
+    BOOST_CHECK (res);
+
+    M = helicsEndpointGetMessageObject (epid2);
+    // BOOST_REQUIRE (M);
+    BOOST_REQUIRE_EQUAL (helicsMessageGetRawDataSize (M), 500);
+
+    char *rdata = static_cast<char *> (helicsMessageGetRawDataPointer (M));
+    BOOST_CHECK_EQUAL (rdata[245], 'a');
+    CE (helicsFederateFinalize (mFed1, &err));
+
+    CE (mFed1State = helicsFederateGetState (mFed1, &err));
+    BOOST_CHECK (mFed1State == helics_federate_state::helics_state_finalize);
+}
+
 BOOST_DATA_TEST_CASE (message_federate_send_receive_2fed, bdata::make (core_types), core_type)
 {
     // extraBrokerArgs = "--loglevel=4";


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will add a new message object API for better access to messages in the C and language API's, and fixes an inability to access raw data in the language API's for messages.

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add messageObject api to the C shared library
- add a few test cases using the API

The old API is still there and functional but will likely be deprecated in HELICS 2.3
This new api actually could be faster in C, since it allows access to the messages with no copying.  
and a much cleaner way to potentially do custom filters in the language API's
