### PR TITLE
Use a multi-stage Docker build for the HELICS apps container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Minor release with some updates to the networking portion of HELICS and some API
 -  CI tests using docker for clang memory sanitizer and the octave interface.
 -  Scripts for generating a single zip file with all the code including submodules.  This will be generated for each new release.  
 -  A broker server that generate multiple brokers on a single system and handles the port allocation intelligently. (Only ZMQ currently supported, this is not backwards compatible, though regular 2.2 brokers should work with 2.1 federates if needed.)
+- A Docker image containing the HELICS apps (available on Docker Hub for tagged releases and the latest develop branch at https://hub.docker.com/r/helics/helics)
 
 ### Removed
 -   ENABLE_SWIG option in cmake as always ON.  This option will only appear for interfaces that have existing build files.  For swig generated interfaces that do not have prebuilt files (octave, python2, and C#) this option will no longer appear as swig is required.  

--- a/config/Docker/Dockerfile-HELICS
+++ b/config/Docker/Dockerfile-HELICS
@@ -12,10 +12,15 @@ RUN apt update && apt install -y \
 WORKDIR /root/develop
 
 RUN git clone https://github.com/GMLC-TDC/HELICS.git
-RUN cd HELICS && mkdir build  && cd build && cmake .. -DBUILD_HELICS_TESTS=OFF -DENABLE_IPC_CORE=OFF -DBUILD_HELICS_EXAMPLES=OFF -DBUILD_C_SHARED_LIB=OFF
+RUN cd HELICS && mkdir build  && cd build && cmake -DBUILD_HELICS_TESTS=OFF -DENABLE_IPC_CORE=OFF -DBUILD_HELICS_EXAMPLES=OFF -DBUILD_C_SHARED_LIB=OFF \
+  -DCMAKE_BUILD_TYPE=Release -DBUILD_RELEASE_ONLY=ON -DCMAKE_INSTALL_PREFIX=/root/develop/helics-install ..
 RUN cd HELICS && cd build && make -j${MAKE_PARALLEL:-2} install
 # Create script to build helics
 
-RUN rm -rf /var/lib/apt/lists/*
-RUN rm -rf HELICS
+RUN rm -rf /var/lib/apt/lists/* && rm -rf HELICS
 
+
+# Final image with HELICS apps
+FROM ubuntu:18.04
+COPY --from=builder /root/develop/helics-install /usr
+RUN apt-get update && apt-get install -y libzmq5 && apt-get clean


### PR DESCRIPTION
### Summary
If merged this pull request will build the HELICS apps docker container using a multistage build to reduce the size, along with doing a Release build of the apps.

Some numbers for the effect of the changes on sizes-- the image size shown by `docker images` goes from 1.01GB -> 265MB from the multistage build, setting the CMake build type to Release decreased the size from 265MB to 132MB. On DockerHub, the size listed next to the tag went from 300MB to 58MB with both changes.

### Proposed changes
- Change the CMAKE_BUILD_TYPE to Release
- Use a multi-stage build to create the HELICS apps Docker image
