### PR TITLE
Zmq leak on delete

### DIFF
--- a/src/helics/apps/helics-broker.cpp
+++ b/src/helics/apps/helics-broker.cpp
@@ -13,10 +13,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gmlc/utilities/stringOps.h"
 #include <iostream>
 #include <thread>
-#ifdef ENABLE_ZMQ_CORE
-#include "../common/zmqContextManager.h"
-#include "cppzmq/zmq.hpp"
-#endif
+
 /** function to run the online terminal program*/
 void terminalFunction (std::vector<std::string> args);
 
@@ -96,14 +93,6 @@ int main (int argc, char *argv[])
         ret = -4;
     }
 
-#ifdef ENABLE_ZMQ_CORE
-#ifdef __APPLE__
-    if (ZmqContextManager::setContextToLeakOnDelete ())
-    {
-        ZmqContextManager::getContext ().close ();
-    }
-#endif
-#endif
     helics::cleanupHelicsLibrary ();
     return ret;
 }

--- a/src/helics/common/zmqContextManager.cpp
+++ b/src/helics/common/zmqContextManager.cpp
@@ -84,6 +84,17 @@ bool ZmqContextManager::setContextToLeakOnDelete (const std::string &contextName
     }
     return false;
 }
+
+bool ZmqContextManager::setContextToNotLeakOnDelete (const std::string &contextName)
+{
+    std::lock_guard<std::mutex> conlock (contextLock);
+    auto fnd = contexts.find (contextName);
+    if (fnd != contexts.end ())
+    {
+        fnd->second->leakOnDelete = false;
+    }
+    return false;
+}
 ZmqContextManager::~ZmqContextManager ()
 {
     // std::cout << "destroying context in " << std::this_thread::get_id() << std::endl;
@@ -96,7 +107,7 @@ ZmqContextManager::~ZmqContextManager ()
     }
     else
     {
-        std::this_thread::sleep_for (std::chrono::milliseconds (200));
+       // std::this_thread::sleep_for (std::chrono::milliseconds (200));
     }
 }
 

--- a/src/helics/common/zmqContextManager.cpp
+++ b/src/helics/common/zmqContextManager.cpp
@@ -105,10 +105,6 @@ ZmqContextManager::~ZmqContextManager ()
         auto val = zcontext.release ();
         (void)(val);
     }
-    else
-    {
-       // std::this_thread::sleep_for (std::chrono::milliseconds (200));
-    }
 }
 
 ZmqContextManager::ZmqContextManager (const std::string &contextName)

--- a/src/helics/common/zmqContextManager.h
+++ b/src/helics/common/zmqContextManager.h
@@ -36,24 +36,25 @@ class ZmqContextManager
       contexts;  //!< container for pointers to all the available contexts
     std::string name;  //!< context name
     std::unique_ptr<zmq::context_t> zcontext;  //!< pointer to the actual context
-    std::atomic<bool> leakOnDelete{false};  //!< this is done to prevent some warning messages for use in DLL's
+    std::atomic<bool> leakOnDelete{true};  //!< this is done to prevent some errors if zmq is not built properly or the OS shuts it down early
     explicit ZmqContextManager (const std::string &contextName);
 
   public:
-    static std::shared_ptr<ZmqContextManager> getContextPointer (const std::string &contextName = std::string ());
+    static std::shared_ptr<ZmqContextManager> getContextPointer (const std::string &contextName = std::string{});
 
-    static zmq::context_t &getContext (const std::string &contextName = std::string ());
+    static zmq::context_t &getContext (const std::string &contextName = std::string{});
     /** start a ZMQ context if it hasn't been started already*/
-    static void startContext (const std::string &contextName = std::string ());
-    /** close a ZMQ context if it exists already*/
-    static void closeContext (const std::string &contextName = std::string ());
+    static void startContext (const std::string &contextName = std::string{});
+    /** close a ZMQ context if it exists already regardless of leakOnDelete Status*/
+    static void closeContext (const std::string &contextName = std::string{});
     /** tell the context to free the pointer and leak the memory on delete
     @details You may ask why, well in windows systems when operating in a DLL if this context is closed after
     certain other operations that happen when the DLL is unlinked bad things can happen, and since in nearly all
     cases this happens at Shutdown leaking really doesn't matter that much
     @return true if the context was found and the flag set, false otherwise
     */
