### PR TITLE
Include the gtest license only if the tests are built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,11 +870,14 @@ set(LICENSE_LIST
 	"cppzmq" "${PROJECT_SOURCE_DIR}/ThirdParty/cppzmq/LICENSE"
 	"fmt" "${PROJECT_SOURCE_DIR}/ThirdParty/fmtlib/LICENSE.rst"
 	"units" "${PROJECT_SOURCE_DIR}/ThirdParty/units/LICENSE"
-	"Google Test" "${PROJECT_SOURCE_DIR}/ThirdParty/googletest/LICENSE"
 	"JsonCpp" "${PROJECT_SOURCE_DIR}/ThirdParty/jsoncpp/LICENSE"
 	"tinytoml" "${PROJECT_SOURCE_DIR}/ThirdParty/toml/LICENSE"
 	"GMLC Utilities" "${PROJECT_SOURCE_DIR}/ThirdParty/utilities/LICENSE"
 )
+
+if(BUILD_HELICS_TESTS)
+	list(APPEND LICENSE_LIST "Google Test" "${PROJECT_SOURCE_DIR}/ThirdParty/googletest/LICENSE"
+endif()
 
 if (EXISTS ${PROJECT_BINARY_DIR}/_deps/libzmq-src)
 	list(APPEND LICENSE_LIST "ZeroMQ" "${PROJECT_BINARY_DIR}/_deps/libzmq-src/COPYING")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,7 +876,7 @@ set(LICENSE_LIST
 )
 
 if(BUILD_HELICS_TESTS)
-	list(APPEND LICENSE_LIST "Google Test" "${PROJECT_SOURCE_DIR}/ThirdParty/googletest/LICENSE"
+	list(APPEND LICENSE_LIST "Google Test" "${PROJECT_SOURCE_DIR}/ThirdParty/googletest/LICENSE")
 endif()
 
 if (EXISTS ${PROJECT_BINARY_DIR}/_deps/libzmq-src)


### PR DESCRIPTION

### Summary

If merged this pull request will only include the gtest license file if the tests using gtest were built.

### Proposed changes

- Include the gtest license only if the tests are built 
