### PR TITLE
set the default ENABLE_SWIG to OFF 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,50 +109,15 @@ endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-
-option(BUILD_PYTHON_INTERFACE "Build Python extension" OFF)
 option(
-    BUILD_PYTHON2_INTERFACE
-    "Build Python2.7 extension(Requires swig and will not build if \"PYTHON_INTERFACE\" is active)"
-    OFF
+    DISABLE_C_SHARED_LIB OFF
+    "turn off building of the C shared interface"
 )
-option(BUILD_MATLAB_INTERFACE "Build Matlab Extension" OFF)
-option(BUILD_OCTAVE_INTERFACE "Build Octave extension" OFF)
-option(BUILD_JAVA_INTERFACE "Build Java extension" OFF)
+mark_as_advanced(DISABLE_C_SHARED_LIB)
 
-if(${CMAKE_VERSION} VERSION_GREATER 3.8)
-    # cmake projects are only available for csharp from 3.8 onward
-    option(BUILD_CSHARP_INTERFACE "Build C# extension" OFF)
-endif()
-
-if(
-    BUILD_PYTHON_INTERFACE
-    OR BUILD_PYTHON2_INTERFACE
-    OR BUILD_MATLAB_INTERFACE
-    OR BUILD_JAVA_INTERFACE
-    OR BUILD_CSHARP_INTERFACE
-    OR BUILD_OCTAVE_INTERFACE
-)
-    set(INTERFACE_BUILD ON)
-else()
-    set(INTERFACE_BUILD OFF)
-endif()
-
-cmake_dependent_option(
-    BUILD_C_SHARED_LIB
-    "Build the Shared Libraries with a C interface"
-    ON
-    "NOT INTERFACE_BUILD"
-    ON
-)
-option(
-    ENABLE_SWIG
-    "enable the use of the swig executable to generate interface code and use repository code instead"
-    ON
-)
 option(BUILD_SHARED_LIBS "install shared libraries for the CXX interface" OFF)
 
-if(INTERFACE_BUILD OR BUILD_C_SHARED_LIB OR BUILD_SHARED_LIBS)
+if(NOT DISABLE_C_SHARED_LIB OR BUILD_SHARED_LIBS)
     set(BUILD_HELICS_SHARED_LIBS ON)
 endif()
 
@@ -695,9 +660,8 @@ if(ENABLE_CLANG_TOOLS)
     include(clang-cxx-dev-tools)
 endif(ENABLE_CLANG_TOOLS)
 
-if(INTERFACE_BUILD)
-    add_subdirectory(interfaces)
-endif()
+add_subdirectory(interfaces)
+
 
 # add base swig interface files as install option, regardless of current interfaces built
 install(
@@ -926,7 +890,7 @@ if(ENABLE_PACKAGE_BUILD)
         java
         octave
         csharp
-	swig
+		swig
         cereal
     )
     if(WIN32)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ before_build:
   - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --yes --limit-output #> $null
   - mkdir build
   - cd build
-  - cmake .. -G "Visual Studio 14 2015 Win64" -DBOOST_INSTALL_PATH=C:/libraries/boost_1_63_0 -DENABLE_PACKAGE_BUILD=ON -DBUILD_RELEASE_ONLY=ON -DBUILD_C_SHARED_LIB=ON -DBUILD_SHARED_LIBS=ON -DBUILD_JAVA_INTERFACE=ON
+  - cmake .. -G "Visual Studio 14 2015 Win64" -DBOOST_INSTALL_PATH=C:/libraries/boost_1_63_0 -DENABLE_PACKAGE_BUILD=ON -DENABLE_SWIG=ON -DBUILD_SHARED_LIBS=ON -DBUILD_JAVA_INTERFACE=ON
   - cd ..
 
 build:

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -6,12 +6,39 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
+if (NOT DISABLE_C_SHARED_INTERFACE)
 