-    static bool setContextToLeakOnDelete (const std::string &contextName = std::string ());
+    static bool setContextToLeakOnDelete (const std::string &contextName = std::string{});
+    static bool setContextToNotLeakOnDelete (const std::string &contextName = std::string{});
     virtual ~ZmqContextManager ();
 
     const std::string &getName () const { return name; }

--- a/src/helics/common/zmqContextManager.h
+++ b/src/helics/common/zmqContextManager.h
@@ -45,7 +45,7 @@ class ZmqContextManager
     static zmq::context_t &getContext (const std::string &contextName = std::string{});
     /** start a ZMQ context if it hasn't been started already*/
     static void startContext (const std::string &contextName = std::string{});
-    /** close a ZMQ context if it exists already regardless of leakOnDelete Status*/
+    /** close a ZMQ context if it exists*/
     static void closeContext (const std::string &contextName = std::string{});
     /** tell the context to free the pointer and leak the memory on delete
     @details You may ask why, well in windows systems when operating in a DLL if this context is closed after

--- a/src/helics/common/zmqContextManager.h
+++ b/src/helics/common/zmqContextManager.h
@@ -28,7 +28,9 @@ namespace zmq
 class context_t;
 }  // namespace zmq
 
-/** class defining a singleton context manager for all zmq usage in gridDyn*/
+/** class defining a global context manager for all zmq usage
+@details the zmq::context_t is stored in global structure so more than one can exist, but most use cases it is just
+the equivalent of a singleton*/
 class ZmqContextManager
 {
   private:
@@ -36,12 +38,16 @@ class ZmqContextManager
       contexts;  //!< container for pointers to all the available contexts
     std::string name;  //!< context name
     std::unique_ptr<zmq::context_t> zcontext;  //!< pointer to the actual context
-    std::atomic<bool> leakOnDelete{true};  //!< this is done to prevent some errors if zmq is not built properly or the OS shuts it down early
+    std::atomic<bool> leakOnDelete{
+      true};  //!< this is done to prevent some errors if zmq is not built properly or the OS shuts it down early
+
+    /** the constructor is private to make sure it is created through the static functions*/
     explicit ZmqContextManager (const std::string &contextName);
 
   public:
+    /** get a shared_ptr to the context by name*/
     static std::shared_ptr<ZmqContextManager> getContextPointer (const std::string &contextName = std::string{});
-
+    /** get an underlying zmq::context_t reference by name */
     static zmq::context_t &getContext (const std::string &contextName = std::string{});
     /** start a ZMQ context if it hasn't been started already*/
     static void startContext (const std::string &contextName = std::string{});
@@ -50,14 +56,19 @@ class ZmqContextManager
     /** tell the context to free the pointer and leak the memory on delete
     @details You may ask why, well in windows systems when operating in a DLL if this context is closed after
     certain other operations that happen when the DLL is unlinked bad things can happen, and since in nearly all
-    cases this happens at Shutdown leaking really doesn't matter that much
+    cases this happens at Shutdown leaking really doesn't matter that much, it also seem to be required when the
+    zmq library is built with curve instead of turning off the encryption or with sodium,  in that case there seems
+    to be some issues in the zmq library itself when closing the context, causing some issue that eventually leads
+    to something trying to access a deleted mutex on program shutdown.  Which is annoying.
     @return true if the context was found and the flag set, false otherwise
     */
     static bool setContextToLeakOnDelete (const std::string &contextName = std::string{});
+    /** turn off the leak on delete mode*/
     static bool setContextToNotLeakOnDelete (const std::string &contextName = std::string{});
-    virtual ~ZmqContextManager ();
-
+    /** destructor*/
+    ~ZmqContextManager ();
+    /** get the name of the context*/
     const std::string &getName () const { return name; }
-
+    /** get a reference to the underlying zmq::context_t for use with cppzmq library calls*/
     zmq::context_t &getBaseContext () const { return *zcontext; }
 };

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -1109,12 +1109,7 @@ void helicsCloseLibrary (void)
     auto ret = std::async (std::launch::async, [] () { helics::CoreFactory::cleanUpCores (2000ms); });
     helics::BrokerFactory::cleanUpBrokers (2000ms);
     ret.get ();
-#ifdef ENABLE_ZMQ_CORE
-    if (ZmqContextManager::setContextToLeakOnDelete ())
-    {
-        ZmqContextManager::getContext ().close ();
-    }
-#endif
+
     helics::LoggerManager::closeLogger ();
     // helics::cleanupHelicsLibrary();
 }

