### PR TITLE
Shared library install file location changes

### DIFF
--- a/interfaces/matlab/CMakeLists.txt
+++ b/interfaces/matlab/CMakeLists.txt
@@ -162,25 +162,30 @@ install(
   DESTINATION matlab
   COMPONENT matlab
 )
-install(FILES $<TARGET_LINKER_FILE:helicsSharedLib> DESTINATION matlab COMPONENT matlab)
+
+if(WIN32)
+  install(FILES $<TARGET_LINKER_FILE:helicsSharedLib> DESTINATION matlab COMPONENT matlab)
+  install(
+    FILES ${PROJECT_BINARY_DIR}/src/helics/shared_api_library/helics_export.h
+    DESTINATION matlab/headers
+    COMPONENT matlab
+  )
+  install(
+    FILES helicsSharedLib.h libhelicsSharedLib.h
+    DESTINATION matlab
+    COMPONENT matlab
+  )
+endif()
+
 install_key_files_with_comp(matlab)
 install(FILES ${HSHARED_LIB_SOURCES} DESTINATION matlab/headers COMPONENT matlab)
 
-install(
-  FILES ${PROJECT_BINARY_DIR}/src/helics/shared_api_library/helics_export.h
-  DESTINATION matlab/headers
-  COMPONENT matlab
-)
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/generatehelicsMEXFile.m 
   DESTINATION matlab
   COMPONENT matlab
 )
-install(
-  FILES helicsSharedLib.h libhelicsSharedLib.h
-  DESTINATION matlab
-  COMPONENT matlab
-)
+
 
 file(GLOB EXTRA_MATLAB_FILES ${CMAKE_CURRENT_SOURCE_DIR}/extra/*.m)
 

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -122,7 +122,7 @@ if(BUILD_SHARED_LIBS)
     )
   else()
     install(
-      TARGETS helicsSharedLib
+      TARGETS helics-shared
       DESTINATION ${CMAKE_INSTALL_LIBDIR}
       COMPONENT Runtime
     )

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -109,16 +109,13 @@ if(BUILD_SHARED_LIBS)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
 
-  install(
-    FILES $<TARGET_LINKER_FILE:helics-shared>
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libs
-  )
-  install(
-    FILES $<TARGET_FILE:helics-shared>
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT libs
-  )
+  if(WIN32)
+    install(
+      FILES $<TARGET_FILE:helics-shared>
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
+      COMPONENT Runtime
+    )
+  endif()
 
 endif(BUILD_SHARED_LIBS)
 

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -111,8 +111,19 @@ if(BUILD_SHARED_LIBS)
 
   if(WIN32)
     install(
+      FILES $<TARGET_LINKER_FILE:helics-shared>
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT libs
+    )
+    install(
       FILES $<TARGET_FILE:helics-shared>
       DESTINATION ${CMAKE_INSTALL_BINDIR}
+      COMPONENT Runtime
+    )
+  else()
+    install(
+      TARGETS helicsSharedLib
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
       COMPONENT Runtime
     )
   endif()

--- a/src/helics/shared_api_library/CMakeLists.txt
+++ b/src/helics/shared_api_library/CMakeLists.txt
@@ -83,14 +83,26 @@ else()
 	set(HELICS_EXCLUSION_COMMAND )
 endif()
 
-  if(WIN32)
-    install(
-      FILES $<TARGET_FILE:helicsSharedLib>
-      DESTINATION ${CMAKE_INSTALL_BINDIR}
-      COMPONENT
-      Runtime ${HELICS_EXCLUSION_COMMAND}
-    )
-  endif()
+if(WIN32)
+  install(
+    FILES $<TARGET_LINKER_FILE:helicsSharedLib>
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT libs ${HELICS_EXCLUSION_COMMAND}
+  )
+  install(
+    FILES $<TARGET_FILE:helicsSharedLib>
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT
+    Runtime ${HELICS_EXCLUSION_COMMAND}
+  )
+else()
+  install(
+    TARGETS helicsSharedLib
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT
+    Runtime ${HELICS_EXCLUSION_COMMAND}
+  )
+endif()
 
 
 install(

--- a/src/helics/shared_api_library/CMakeLists.txt
+++ b/src/helics/shared_api_library/CMakeLists.txt
@@ -83,17 +83,14 @@ else()
 	set(HELICS_EXCLUSION_COMMAND )
 endif()
 
- install(
-    FILES $<TARGET_LINKER_FILE:helicsSharedLib>
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libs ${HELICS_EXCLUSION_COMMAND}
-  )
-  install(
-    FILES $<TARGET_FILE:helicsSharedLib>
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT
-    Runtime ${HELICS_EXCLUSION_COMMAND}
-  )
+  if(WIN32)
+    install(
+      FILES $<TARGET_FILE:helicsSharedLib>
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
+      COMPONENT
+      Runtime ${HELICS_EXCLUSION_COMMAND}
+    )
+  endif()
 
 
 install(


### PR DESCRIPTION
### Summary
If merged this pull request will stop installing copies (some of which are non-functional due to symlinks) of the helics shared library outside of the lib folder on non-Windows systems, in favor of relying on a system installed copy or properly set PATH/LD_LIBRARY_PATH environment variables.

### Proposed changes
- Remove install of shared library files in BINDIR, except on Windows
- Remove non-functioning install of helicsSharedLib from the Matlab extension folder on non-Windows 