-if(ENABLE_SWIG)
+option(BUILD_PYTHON_INTERFACE "Build Python extension" OFF)
+option(
+    BUILD_PYTHON2_INTERFACE
+    "Build Python2.7 extension(Requires swig and will not build if \"PYTHON_INTERFACE\" is active)"
+    OFF
+)
+option(BUILD_MATLAB_INTERFACE "Build Matlab Extension" OFF)
+option(BUILD_OCTAVE_INTERFACE "Build Octave extension" OFF)
+option(BUILD_JAVA_INTERFACE "Build Java extension" OFF)
+
+if(${CMAKE_VERSION} VERSION_GREATER 3.8)
+    # cmake projects are only available for csharp from 3.8 onward
+    option(BUILD_CSHARP_INTERFACE "Build C# extension" OFF)
+endif()
+
+
+IF(BUILD_CSHARP_INTERFACE OR BUILD_OCTAVE_INTERFACE OR BUILD_PYTHON2_INTERFACE)
+set(SWIG_REQUIRED ON)
+else()
+set(SWIG_REQUIRED OFF)
+if (BUILD_PYTHON_INTERFACE OR BUILD_MATLAB_INTERFACE OR BUILD_JAVA_INTERFACE)
+option(ENABLE_SWIG OFF "use swig to generate the interface files")
+endif()
+endif()
+
+if(ENABLE_SWIG OR SWIG_REQUIRED)
   if(WIN32 AND NOT MSYS)
     if(NOT CMAKE_PROGRAM_PATH)
       set(
         CMAKE_PROGRAM_PATH
+	"C:/local/swigwin-4.0.0"
         "C:/local/swigwin-3.0.12"
         "C:/local/swigwin-3.0.11"
         "C:/local/swigwin-3.0.10"
@@ -20,6 +47,7 @@ if(ENABLE_SWIG)
       set(
         CMAKE_PROGRAM_PATH
         "${CMAKE_PROGRAM_PATH}"
+	"C:/local/swigwin-4.0.0"
         "C:/local/swigwin-3.0.12"
         "C:/local/swigwin-3.0.11"
         "C:/local/swigwin-3.0.10"
@@ -66,3 +94,5 @@ endif()
 if(BUILD_CSHARP_INTERFACE)
    add_subdirectory(csharp)
 endif()
+
+endif()  # disable c shared interface

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -31,8 +31,8 @@ fi
 if [[ "${DISABLE_INTERFACES}" != *"Python"* ]]; then
     OPTION_FLAGS_ARR+=("-DBUILD_PYTHON_INTERFACE=ON" "-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}" "-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH}")
 fi
-if [[ "$USE_SWIG" == 'false' ]]; then
-    OPTION_FLAGS_ARR+=("-DENABLE_SWIG=OFF")
+if [[ "$USE_SWIG" == 'true' ]]; then
+    OPTION_FLAGS_ARR+=("-DENABLE_SWIG=ON")
 fi
 
 # Options related to the CMake build type

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -117,7 +117,7 @@ if (BUILD_APP_LIBRARY)
 	add_subdirectory(apps)
 endif(BUILD_APP_LIBRARY)
 
-if(BUILD_C_SHARED_LIB OR INTERFACE_BUILD)
+if(NOT DISABLE_C_SHARED_LIB)
   add_subdirectory(shared_api_library)
   add_subdirectory(cpp98)
   install(

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -267,7 +267,7 @@ FederateState *CommonCore::getFederate (const std::string &federateName) const
 
 FederateState *CommonCore::getHandleFederate (interface_handle handle)
 {
-    auto local_fed_id = handles.read ([handle] (auto &hand) { return hand.getLocalFedID (handle); });
+    auto local_fed_id = handles.read ([handle](auto &hand) { return hand.getLocalFedID (handle); });
     if (local_fed_id.isValid ())
     {
         auto feds = federates.lock ();
@@ -291,7 +291,7 @@ FederateState *CommonCore::getFederateCore (const std::string &federateName)
 
 FederateState *CommonCore::getHandleFederateCore (interface_handle handle)
 {
-    auto local_fed_id = handles.read ([handle] (auto &hand) { return hand.getLocalFedID (handle); });
+    auto local_fed_id = handles.read ([handle](auto &hand) { return hand.getLocalFedID (handle); });
     if (local_fed_id.isValid ())
     {
         return loopFederates[local_fed_id.baseValue ()].fed;
@@ -302,12 +302,12 @@ FederateState *CommonCore::getHandleFederateCore (interface_handle handle)
 
 const BasicHandleInfo *CommonCore::getHandleInfo (interface_handle handle) const
 {
-    return handles.read ([handle] (auto &hand) { return hand.getHandleInfo (handle.baseValue ()); });
+    return handles.read ([handle](auto &hand) { return hand.getHandleInfo (handle.baseValue ()); });
 }
 
 const BasicHandleInfo *CommonCore::getLocalEndpoint (const std::string &name) const
 {
-    return handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
+    return handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
 }
 
 bool CommonCore::isLocal (global_federate_id global_fedid) const
@@ -374,7 +374,7 @@ bool CommonCore::allInitReady () const
     }
     // all federates must be requesting init
     return std::all_of (loopFederates.begin (), loopFederates.end (),
-                        [] (const auto &fed) { return fed->init_transmitted.load (); });
+                        [](const auto &fed) { return fed->init_transmitted.load (); });
 }
 
 bool CommonCore::allDisconnected () const
@@ -391,7 +391,7 @@ bool CommonCore::allDisconnected () const
 bool CommonCore::allFedDisconnected () const
 {
     // all federates must have hit finished state
-    auto pred = [] (const auto &fed) { return fed.disconnected; };
+    auto pred = [](const auto &fed) { return fed.disconnected; };
     return std::all_of (loopFederates.begin (), loopFederates.end (), pred);
 }
 
@@ -528,7 +528,7 @@ local_federate_id CommonCore::registerFederate (const std::string &name, const C
     // setting up the Logger
     // auto ptr = fed.get();
     // if we are using the Logger, log all messages coming from the federates so they can control the level*/
-    fed->setLogger ([this] (int /*level*/, const std::string &ident, const std::string &message) {
+    fed->setLogger ([this](int /*level*/, const std::string &ident, const std::string &message) {
         sendToLogger (parent_broker_id, -2, ident, message);
     });
 
@@ -811,7 +811,7 @@ const BasicHandleInfo &CommonCore::createBasicHandle (global_federate_id global_
                                                       const std::string &units,
                                                       uint16_t flags)
 {
-    return handles.modify ([&] (auto &hand) -> const BasicHandleInfo & {
+    return handles.modify ([&](auto &hand) -> const BasicHandleInfo & {
         auto &hndl = hand.addHandle (global_federateId, HandleType, key, type, units);
         hndl.local_fed_id = local_federateId;
         hndl.flags = flags;
@@ -831,7 +831,7 @@ interface_handle CommonCore::registerInput (local_federate_id federateID,
     {
         throw (InvalidIdentifier ("federateID not valid (registerNamedInput)"));
     }
-    auto ci = handles.read ([&key] (auto &hand) { return hand.getInput (key); });
+    auto ci = handles.read ([&key](auto &hand) { return hand.getInput (key); });
     if (ci != nullptr)  // this key is already found
     {
         throw (RegistrationFailure ("named Input already exists"));
@@ -856,7 +856,7 @@ interface_handle CommonCore::registerInput (local_federate_id federateID,
 
 interface_handle CommonCore::getInput (local_federate_id federateID, const std::string &key) const
 {
-    auto ci = handles.read ([&key] (auto &hand) { return hand.getInput (key); });
+    auto ci = handles.read ([&key](auto &hand) { return hand.getInput (key); });
     if (ci->local_fed_id != federateID)
     {
         return {};
@@ -875,7 +875,7 @@ interface_handle CommonCore::registerPublication (local_federate_id federateID,
         throw (InvalidIdentifier ("federateID not valid (registerPublication)"));
     }
     LOG_INTERFACES (parent_broker_id, fed->getIdentifier (), fmt::format ("registering PUB {}", key));
-    auto pub = handles.read ([&key] (auto &hand) { return hand.getPublication (key); });
+    auto pub = handles.read ([&key](auto &hand) { return hand.getPublication (key); });
     if (pub != nullptr)  // this key is already found
     {
         throw (RegistrationFailure ("Publication key already exists"));
@@ -899,7 +899,7 @@ interface_handle CommonCore::registerPublication (local_federate_id federateID,
 
 interface_handle CommonCore::getPublication (local_federate_id federateID, const std::string &key) const
 {
-    auto pub = handles.read ([&key] (auto &hand) { return hand.getPublication (key); });
+    auto pub = handles.read ([&key](auto &hand) { return hand.getPublication (key); });
     if (pub->local_fed_id != federateID)
     {
         return interface_handle ();
@@ -995,7 +995,7 @@ void CommonCore::setHandleOption (interface_handle handle, int32_t option, bool 
         return;
     }
     handles.modify (
-      [handle, option, option_value] (auto &hand) { return hand.setHandleOption (handle, option, option_value); });
+      [handle, option, option_value](auto &hand) { return hand.setHandleOption (handle, option, option_value); });
 
     ActionMessage fcn (CMD_INTERFACE_CONFIGURE);
     fcn.dest_handle = handle;
@@ -1032,7 +1032,7 @@ bool CommonCore::getHandleOption (interface_handle handle, int32_t option) const
     {
     case defs::options::connection_required:
     case defs::options::connection_optional:
-        return handles.read ([handle, option] (auto &hand) { return hand.getHandleOption (handle, option); });
+        return handles.read ([handle, option](auto &hand) { return hand.getHandleOption (handle, option); });
     default:
         break;
     }
@@ -1066,7 +1066,7 @@ void CommonCore::closeHandle (interface_handle handle)
     cmd.setSource (handleInfo->handle);
     cmd.messageID = static_cast<int32_t> (handleInfo->handleType);
     addActionMessage (cmd);
-    handles.modify ([handle] (auto &hand) { setActionFlag (*hand.getHandleInfo (handle), disconnected_flag); });
+    handles.modify ([handle](auto &hand) { setActionFlag (*hand.getHandleInfo (handle), disconnected_flag); });
 }
 
 void CommonCore::removeTarget (interface_handle handle, const std::string &targetToRemove)
@@ -1266,7 +1266,7 @@ CommonCore::registerEndpoint (local_federate_id federateID, const std::string &n
     {
         throw (InvalidIdentifier ("federateID not valid (registerEndpoint)"));
     }
-    auto ept = handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
+    auto ept = handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
     if (ept != nullptr)
     {
         throw (RegistrationFailure ("endpoint name is already used"));
@@ -1289,7 +1289,7 @@ CommonCore::registerEndpoint (local_federate_id federateID, const std::string &n
 
 interface_handle CommonCore::getEndpoint (local_federate_id federateID, const std::string &name) const
 {
-    auto ept = handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
+    auto ept = handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
     if (ept->local_fed_id != federateID)
     {
         return interface_handle ();
@@ -1303,7 +1303,7 @@ CommonCore::registerFilter (const std::string &filterName, const std::string &ty
     // check to make sure the name isn't already used
     if (!filterName.empty ())
     {
-        if (handles.read ([&filterName] (auto &hand) {
+        if (handles.read ([&filterName](auto &hand) {
                 auto *res = hand.getFilter (filterName);
                 return (res != nullptr);
             }))
@@ -1344,7 +1344,7 @@ interface_handle CommonCore::registerCloningFilter (const std::string &filterNam
     // check to make sure the name isn't already used
     if (!filterName.empty ())
     {
-        if (handles.read ([&filterName] (auto &hand) {
+        if (handles.read ([&filterName](auto &hand) {
                 auto *res = hand.getFilter (filterName);
                 return (res != nullptr);
             }))
@@ -1382,7 +1382,7 @@ interface_handle CommonCore::registerCloningFilter (const std::string &filterNam
 
 interface_handle CommonCore::getFilter (const std::string &name) const
 {
-    auto filt = handles.read ([&name] (auto &hand) { return hand.getFilter (name); });
+    auto filt = handles.read ([&name](auto &hand) { return hand.getFilter (name); });
     if ((filt != nullptr) && (filt->handleType == handle_type::filter))
     {
         return filt->getInterfaceHandle ();
@@ -1803,7 +1803,7 @@ void CommonCore::setLoggingLevel (int logLevel)
 
 void CommonCore::setLoggingCallback (
   local_federate_id federateID,
-  std::function<void (int, const std::string &, const std::string &)> logFunction)
+  std::function<void(int, const std::string &, const std::string &)> logFunction)
 {
     if (federateID == local_core_id)
     {
@@ -1953,29 +1953,29 @@ std::string CommonCore::coreQuery (const std::string &queryStr) const
 {
     if (queryStr == "federates")
     {
-        return generateStringVector (loopFederates, [] (const auto &fed) { return fed->getIdentifier (); });
+        return generateStringVector (loopFederates, [](const auto &fed) { return fed->getIdentifier (); });
     }
     if (queryStr == "publications")
     {
         return generateStringVector_if (
-          loopHandles, [] (const auto &handle) { return handle.key; },
-          [] (const auto &handle) { return (handle.handleType == handle_type::publication); });
+          loopHandles, [](const auto &handle) { return handle.key; },
+          [](const auto &handle) { return (handle.handleType == handle_type::publication); });
     }
     if (queryStr == "endpoints")
     {
         return generateStringVector_if (
-          loopHandles, [] (const auto &handle) { return handle.key; },
-          [] (const auto &handle) { return (handle.handleType == handle_type::endpoint); });
+          loopHandles, [](const auto &handle) { return handle.key; },
+          [](const auto &handle) { return (handle.handleType == handle_type::endpoint); });
     }
     if (queryStr == "dependson")
     {
         return generateStringVector (timeCoord->getDependencies (),
-                                     [] (auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [](auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (queryStr == "dependents")
     {
         return generateStringVector (timeCoord->getDependents (),
-                                     [] (auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [](auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (queryStr == "isinit")
     {
@@ -2447,7 +2447,7 @@ void CommonCore::processCommand (ActionMessage &&command)
     case CMD_CHECK_CONNECTIONS:
     {
         auto res = checkAndProcessDisconnect ();
-        auto pred = [] (const auto &fed) {
+        auto pred = [](const auto &fed) {
             auto state = fed->getState ();
             return (HELICS_FINISHED == state) || (HELICS_ERROR == state);
         };
@@ -2870,7 +2870,7 @@ void CommonCore::registerInterface (ActionMessage &command)
     {
         auto handle = command.source_handle;
         auto &lH = loopHandles;
-        handles.read ([handle, &lH] (auto &hand) {
+        handles.read ([handle, &lH](auto &hand) {
             auto ifc = hand.getHandleInfo (handle.baseValue ());
             if (ifc != nullptr)
             {
@@ -2967,7 +2967,7 @@ void CommonCore::setAsUsed (BasicHandleInfo *hand)
         return;
     }
     hand->used = true;
-    handles.modify ([&] (auto &handle) { handle.getHandleInfo (hand->handle.handle)->used = true; });
+    handles.modify ([&](auto &handle) { handle.getHandleInfo (hand->handle.handle)->used = true; });
 }
 void CommonCore::checkForNamedInterface (ActionMessage &command)
 {
@@ -3668,7 +3668,7 @@ void CommonCore::processCoreConfigureCommands (ActionMessage &cmd)
             auto op = dataAirlocks[cmd.counter].try_unload ();
             if (op)
             {
-                auto M = stx::any_cast<std::function<void (int, const std::string &, const std::string &)>> (
+                auto M = stx::any_cast<std::function<void(int, const std::string &, const std::string &)>> (
                   std::move (*op));
                 setLoggerFunction (std::move (M));
             }
@@ -3882,7 +3882,11 @@ void CommonCore::routeMessage (ActionMessage &cmd, global_federate_id dest)
             }
             else
             {
-                fed->processPostTerminationAction (cmd);
+                auto rep = fed->processPostTerminationAction (cmd);
+                if (rep)
+                {
+                    routeMessage (*rep);
+                }
             }
         }
     }
@@ -3915,7 +3919,11 @@ void CommonCore::routeMessage (const ActionMessage &cmd)
             }
             else
             {
-                fed->processPostTerminationAction (cmd);
+                auto rep = fed->processPostTerminationAction (cmd);
+                if (rep)
+                {
+                    routeMessage (*rep);
+                }
             }
         }
     }
@@ -3952,7 +3960,11 @@ void CommonCore::routeMessage (ActionMessage &&cmd, global_federate_id dest)
             }
             else
             {
-                fed->processPostTerminationAction (cmd);
+                auto rep = fed->processPostTerminationAction (cmd);
+                if (rep)
+                {
+                    routeMessage (*rep);
+                }
             }
         }
     }
@@ -3985,7 +3997,11 @@ void CommonCore::routeMessage (ActionMessage &&cmd)
             }
             else
             {
-                fed->processPostTerminationAction (cmd);
+                auto rep = fed->processPostTerminationAction (cmd);
+                if (rep)
+                {
+                    routeMessage (*rep);
+                }
             }
         }
     }
@@ -4343,6 +4359,6 @@ const std::string &CommonCore::getInterfaceInfo (interface_handle handle) const
 
 void CommonCore::setInterfaceInfo (helics::interface_handle handle, std::string info)
 {
-    handles.modify ([&] (auto &hdls) { hdls.getHandleInfo (handle.baseValue ())->interface_info = info; });
+    handles.modify ([&](auto &hdls) { hdls.getHandleInfo (handle.baseValue ())->interface_info = info; });
 }
 }  // namespace helics

--- a/src/helics/core/HandleManager.cpp
+++ b/src/helics/core/HandleManager.cpp
@@ -93,7 +93,7 @@ void HandleManager::addHandleAtIndex (const BasicHandleInfo &otherHandle, int32_
     }
     else if (index > 0)
     {
-        handles.resize (index + 1);
+        handles.resize (static_cast<size_t>(index) + 1);
         // use placement new to reconstruct new object
         new (&handles[index]) BasicHandleInfo (otherHandle);
         addSearchFields (handles[index], index);

--- a/src/helics/core/zmq/ZmqRequestSets.h
+++ b/src/helics/core/zmq/ZmqRequestSets.h
@@ -22,7 +22,7 @@ namespace zeromq
 class WaitingResponse
 {
   public:
-    int route;  //!< the route identifier for the socket
+    int route=0;  //!< the route identifier for the socket
     std::uint16_t loops = 0;  //!< the number of loops
     bool waiting = false;  //!< whether the response is waiting
     ActionMessage txmsg;  //!< the most recently sent message


### PR DESCRIPTION
and not even give the option if CSHARP, PYTHON2, or OCTAVE interfaces are enabled.  move the definitions of the options to the interfaces folder CMAKE and create a DISABLE_C_SHARED_LIB option to explicily disable the C_SHARED_LIB otherwise by default it is enabled.

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will change the options for ENABLE_SWIG, the default is off unless one of the interfaces that needs to be generated is selected.  Then it is required.  Also move the interface options to the interfaces folder, and then make an advanced option for DISABLE_C_SHARED_LIB to explicitly disable it otherwise it is on by default.
This resolves issue #765 