### PR TITLE
Fix addUnits Option parameter for CMake to match option parameter order

### DIFF
--- a/config/cmake/addUnits.cmake
+++ b/config/cmake/addUnits.cmake
@@ -3,9 +3,9 @@
 set(UNITS_LIBRARY_EXPORT_COMMAND ${HELICS_EXPORT_COMMAND} CACHE INTERNAL "")
 
 if (MSVC)
-  option(HELICS_UNITS_OBJLIB OFF "use the units objlib for linking object files instead of the normal target") 
+  option(HELICS_UNITS_OBJLIB "use the units objlib for linking object files instead of the normal target" OFF)
 else(MSVC)
-  option(HELICS_UNITS_OBJLIB ON "use the units objlib for linking object files instead of the normal target") 
+  option(HELICS_UNITS_OBJLIB "use the units objlib for linking object files instead of the normal target" ON)
 endif(MSVC)
 
 mark_as_advanced(HELICS_UNITS_OBJLIB)


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will fix order of option parameters in addUnit.cmake, so value is actually set for HELICS_UNIT_OBJLIB. 
Refer to [CMake option](https://cmake.org/cmake/help/latest/command/option.html) for syntax. 

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
-