--- a/tests/helics/application_api/application-api-tests.cpp
+++ b/tests/helics/application_api/application-api-tests.cpp
@@ -9,11 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/helics-config.h"
 #include <helics/application_api/Federate.hpp>
 //#include <iostream>
- 
-#ifdef ENABLE_ZMQ_CORE
-#include "helics/common/zmqContextManager.h"
-#include "cppzmq/zmq.hpp"
-#endif
+
 
 #ifndef BOOST_STATIC
 #define BOOST_TEST_DYN_LINK
@@ -29,15 +25,6 @@ struct globalTestConfig
     globalTestConfig () = default;
     ~globalTestConfig ()
     {
-        // macOS ZeroMQ can have issues shutting down, if not built from source without CURVE
-#ifdef ENABLE_ZMQ_CORE
-#ifdef __APPLE__
-        if (ZmqContextManager::setContextToLeakOnDelete ())
-        {
-            ZmqContextManager::getContext ().close ();
-        }
-#endif
-#endif
         //    std::cout << "cleaning up" << std::endl;
         helics::cleanupHelicsLibrary ();
         //     std::cout << "finished cleaning up" << std::endl;

--- a/tests/helics/common/common-tests.cpp
+++ b/tests/helics/common/common-tests.cpp
@@ -8,11 +8,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 
-#ifdef ENABLE_ZMQ_CORE
-#include "cppzmq/zmq.hpp"
-#include "helics/common/zmqContextManager.h"
-#endif
-
 #include <helics/core/BrokerFactory.hpp>
 #include <helics/core/CoreFactory.hpp>
 
@@ -20,14 +15,6 @@ struct globalTestConfig : public ::testing::Environment
 {
     virtual void TearDown () override
     {
-#ifdef ENABLE_ZMQ_CORE
-#ifdef __APPLE__
-        if (ZmqContextManager::setContextToLeakOnDelete ())
-        {
-            ZmqContextManager::getContext ().close ();
-        }
-#endif
-#endif
         helics::CoreFactory::cleanUpCores ();
         helics::BrokerFactory::cleanUpBrokers ();
     }

--- a/tests/helics/core/core-tests.cpp
+++ b/tests/helics/core/core-tests.cpp
@@ -8,11 +8,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 
-#ifdef ENABLE_ZMQ_CORE
-#include "cppzmq/zmq.hpp"
-#include "helics/common/zmqContextManager.h"
-#endif
-
 #include <helics/core/BrokerFactory.hpp>
 #include <helics/core/CoreFactory.hpp>
 
@@ -20,14 +15,6 @@ struct globalTestConfig : public ::testing::Environment
 {
     virtual void TearDown () override
     {
-#ifdef ENABLE_ZMQ_CORE
-#ifdef __APPLE__
-        if (ZmqContextManager::setContextToLeakOnDelete ())
-        {
-            ZmqContextManager::getContext ().close ();
-        }
-#endif
-#endif
         helics::CoreFactory::cleanUpCores ();
         helics::BrokerFactory::cleanUpBrokers ();
     }

--- a/tests/helics/system_tests/helics_system_tests.cpp
+++ b/tests/helics/system_tests/helics_system_tests.cpp
@@ -8,11 +8,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 
-#ifdef ENABLE_ZMQ_CORE
-#include "cppzmq/zmq.hpp"
-#include "helics/common/zmqContextManager.h"
-#endif
-
 #include <helics/core/BrokerFactory.hpp>
 #include <helics/core/CoreFactory.hpp>
 
@@ -20,14 +15,7 @@ struct globalTestConfig : public ::testing::Environment
 {
     virtual void TearDown () override
     {
-#ifdef ENABLE_ZMQ_CORE
-#ifdef __APPLE__
-        if (ZmqContextManager::setContextToLeakOnDelete ())
-        {
-            ZmqContextManager::getContext ().close ();
-        }
-#endif
-#endif
+
         helics::CoreFactory::cleanUpCores ();
         helics::BrokerFactory::cleanUpBrokers ();
     }


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will make zmq leaking on delete the default, and remove the excess calls for that in the various executables.  

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- make zmqleakonDelete the default
- add functions to turn that off
- add some documentation on the zmqcontextmanager
