### PR TITLE
Apps test to gtest

### DIFF
--- a/scripts/run-nighly-circleci-tests.sh
+++ b/scripts/run-nighly-circleci-tests.sh
@@ -3,7 +3,9 @@ tests=(
     /root/project/build/tests/helics/core/core-tests
     /root/project/build/tests/helics/common/common-tests
     "/root/project/build/tests/helics/system_tests/system-tests --gtest_filter=-*realtime*"
+	/root/project/build/tests/helics/helics_apps-tests/helics_apps-tests
 )
+
 SUMRESULT=0
 for test in "${tests[@]}"; do
     echo "${test}"

--- a/scripts/run-nighly-circleci-tests.sh
+++ b/scripts/run-nighly-circleci-tests.sh
@@ -3,7 +3,7 @@ tests=(
     /root/project/build/tests/helics/core/core-tests
     /root/project/build/tests/helics/common/common-tests
     "/root/project/build/tests/helics/system_tests/system-tests --gtest_filter=-*realtime*"
-	/root/project/build/tests/helics/helics_apps-tests/helics_apps-tests
+	/root/project/build/tests/helics/apps/helics_apps-tests
 )
 
 SUMRESULT=0

--- a/tests/helics/CMakeLists.txt
+++ b/tests/helics/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(helics_google_test_base INTERFACE helics_base_includes com
 add_subdirectory(core)
 add_subdirectory(common)
 add_subdirectory(system_tests)
+add_subdirectory(apps)
 
 if (BUILD_BOOST_TESTS)
 
@@ -27,8 +28,6 @@ add_subdirectory(application_api)
 if(NOT DISABLE_C_SHARED_LIB)
     add_subdirectory(shared_library)
 endif()
-
-add_subdirectory(apps)
 
 add_subdirectory(performance_tests)
 endif()

--- a/tests/helics/apps/BrokerServerTests.cpp
+++ b/tests/helics/apps/BrokerServerTests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #include "exeTestHelper.h"
 
@@ -16,12 +15,9 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 
-namespace utf = boost::unit_test;
 using namespace helics;
 
-BOOST_AUTO_TEST_SUITE (broker_server_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_CASE (startup_tests)
+TEST (broker_server_tests, startup_tests)
 {
     apps::BrokerServer brks (std::vector<std::string>{"--zmq"});
     bool active = brks.hasActiveBrokers ();
@@ -30,21 +26,21 @@ BOOST_AUTO_TEST_CASE (startup_tests)
         std::this_thread::sleep_for (std::chrono::milliseconds (300));
         active = brks.hasActiveBrokers ();
     }
-    BOOST_CHECK (!active);
+    EXPECT_TRUE (!active);
     brks.startServers ();
 
     auto cr = helics::CoreFactory::create (helics::core_type::ZMQ, "--brokername=fred");
-    BOOST_CHECK (cr->isConfigured ());
+    EXPECT_TRUE (cr->isConfigured ());
     cr->connect ();
-    BOOST_CHECK (cr->isConnected ());
+    EXPECT_TRUE (cr->isConnected ());
 
     auto cr2 = helics::CoreFactory::create (helics::core_type::ZMQ, "--brokername=fred2");
-    BOOST_CHECK (cr2->isConfigured ());
+    EXPECT_TRUE (cr2->isConfigured ());
     cr2->connect ();
-    BOOST_CHECK (cr2->isConnected ());
+    EXPECT_TRUE (cr2->isConnected ());
 
     auto objs = helics::BrokerFactory::getAllBrokers ();
-    BOOST_CHECK_EQUAL (objs.size (), 2u);
+    EXPECT_EQ (objs.size (), 2u);
 
     brks.forceTerminate ();
     cr->disconnect ();
@@ -59,12 +55,12 @@ BOOST_AUTO_TEST_CASE (startup_tests)
     {
         cr2disconnect = cr2->waitForDisconnect (std::chrono::milliseconds (1000));
     }
-    BOOST_CHECK (crdisconnect);
-    BOOST_CHECK (cr2disconnect);
+    EXPECT_TRUE (crdisconnect);
+    EXPECT_TRUE (cr2disconnect);
     cleanupHelicsLibrary ();
 }
 
-BOOST_AUTO_TEST_CASE (execution_tests)
+TEST (broker_server_tests, execution_tests)
 {
     apps::BrokerServer brks (std::vector<std::string>{"--zmq"});
     brks.startServers ();
@@ -80,7 +76,7 @@ BOOST_AUTO_TEST_CASE (execution_tests)
     auto &sub = fed2.registerSubscription ("key1");
     sub.setOption (helics_handle_option_connection_required);
     fed1.enterExecutingModeAsync ();
-    BOOST_CHECK_NO_THROW (fed2.enterExecutingMode ());
+    EXPECT_NO_THROW (fed2.enterExecutingMode ());
     fed1.enterExecutingModeComplete ();
 
     fed1.finalize ();
@@ -89,7 +85,7 @@ BOOST_AUTO_TEST_CASE (execution_tests)
     cleanupHelicsLibrary ();
 }
 
-BOOST_AUTO_TEST_CASE (execution_tests_duplicate)
+TEST (broker_server_tests, execution_tests_duplicate)
 {
     apps::BrokerServer brks (std::vector<std::string>{"--zmq"});
     brks.startServers ();
@@ -105,7 +101,7 @@ BOOST_AUTO_TEST_CASE (execution_tests_duplicate)
     auto &sub2 = fed2.registerSubscription ("key1");
     sub2.setOption (helics_handle_option_connection_required);
     fed1.enterExecutingModeAsync ();
-    BOOST_CHECK_NO_THROW (fed2.enterExecutingMode ());
+    EXPECT_NO_THROW (fed2.enterExecutingMode ());
     fed1.enterExecutingModeComplete ();
 
     fi.coreName = "c3b";
@@ -118,7 +114,7 @@ BOOST_AUTO_TEST_CASE (execution_tests_duplicate)
     auto &sub4 = fed4.registerSubscription ("key1");
     sub4.setOption (helics_handle_option_connection_required);
     fed3.enterExecutingModeAsync ();
-    BOOST_CHECK_NO_THROW (fed4.enterExecutingMode ());
+    EXPECT_NO_THROW (fed4.enterExecutingMode ());
     fed3.enterExecutingModeComplete ();
 
     pub1.publish (27.5);
@@ -132,8 +128,8 @@ BOOST_AUTO_TEST_CASE (execution_tests_duplicate)
     fed2.requestTime (1.0);
     fed1.requestTimeComplete ();
 
-    BOOST_CHECK_EQUAL (sub2.getValue<double> (), 27.5);
-    BOOST_CHECK_EQUAL (sub4.getValue<double> (), 30.6);
+    EXPECT_EQ (sub2.getValue<double> (), 27.5);
+    EXPECT_EQ (sub4.getValue<double> (), 30.6);
     fed1.finalize ();
     fed2.finalize ();
     fed3.finalize ();
@@ -141,5 +137,3 @@ BOOST_AUTO_TEST_CASE (execution_tests_duplicate)
     brks.forceTerminate ();
     cleanupHelicsLibrary ();
 }
-
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/CMakeLists.txt
+++ b/tests/helics/apps/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(helics_apps-tests ${helics_apps_test_sources})
 
 set_target_properties(helics_apps-tests PROPERTIES FOLDER tests)
 
-target_link_libraries(helics_apps-tests helics_apps helics_boost_test_base)
+target_link_libraries(helics_apps-tests helics_apps helics_google_test_base)
 
 target_include_directories(helics_apps-tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
 

--- a/tests/helics/apps/CloneTests.cpp
+++ b/tests/helics/apps/CloneTests.cpp
@@ -143,24 +143,19 @@ TEST (clone_tests, simple_clone_test_message)
     auto cnt = c1.messageCount ();
     EXPECT_EQ (cnt, 2u);
     c1.saveFile ("eptsave.json");
-}
+    // now test the files
+    auto fi2 = helics::loadFederateInfo ("eptsave.json");
+    fi2.coreName = "clone_core5";
+    fi2.coreInitString = "--autobroker";
+    fi2.coreType = helics::core_type::TEST;
+    helics::apps::Player p1 ("c1", fi2);
+    p1.loadFile ("eptsave.json");
 
-TEST (clone_tests,
-      simple_clone_test_message_file,
-      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_message"))
-{
-    auto fi = helics::loadFederateInfo ("eptsave.json");
-    fi.coreName = "clone_core5";
-    fi.coreInitString = "--autobroker";
-    fi.coreType = helics::core_type::TEST;
-    helics::apps::Player c1 ("c1", fi);
-    c1.loadFile ("eptsave.json");
+    p1.initialize ();
 
-    c1.initialize ();
-
-    EXPECT_EQ (c1.messageCount (), 2u);
-    EXPECT_EQ (c1.endpointCount (), 3u);
-    c1.finalize ();
+    EXPECT_EQ (p1.messageCount (), 2u);
+    EXPECT_EQ (p1.endpointCount (), 3u);
+    p1.finalize ();
     ghc::filesystem::remove ("eptsave.json");
 }
 
@@ -206,26 +201,21 @@ TEST (clone_tests, simple_clone_test_combo)
     EXPECT_EQ (cnt, 3u);
 
     c1.saveFile ("combsave.json");
-}
 
-TEST (clone_tests,
-      simple_clone_test_combo_file,
-      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_combo"))
-{
-    auto fi = helics::loadFederateInfo ("combsave.json");
-    fi.coreName = "clone_core7";
-    fi.coreInitString = "--autobroker";
-    fi.coreType = helics::core_type::TEST;
-    helics::apps::Player c1 ("c1", fi);
-    c1.loadFile ("combsave.json");
+    auto fi2 = helics::loadFederateInfo ("combsave.json");
+    fi2.coreName = "clone_core7";
+    fi2.coreInitString = "--autobroker";
+    fi2.coreType = helics::core_type::TEST;
+    helics::apps::Player p1 ("c1", fi2);
+    p1.loadFile ("combsave.json");
 
-    c1.initialize ();
+    p1.initialize ();
 
-    EXPECT_EQ (c1.messageCount (), 2u);
-    EXPECT_EQ (c1.endpointCount (), 3u);
-    EXPECT_EQ (c1.pointCount (), 3u);
-    EXPECT_EQ (c1.publicationCount (), 2u);
-    c1.finalize ();
+    EXPECT_EQ (p1.messageCount (), 2u);
+    EXPECT_EQ (p1.endpointCount (), 3u);
+    EXPECT_EQ (p1.pointCount (), 3u);
+    EXPECT_EQ (p1.publicationCount (), 2u);
+    p1.finalize ();
     ghc::filesystem::remove ("combsave.json");
 }
 

--- a/tests/helics/apps/CloneTests.cpp
+++ b/tests/helics/apps/CloneTests.cpp
@@ -88,25 +88,20 @@ TEST (clone_tests, simple_clone_test_pub2)
     EXPECT_EQ (icnt, 2);
     c1.saveFile ("pubtest2.json");
 
-    EXPECT_TRUE (ghc::filesystem::exists ("pubtest2.json"));
-}
+    ASSERT_TRUE (ghc::filesystem::exists ("pubtest2.json"));
 
-TEST (clone_tests,
-      simple_clone_test_pub2_file,
-      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_pub2"))
-{
-    auto fi = helics::loadFederateInfo ("pubtest2.json");
-    fi.coreName = "clone_core3";
-    fi.coreInitString = "--autobroker";
-    fi.coreType = helics::core_type::TEST;
-    helics::apps::Player c1 ("c1", fi);
-    c1.loadFile ("pubtest2.json");
+    auto fi2 = helics::loadFederateInfo ("pubtest2.json");
+    fi2.coreName = "clone_core3";
+    fi2.coreInitString = "--autobroker";
+    fi2.coreType = helics::core_type::TEST;
+    helics::apps::Player p1 ("p1", fi2);
+    p1.loadFile ("pubtest2.json");
 
-    c1.initialize ();
+    p1.initialize ();
 
-    EXPECT_EQ (c1.pointCount (), 3u);
-    EXPECT_EQ (c1.publicationCount (), 2u);
-    c1.finalize ();
+    EXPECT_EQ (p1.pointCount (), 3u);
+    EXPECT_EQ (p1.publicationCount (), 2u);
+    p1.finalize ();
     ghc::filesystem::remove ("pubtest2.json");
 }
 
@@ -148,7 +143,7 @@ TEST (clone_tests, simple_clone_test_message)
     fi2.coreName = "clone_core5";
     fi2.coreInitString = "--autobroker";
     fi2.coreType = helics::core_type::TEST;
-    helics::apps::Player p1 ("c1", fi2);
+    helics::apps::Player p1 ("p1", fi2);
     p1.loadFile ("eptsave.json");
 
     p1.initialize ();
@@ -206,7 +201,7 @@ TEST (clone_tests, simple_clone_test_combo)
     fi2.coreName = "clone_core7";
     fi2.coreInitString = "--autobroker";
     fi2.coreType = helics::core_type::TEST;
-    helics::apps::Player p1 ("c1", fi2);
+    helics::apps::Player p1 ("p1", fi2);
     p1.loadFile ("combsave.json");
 
     p1.initialize ();
@@ -268,24 +263,22 @@ TEST (clone_tests, simple_clone_test_sub)
     EXPECT_EQ (icnt, 2);
     c1.saveFile ("subtest.json");
 
-    EXPECT_TRUE (ghc::filesystem::exists ("subtest.json"));
-}
+    ASSERT_TRUE (ghc::filesystem::exists ("subtest.json"));
 
-TEST (clone_tests, simple_clone_test_sub_file, *boost::unit_test::depends_on ("clone_tests/simple_clone_test_sub"))
-{
-    auto fi = helics::loadFederateInfo ("subtest.json");
-    fi.coreName = "clone_core9";
-    fi.coreInitString = "--autobroker";
-    fi.coreType = helics::core_type::TEST;
-    helics::apps::Player c1 ("c1", fi);
-    c1.loadFile ("subtest.json");
+    // now test the file loading
+    auto fi2 = helics::loadFederateInfo ("subtest.json");
+    fi2.coreName = "clone_core9";
+    fi2.coreInitString = "--autobroker";
+    fi2.coreType = helics::core_type::TEST;
+    helics::apps::Player p1 ("p1", fi2);
+    p1.loadFile ("subtest.json");
 
-    c1.initialize ();
+    p1.initialize ();
 
-    EXPECT_EQ (c1.pointCount (), 3u);
-    EXPECT_EQ (c1.publicationCount (), 2u);
-    EXPECT_EQ (c1.accessUnderlyingFederate ().getInputCount (), 2);
-    c1.finalize ();
+    EXPECT_EQ (p1.pointCount (), 3u);
+    EXPECT_EQ (p1.publicationCount (), 2u);
+    EXPECT_EQ (p1.accessUnderlyingFederate ().getInputCount (), 2);
+    p1.finalize ();
     ghc::filesystem::remove ("subtest.json");
 }
 

--- a/tests/helics/apps/CloneTests.cpp
+++ b/tests/helics/apps/CloneTests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #ifdef _MSC_VER
 #pragma warning(push, 0)
@@ -23,11 +22,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <cstdio>
 #include <future>
 
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (clone_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_CASE (simple_clone_test_pub)
+TEST (clone_tests, simple_clone_test_pub)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "clone_core1";
@@ -37,27 +32,27 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_pub)
 
     helics::ValueFederate vfed ("block1", fi);
     helics::Publication pub1 (helics::GLOBAL, &vfed, "pub1", helics::data_type::helics_double);
-    auto fut = std::async (std::launch::async, [&c1] () { c1.runTo (4); });
+    auto fut = std::async (std::launch::async, [&c1]() { c1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
     c1.finalize ();
     auto cnt = c1.pointCount ();
-    BOOST_CHECK_EQUAL (cnt, 2u);
+    EXPECT_EQ (cnt, 2u);
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_pub2)
+TEST (clone_tests, simple_clone_test_pub2)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "clone_core2";
@@ -71,33 +66,34 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_pub2)
 
     auto &pub2 = vfed.registerPublication ("pub2", "double", "m");
 
-    auto fut = std::async (std::launch::async, [&c1] () { c1.runTo (4); });
+    auto fut = std::async (std::launch::async, [&c1]() { c1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
     pub2.publish (3.3);
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
     c1.finalize ();
     auto cnt = c1.pointCount ();
-    BOOST_CHECK_EQUAL (cnt, 3u);
+    EXPECT_EQ (cnt, 3u);
     auto icnt = c1.accessUnderlyingFederate ().getInputCount ();
-    BOOST_CHECK_EQUAL (icnt, 2);
+    EXPECT_EQ (icnt, 2);
     c1.saveFile ("pubtest2.json");
 
-    BOOST_CHECK (ghc::filesystem::exists ("pubtest2.json"));
+    EXPECT_TRUE (ghc::filesystem::exists ("pubtest2.json"));
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_pub2_file,
-                      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_pub2"))
+TEST (clone_tests,
+      simple_clone_test_pub2_file,
+      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_pub2"))
 {
     auto fi = helics::loadFederateInfo ("pubtest2.json");
     fi.coreName = "clone_core3";
@@ -108,13 +104,13 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_pub2_file,
 
     c1.initialize ();
 
-    BOOST_CHECK_EQUAL (c1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (c1.publicationCount (), 2u);
+    EXPECT_EQ (c1.pointCount (), 3u);
+    EXPECT_EQ (c1.publicationCount (), 2u);
     c1.finalize ();
     ghc::filesystem::remove ("pubtest2.json");
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_message)
+TEST (clone_tests, simple_clone_test_message)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "clone_core4";
@@ -128,29 +124,30 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_message)
     auto &ept2 = mfed.registerGlobalEndpoint ("ept3");
     mfed.registerEndpoint ("e3");
 
-    auto fut = std::async (std::launch::async, [&c1] () { c1.runTo (4); });
+    auto fut = std::async (std::launch::async, [&c1]() { c1.runTo (4); });
     mfed.enterExecutingMode ();
     auto retTime = mfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     ept.send ("ept3", "message");
 
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     ept2.send ("ept1", "reply");
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
 
     mfed.finalize ();
     fut.get ();
     c1.finalize ();
     auto cnt = c1.messageCount ();
-    BOOST_CHECK_EQUAL (cnt, 2u);
+    EXPECT_EQ (cnt, 2u);
     c1.saveFile ("eptsave.json");
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_message_file,
-                      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_message"))
+TEST (clone_tests,
+      simple_clone_test_message_file,
+      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_message"))
 {
     auto fi = helics::loadFederateInfo ("eptsave.json");
     fi.coreName = "clone_core5";
@@ -161,13 +158,13 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_message_file,
 
     c1.initialize ();
 
-    BOOST_CHECK_EQUAL (c1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (c1.endpointCount (), 3u);
+    EXPECT_EQ (c1.messageCount (), 2u);
+    EXPECT_EQ (c1.endpointCount (), 3u);
     c1.finalize ();
     ghc::filesystem::remove ("eptsave.json");
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_combo)
+TEST (clone_tests, simple_clone_test_combo)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "clone_core6";
@@ -185,34 +182,35 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_combo)
 
     auto &pub2 = mfed.registerPublication ("pub2", "double", "m");
 
-    auto fut = std::async (std::launch::async, [&c1] () { c1.runTo (4); });
+    auto fut = std::async (std::launch::async, [&c1]() { c1.runTo (4); });
     mfed.enterExecutingMode ();
     auto retTime = mfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     ept.send ("ept3", "message");
     pub1.publish (3.4);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     ept2.send ("ept1", "reply");
     pub1.publish (4.7);
     pub2.publish (3.3);
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
 
     mfed.finalize ();
     fut.get ();
     c1.finalize ();
     auto cnt = c1.messageCount ();
-    BOOST_CHECK_EQUAL (cnt, 2u);
+    EXPECT_EQ (cnt, 2u);
 
     cnt = c1.pointCount ();
-    BOOST_CHECK_EQUAL (cnt, 3u);
+    EXPECT_EQ (cnt, 3u);
 
     c1.saveFile ("combsave.json");
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_combo_file,
-                      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_combo"))
+TEST (clone_tests,
+      simple_clone_test_combo_file,
+      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_combo"))
 {
     auto fi = helics::loadFederateInfo ("combsave.json");
     fi.coreName = "clone_core7";
@@ -223,15 +221,15 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_combo_file,
 
     c1.initialize ();
 
-    BOOST_CHECK_EQUAL (c1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (c1.endpointCount (), 3u);
-    BOOST_CHECK_EQUAL (c1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (c1.publicationCount (), 2u);
+    EXPECT_EQ (c1.messageCount (), 2u);
+    EXPECT_EQ (c1.endpointCount (), 3u);
+    EXPECT_EQ (c1.pointCount (), 3u);
+    EXPECT_EQ (c1.publicationCount (), 2u);
     c1.finalize ();
     ghc::filesystem::remove ("combsave.json");
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_sub)
+TEST (clone_tests, simple_clone_test_sub)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "clone_core8";
@@ -254,37 +252,36 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_sub)
 
     vfed.registerSubscription ("block2/pub");
 
-    auto fut = std::async (std::launch::async, [&c1] () { c1.runTo (4); });
+    auto fut = std::async (std::launch::async, [&c1]() { c1.runTo (4); });
     vfed2.enterExecutingModeAsync ();
     vfed.enterExecutingMode ();
     vfed2.enterExecutingModeComplete ();
     vfed2.requestTimeAsync (5);
     auto retTime = vfed.requestTime (1);
     vfed2.requestTimeComplete ();
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
     pub2.publish (3.3);
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed2.finalize ();
     vfed.finalize ();
     fut.get ();
     c1.finalize ();
     auto cnt = c1.pointCount ();
-    BOOST_CHECK_EQUAL (cnt, 3u);
+    EXPECT_EQ (cnt, 3u);
     auto icnt = c1.accessUnderlyingFederate ().getInputCount ();
-    BOOST_CHECK_EQUAL (icnt, 2);
+    EXPECT_EQ (icnt, 2);
     c1.saveFile ("subtest.json");
 
-    BOOST_CHECK (ghc::filesystem::exists ("subtest.json"));
+    EXPECT_TRUE (ghc::filesystem::exists ("subtest.json"));
 }
 
-BOOST_AUTO_TEST_CASE (simple_clone_test_sub_file,
-                      *boost::unit_test::depends_on ("clone_tests/simple_clone_test_sub"))
+TEST (clone_tests, simple_clone_test_sub_file, *boost::unit_test::depends_on ("clone_tests/simple_clone_test_sub"))
 {
     auto fi = helics::loadFederateInfo ("subtest.json");
     fi.coreName = "clone_core9";
@@ -295,24 +292,22 @@ BOOST_AUTO_TEST_CASE (simple_clone_test_sub_file,
 
     c1.initialize ();
 
-    BOOST_CHECK_EQUAL (c1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (c1.publicationCount (), 2u);
-    BOOST_CHECK_EQUAL (c1.accessUnderlyingFederate ().getInputCount (), 2);
+    EXPECT_EQ (c1.pointCount (), 3u);
+    EXPECT_EQ (c1.publicationCount (), 2u);
+    EXPECT_EQ (c1.accessUnderlyingFederate ().getInputCount (), 2);
     c1.finalize ();
     ghc::filesystem::remove ("subtest.json");
 }
 
-BOOST_AUTO_TEST_CASE (clone_test_help)
+TEST (clone_tests, clone_test_help)
 {
     std::vector<std::string> args{"--quiet", "--version"};
     helics::apps::Clone c1 (args);
 
-    BOOST_CHECK (!c1.isActive ());
+    EXPECT_TRUE (!c1.isActive ());
 
     args.emplace_back ("-?");
     helics::apps::Clone c2 (args);
 
-    BOOST_CHECK (!c2.isActive ());
+    EXPECT_TRUE (!c2.isActive ());
 }
-
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/EchoTests.cpp
+++ b/tests/helics/apps/EchoTests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #include <cstdio>
 
@@ -15,12 +14,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/BrokerFactory.hpp"
 #include <future>
 
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (echo_tests, *utf::label ("ci"))
-
 // this test will test basic echo functionality
-BOOST_AUTO_TEST_CASE (echo_test1)
+TEST (echo_tests, echo_test1)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -36,17 +31,17 @@ BOOST_AUTO_TEST_CASE (echo_test1)
     mfed.enterExecutingMode ();
     ep1.send ("test", "hello world");
     auto retTime = mfed.requestTime (1.0);
-    BOOST_CHECK (ep1.hasMessage ());
-    BOOST_CHECK_LT (retTime, 1.0);
+    EXPECT_TRUE (ep1.hasMessage ());
+    EXPECT_LT (retTime, 1.0);
     auto m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello world");
-    BOOST_CHECK_EQUAL (m->source, "test");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello world");
+    EXPECT_EQ (m->source, "test");
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (echo_test_delay)
+TEST (echo_tests, echo_test_delay)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -62,19 +57,19 @@ BOOST_AUTO_TEST_CASE (echo_test_delay)
     mfed.enterExecutingMode ();
     ep1.send ("test", "hello world");
     mfed.requestTime (1.0);
-    BOOST_CHECK (!ep1.hasMessage ());
+    EXPECT_TRUE (!ep1.hasMessage ());
     auto ntime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (ntime, helics::timeEpsilon + 1.2);
-    BOOST_CHECK (ep1.hasMessage ());
+    EXPECT_EQ (ntime, helics::timeEpsilon + 1.2);
+    EXPECT_TRUE (ep1.hasMessage ());
     auto m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello world");
-    BOOST_CHECK_EQUAL (m->source, "test");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello world");
+    EXPECT_EQ (m->source, "test");
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (echo_test_delay_period)
+TEST (echo_tests, echo_test_delay_period)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -92,19 +87,19 @@ BOOST_AUTO_TEST_CASE (echo_test_delay_period)
     mfed.enterExecutingMode ();
     ep1.send ("test", "hello world");
     mfed.requestTime (1.0);
-    BOOST_CHECK (!ep1.hasMessage ());
+    EXPECT_TRUE (!ep1.hasMessage ());
     auto ntime = mfed.requestTime (4.0);
-    BOOST_CHECK_EQUAL (ntime, 2.3);
-    BOOST_CHECK (ep1.hasMessage ());
+    EXPECT_EQ (ntime, 2.3);
+    EXPECT_TRUE (ep1.hasMessage ());
     auto m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello world");
-    BOOST_CHECK_EQUAL (m->source, "test");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello world");
+    EXPECT_EQ (m->source, "test");
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (echo_test_multiendpoint)
+TEST (echo_tests, echo_test_multiendpoint)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -121,27 +116,27 @@ BOOST_AUTO_TEST_CASE (echo_test_multiendpoint)
     ep1.send ("test", "hello world");
     mfed.requestTime (1.0);
     ep1.send ("test2", "hello again");
-    BOOST_CHECK (!ep1.hasMessage ());
+    EXPECT_TRUE (!ep1.hasMessage ());
     auto ntime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (ntime, helics::timeEpsilon + 1.2);
-    BOOST_CHECK (ep1.hasMessage ());
+    EXPECT_EQ (ntime, helics::timeEpsilon + 1.2);
+    EXPECT_TRUE (ep1.hasMessage ());
     auto m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello world");
-    BOOST_CHECK_EQUAL (m->source, "test");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello world");
+    EXPECT_EQ (m->source, "test");
 
     ntime = mfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (ntime, 2.2);
-    BOOST_CHECK (ep1.hasMessage ());
+    EXPECT_EQ (ntime, 2.2);
+    EXPECT_TRUE (ep1.hasMessage ());
     m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello again");
-    BOOST_CHECK_EQUAL (m->source, "test2");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello again");
+    EXPECT_EQ (m->source, "test2");
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (echo_test_fileload)
+TEST (echo_tests, echo_test_fileload)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "ecore4-file";
@@ -156,24 +151,22 @@ BOOST_AUTO_TEST_CASE (echo_test_fileload)
     ep1.send ("test", "hello world");
     mfed.requestTime (1.0);
     ep1.send ("test2", "hello again");
-    BOOST_CHECK (!ep1.hasMessage ());
+    EXPECT_TRUE (!ep1.hasMessage ());
     auto ntime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (ntime, helics::timeEpsilon + 1.2);
-    BOOST_CHECK (ep1.hasMessage ());
+    EXPECT_EQ (ntime, helics::timeEpsilon + 1.2);
+    EXPECT_TRUE (ep1.hasMessage ());
     auto m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello world");
-    BOOST_CHECK_EQUAL (m->source, "test");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello world");
+    EXPECT_EQ (m->source, "test");
 
     ntime = mfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (ntime, 2.2);
-    BOOST_CHECK (ep1.hasMessage ());
+    EXPECT_EQ (ntime, 2.2);
+    EXPECT_TRUE (ep1.hasMessage ());
     m = ep1.getMessage ();
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "hello again");
-    BOOST_CHECK_EQUAL (m->source, "test2");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "hello again");
+    EXPECT_EQ (m->source, "test2");
     mfed.finalize ();
     fut.get ();
 }
-
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/PlayerTests.cpp
+++ b/tests/helics/apps/PlayerTests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #include <cstdio>
 
@@ -15,11 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/BrokerFactory.hpp"
 #include <future>
 
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (player_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_CASE (simple_player_test)
+TEST (player_tests, simple_player_test)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -37,27 +32,27 @@ BOOST_AUTO_TEST_CASE (simple_player_test)
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_player_test_diff_inputs)
+TEST (player_tests, simple_player_test_diff_inputs)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore2";
@@ -74,32 +69,32 @@ BOOST_AUTO_TEST_CASE (simple_player_test_diff_inputs)
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 5.0);
+    EXPECT_EQ (val, 5.0);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 4.0);
+    EXPECT_EQ (retTime, 4.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 5.0);
+    EXPECT_EQ (val, 5.0);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_player_test_iterative)
+TEST (player_tests, simple_player_test_iterative)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore3";
@@ -116,31 +111,31 @@ BOOST_AUTO_TEST_CASE (simple_player_test_iterative)
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTimeIterative (5, helics::iteration_request::iterate_if_needed);
-    BOOST_CHECK_EQUAL (retTime.grantedTime, 1.0);
-    BOOST_CHECK (retTime.state == helics::iteration_result::next_step);
+    EXPECT_EQ (retTime.grantedTime, 1.0);
+    EXPECT_TRUE (retTime.state == helics::iteration_result::next_step);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
 
     retTime = vfed.requestTimeIterative (5, helics::iteration_request::iterate_if_needed);
-    BOOST_CHECK_EQUAL (retTime.grantedTime, 1.0);
-    BOOST_CHECK (retTime.state == helics::iteration_result::iterating);
+    EXPECT_EQ (retTime.grantedTime, 1.0);
+    EXPECT_TRUE (retTime.state == helics::iteration_result::iterating);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
 
     retTime = vfed.requestTimeIterative (5, helics::iteration_request::iterate_if_needed);
-    BOOST_CHECK_EQUAL (retTime.grantedTime, 1.0);
-    BOOST_CHECK (retTime.state == helics::iteration_result::iterating);
+    EXPECT_EQ (retTime.grantedTime, 1.0);
+    EXPECT_TRUE (retTime.state == helics::iteration_result::iterating);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
 
     retTime = vfed.requestTimeIterative (5, helics::iteration_request::iterate_if_needed);
-    BOOST_CHECK_EQUAL (retTime.grantedTime, 5.0);
-    BOOST_CHECK (retTime.state == helics::iteration_result::next_step);
+    EXPECT_EQ (retTime.grantedTime, 5.0);
+    EXPECT_TRUE (retTime.state == helics::iteration_result::next_step);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_player_test2)
+TEST (player_tests, simple_player_test2)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore4";
@@ -164,28 +159,28 @@ BOOST_AUTO_TEST_CASE (simple_player_test2)
     vfed.enterExecutingMode ();
 
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 0.4, 0.000001);
+    EXPECT_DOUBLE_EQ (val, 0.4);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.6);
+    EXPECT_EQ (val, 0.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.9);
+    EXPECT_EQ (val, 0.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
 }
@@ -193,16 +188,20 @@ BOOST_AUTO_TEST_CASE (simple_player_test2)
 static constexpr const char *simple_files[] = {"example1.player", "example2.player", "example3.player",
                                                "example4.player", "example5.json",   "example5.player"};
 
-BOOST_DATA_TEST_CASE (simple_player_test_files, boost::unit_test::data::make (simple_files), file)
+class player_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P (player_file_tests, test_files)
 {
     static char indx = 'a';
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("pcore5") + file;
+    fi.coreName = std::string ("pcore5") + GetParam ();
     fi.coreName.push_back (indx++);
     fi.coreInitString = "-f 2 --autobroker";
     helics::apps::Player play1 ("player1", fi);
 
-    play1.loadFile (std::string (TEST_DIR) + file);
+    play1.loadFile (std::string (TEST_DIR) + GetParam ());
 
     helics::ValueFederate vfed ("block1", fi);
     auto &sub1 = vfed.registerSubscription ("pub1");
@@ -210,36 +209,36 @@ BOOST_DATA_TEST_CASE (simple_player_test_files, boost::unit_test::data::make (si
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     vfed.enterExecutingMode ();
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.3);
+    EXPECT_EQ (val, 0.3);
 
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 0.4, 0.000001);
+    EXPECT_DOUBLE_EQ (val, 0.4);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.6);
+    EXPECT_EQ (val, 0.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.9);
+    EXPECT_EQ (val, 0.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_player_mlinecomment)
+TEST (player_tests, simple_player_mlinecomment)
 {
     static char indx = 'a';
     helics::FederateInfo fi (helics::core_type::TEST);
@@ -249,50 +248,50 @@ BOOST_AUTO_TEST_CASE (simple_player_mlinecomment)
     helics::apps::Player play1 ("player1", fi);
     play1.loadFile (std::string (TEST_DIR) + "/example_comments.player");
 
-    BOOST_CHECK_EQUAL (play1.pointCount (), 7u);
+    EXPECT_EQ (play1.pointCount (), 7u);
     helics::ValueFederate vfed ("block1", fi);
     auto &sub1 = vfed.registerSubscription ("pub1");
     auto &sub2 = vfed.registerSubscription ("pub2");
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     vfed.enterExecutingMode ();
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.3);
+    EXPECT_EQ (val, 0.3);
 
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 0.4, 0.000001);
+    EXPECT_DOUBLE_EQ (val, 0.4);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.6);
+    EXPECT_EQ (val, 0.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.9);
+    EXPECT_EQ (val, 0.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (play1.publicationCount (), 2u);
+    EXPECT_EQ (play1.publicationCount (), 2u);
 }
 
 #ifdef ENABLE_IPC_CORE
-BOOST_DATA_TEST_CASE (simple_player_test_files_cmdline, boost::unit_test::data::make (simple_files), file)
+TEST_P (player_file_tests, test_files_cmd)
 {
     std::this_thread::sleep_for (std::chrono::milliseconds (300));
     auto brk = helics::BrokerFactory::create (helics::core_type::IPC, "ipc_broker", "-f 2");
     brk->connect ();
-    std::string exampleFile = std::string (TEST_DIR) + file;
+    std::string exampleFile = std::string (TEST_DIR) + GetParam ();
 
     std::vector<std::string> args{"", "--name=player", "--broker=ipc_broker", "--coretype=ipc", exampleFile};
     char *argv[5];
@@ -313,31 +312,31 @@ BOOST_DATA_TEST_CASE (simple_player_test_files_cmdline, boost::unit_test::data::
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     vfed.enterExecutingMode ();
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.3);
+    EXPECT_EQ (val, 0.3);
 
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 0.4, 0.000001);
+    EXPECT_DOUBLE_EQ (val, 0.4);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.6);
+    EXPECT_EQ (val, 0.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.9);
+    EXPECT_EQ (val, 0.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
     brk = nullptr;
@@ -347,7 +346,7 @@ BOOST_DATA_TEST_CASE (simple_player_test_files_cmdline, boost::unit_test::data::
 
 #ifdef ENABLE_ZMQ_CORE
 #ifndef DISABLE_SYSTEM_CALL_TESTS
-BOOST_DATA_TEST_CASE (simple_player_test_files_ext, boost::unit_test::data::make (simple_files), file)
+TEST_P (player_file_tests, test_files_ext)
 {
     std::this_thread::sleep_for (std::chrono::milliseconds (300));
     exeTestRunner playerExe (std::string (HELICS_INSTALL_LOC), std::string (HELICS_BUILD_LOC) + "/apps/",
@@ -356,10 +355,10 @@ BOOST_DATA_TEST_CASE (simple_player_test_files_ext, boost::unit_test::data::make
     exeTestRunner brokerExe (std::string (HELICS_INSTALL_LOC), std::string (HELICS_BUILD_LOC) + "/apps/",
                              "helics_broker");
 
-    BOOST_REQUIRE (playerExe.isActive ());
-    BOOST_REQUIRE (brokerExe.isActive ());
+    ASSERT_TRUE (playerExe.isActive ());
+    ASSERT_TRUE (brokerExe.isActive ());
     auto res = brokerExe.runAsync ("-f 2 --coretype=zmq --name=zmq_broker");
-    std::string exampleFile = std::string (TEST_DIR) + file;
+    std::string exampleFile = std::string (TEST_DIR) + GetParam ();
     auto res2 = playerExe.runCaptureOutputAsync ("--name=player --coretype=zmq " + exampleFile);
 
     helics::FederateInfo fi (helics::core_type::ZMQ);
@@ -370,31 +369,31 @@ BOOST_DATA_TEST_CASE (simple_player_test_files_ext, boost::unit_test::data::make
     auto &sub2 = vfed.registerSubscription ("pub2");
     vfed.enterExecutingMode ();
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.3);
+    EXPECT_EQ (val, 0.3);
 
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 0.4, 0.000001);
+    EXPECT_DOUBLE_EQ (val, 0.4);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.6);
+    EXPECT_EQ (val, 0.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.9);
+    EXPECT_EQ (val, 0.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     auto out2 = res2.get ();
     res.get ();
@@ -404,7 +403,9 @@ BOOST_DATA_TEST_CASE (simple_player_test_files_ext, boost::unit_test::data::make
 #endif
 #endif
 
-BOOST_AUTO_TEST_CASE (simple_player_testjson)
+INSTANTIATE_TEST_SUITE_P (player_tests, player_file_tests, ::testing::ValuesIn (simple_files));
+
+TEST (player_tests, simple_player_testjson)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore7";
@@ -419,33 +420,33 @@ BOOST_AUTO_TEST_CASE (simple_player_testjson)
     vfed.enterExecutingMode ();
 
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.5);
+    EXPECT_EQ (val, 0.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 0.4, 0.000001);
+    EXPECT_DOUBLE_EQ (val, 0.4);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.7);
+    EXPECT_EQ (val, 0.7);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.6);
+    EXPECT_EQ (val, 0.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.8);
+    EXPECT_EQ (val, 0.8);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 0.9);
+    EXPECT_EQ (val, 0.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (player_test_message)
+TEST (player_tests, player_test_message)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore8";
@@ -460,21 +461,21 @@ BOOST_AUTO_TEST_CASE (player_test_message)
     mfed.enterExecutingMode ();
 
     auto retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is a message");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is a message");
     }
 
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (player_test_message2)
+TEST (player_tests, player_test_message2)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore9";
@@ -492,42 +493,42 @@ BOOST_AUTO_TEST_CASE (player_test_message2)
     mfed.enterExecutingMode ();
 
     auto retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is a test message");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is a test message");
     }
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is test message2");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is test message2");
     }
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is message 3");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is message 3");
     }
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (player_test_message3)
+TEST (player_tests, player_test_message3)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "pcore10";
@@ -546,36 +547,36 @@ BOOST_AUTO_TEST_CASE (player_test_message3)
     mfed.enterExecutingMode ();
 
     auto retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is a test message");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is a test message");
     }
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is test message2");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is test message2");
     }
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is message 3");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is message 3");
     }
     mfed.finalize ();
     fut.get ();
@@ -584,72 +585,76 @@ BOOST_AUTO_TEST_CASE (player_test_message3)
 static constexpr const char *simple_message_files[] = {"example_message1.player", "example_message2.player",
                                                        "example_message3.json"};
 
-BOOST_DATA_TEST_CASE (simple_message_player_test_files, boost::unit_test::data::make (simple_message_files), file)
+class player_message_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P (player_message_file_tests, message_test_files)
 {
     static char indx = 'a';
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("pcore11") + file;
+    fi.coreName = std::string ("pcore11") + GetParam ();
     fi.coreName.push_back (indx++);
     fi.coreInitString = "-f 2 --autobroker";
     helics::apps::Player play1 ("player1", fi);
 
     helics::MessageFederate mfed ("block1", fi);
     helics::Endpoint e1 (helics::GLOBAL, &mfed, "dest");
-    play1.loadFile (std::string (TEST_DIR) + file);
+    play1.loadFile (std::string (TEST_DIR) + GetParam ());
     auto fut = std::async (std::launch::async, [&play1]() { play1.run (); });
     mfed.enterExecutingMode ();
 
     auto retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is a test message");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is a test message");
     }
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is test message2");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is test message2");
     }
 
     retTime = mfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     mess = e1.getMessage ();
-    BOOST_CHECK (mess);
+    EXPECT_TRUE (mess);
     if (mess)
     {
-        BOOST_CHECK_EQUAL (mess->source, "src");
-        BOOST_CHECK_EQUAL (mess->dest, "dest");
-        BOOST_CHECK_EQUAL (mess->data.to_string (), "this is message 3");
+        EXPECT_EQ (mess->source, "src");
+        EXPECT_EQ (mess->dest, "dest");
+        EXPECT_EQ (mess->data.to_string (), "this is message 3");
     }
     mfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (player_test_help)
+TEST (player_tests, player_test_help)
 {
     std::vector<std::string> args{"--quiet", "--version"};
     helics::apps::Player play1 (args);
 
-    BOOST_CHECK (!play1.isActive ());
+    EXPECT_TRUE (!play1.isActive ());
 
     args.emplace_back ("-?");
     helics::apps::Player play2 (args);
 
-    BOOST_CHECK (!play2.isActive ());
+    EXPECT_TRUE (!play2.isActive ());
 }
 #ifndef DISABLE_SYSTEM_CALL_TESTS
 /*
-BOOST_AUTO_TEST_CASE (simple_player_test)
+TEST( player_tests,simple_player_test)
 {
     static exeTestRunner playerExe (HELICS_BIN_LOC "apps/", "helics_player");
 
@@ -662,11 +667,9 @@ exampleFile);
 
     auto val = res2.get ();
     auto val2 = res.get ();
-    BOOST_CHECK_EQUAL (val2, 0);
+    EXPECT_EQ (val2, 0);
     std::string compareString = "read file 24 points for 1 tags";
-    BOOST_CHECK (val.compare (0, compareString.size (), compareString) == 0);
+    EXPECT_TRUE (val.compare (0, compareString.size (), compareString) == 0);
 }
 */
 #endif
-
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/PlayerTests.cpp
+++ b/tests/helics/apps/PlayerTests.cpp
@@ -640,6 +640,8 @@ TEST_P (player_message_file_tests, message_test_files)
     fut.get ();
 }
 
+INSTANTIATE_TEST_SUITE_P (player_tests, player_message_file_tests, ::testing::ValuesIn (simple_message_files));
+
 TEST (player_tests, player_test_help)
 {
     std::vector<std::string> args{"--quiet", "--version"};

--- a/tests/helics/apps/RecorderTests.cpp
+++ b/tests/helics/apps/RecorderTests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #ifdef _MSC_VER
 #pragma warning(push, 0)
@@ -22,11 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <cstdio>
 #include <future>
 
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (recorder_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_CASE (simple_recorder_test)
+TEST (recorder_tests, simple_recorder_test)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "rcore1";
@@ -39,24 +34,24 @@ BOOST_AUTO_TEST_CASE (simple_recorder_test)
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
     rec1.finalize ();
     auto cnt = rec1.pointCount ();
-    BOOST_CHECK_EQUAL (cnt, 2u);
+    EXPECT_EQ (cnt, 2u);
 }
 
-BOOST_AUTO_TEST_CASE (simple_recorder_test2)
+TEST (recorder_tests, simple_recorder_test2)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "rcore1-t2";
@@ -69,36 +64,36 @@ BOOST_AUTO_TEST_CASE (simple_recorder_test2)
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
     rec1.finalize ();
     auto v1 = rec1.getValue (0);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.4));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (3.4));
 
     v1 = rec1.getValue (1);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (4.7));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (4.7));
 
     v1 = rec1.getValue (2);
-    BOOST_CHECK_EQUAL (v1.first, std::string ());
-    BOOST_CHECK_EQUAL (v1.second, std::string ());
+    EXPECT_EQ (v1.first, std::string ());
+    EXPECT_EQ (v1.second, std::string ());
 
     auto m2 = rec1.getMessage (4);
-    BOOST_CHECK (!m2);
+    EXPECT_TRUE (!m2);
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_message)
+TEST (recorder_tests, recorder_test_message)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "rcore-tm";
@@ -115,30 +110,31 @@ BOOST_AUTO_TEST_CASE (recorder_test_message)
 
     auto retTime = mfed.requestTime (1.0);
     e1.send ("src1", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     retTime = mfed.requestTime (2.0);
     e1.send ("src1", "this is a test message2");
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
 
     mfed.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
 
     auto m = rec1.getMessage (0);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message");
+    EXPECT_EQ (m->data.to_string (), "this is a test message");
 }
 
-static constexpr const char *simple_files[] = {"example1.recorder", "example2.record",    "example3rec.json",
-                                               "example4rec.json",  "exampleCapture.txt", "exampleCapture.json"};
+class recorder_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
 
-BOOST_DATA_TEST_CASE (simple_recorder_test_files, boost::unit_test::data::make (simple_files), file)
+TEST_P (recorder_file_tests, test_files)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("coref") + file;
+    fi.coreName = std::string ("coref") + GetParam ();
     fi.coreInitString = "-f 2 --autobroker";
     helics::apps::Recorder rec1 ("rec1", fi);
 
-    rec1.loadFile (std::string (TEST_DIR) + file);
+    rec1.loadFile (std::string (TEST_DIR) + GetParam ());
 
     helics::ValueFederate vfed ("block1", fi);
     helics::Publication pub1 (helics::GLOBAL, &vfed, "pub1", helics::data_type::helics_double);
@@ -147,56 +143,63 @@ BOOST_DATA_TEST_CASE (simple_recorder_test_files, boost::unit_test::data::make (
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
     rec1.finalize ();
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 4u);
+    EXPECT_EQ (rec1.pointCount (), 4u);
     auto v1 = rec1.getValue (0);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.4));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (3.4));
     v1 = rec1.getValue (1);
-    BOOST_CHECK_EQUAL (v1.first, "pub2");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (5.7));
+    EXPECT_EQ (v1.first, "pub2");
+    EXPECT_EQ (v1.second, std::to_string (5.7));
 
     v1 = rec1.getValue (2);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (4.7));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (4.7));
 
     v1 = rec1.getValue (3);
-    BOOST_CHECK_EQUAL (v1.first, "pub2");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.9));
+    EXPECT_EQ (v1.first, "pub2");
+    EXPECT_EQ (v1.second, std::to_string (3.9));
 }
+
+static constexpr const char *simple_files[] = {"example1.recorder", "example2.record",    "example3rec.json",
+                                               "example4rec.json",  "exampleCapture.txt", "exampleCapture.json"};
+
+INSTANTIATE_TEST_SUITE_P (recorder_tests, recorder_file_tests, ::testing::ValuesIn (simple_files));
 
 static constexpr const char *simple_message_files[] = {"example4.recorder", "example5.record", "example6rec.json"};
 
-BOOST_DATA_TEST_CASE (simple_recorder_test_message_files,
-                      boost::unit_test::data::make (simple_message_files),
-                      file)
+class recorder_message_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P (recorder_message_file_tests, test_message_files)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("rcoretmf") + file;
+    fi.coreName = std::string ("rcoretmf") + GetParam ();
     fi.coreInitString = "-f 2 --autobroker";
     helics::apps::Recorder rec1 ("rec1", fi);
 
-    rec1.loadFile (std::string (TEST_DIR) + file);
+    rec1.loadFile (std::string (TEST_DIR) + GetParam ());
 
     helics::CombinationFederate cfed ("block1", fi);
     helics::Publication pub1 (helics::GLOBAL, &cfed, "pub1", helics::data_type::helics_double);
@@ -206,61 +209,59 @@ BOOST_DATA_TEST_CASE (simple_recorder_test_message_files,
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (5); });
     cfed.enterExecutingMode ();
     auto retTime = cfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
     e1.send ("src1", "this is a test message");
 
     retTime = cfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = cfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     e1.send ("src1", "this is a test message2");
     pub1.publish (4.7);
 
     retTime = cfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = cfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     cfed.finalize ();
     fut.get ();
     rec1.finalize ();
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 4u);
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.pointCount (), 4u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
 
     auto v1 = rec1.getValue (0);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.4));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (3.4));
     v1 = rec1.getValue (1);
-    BOOST_CHECK_EQUAL (v1.first, "pub2");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (5.7));
+    EXPECT_EQ (v1.first, "pub2");
+    EXPECT_EQ (v1.second, std::to_string (5.7));
 
     v1 = rec1.getValue (2);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (4.7));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (4.7));
 
     v1 = rec1.getValue (3);
-    BOOST_CHECK_EQUAL (v1.first, "pub2");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.9));
+    EXPECT_EQ (v1.first, "pub2");
+    EXPECT_EQ (v1.second, std::to_string (3.9));
 
     auto m = rec1.getMessage (1);
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message2");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "this is a test message2");
 }
 
 #ifdef ENABLE_IPC_CORE
-BOOST_DATA_TEST_CASE (simple_recorder_test_message_files_cmd,
-                      boost::unit_test::data::make (simple_message_files),
-                      file)
+TEST_P (recorder_message_file_tests, test_message_files_cmd)
 {
     std::this_thread::sleep_for (std::chrono::milliseconds (600));
     auto brk = helics::BrokerFactory::create (helics::core_type::IPC, "ipc_broker", "-f 2");
     brk->connect ();
-    std::string exampleFile = std::string (TEST_DIR) + file;
+    std::string exampleFile = std::string (TEST_DIR) + GetParam ();
 
     std::vector<std::string> args{"", "--name=rec", "--broker=ipc_broker", "--coretype=ipc", exampleFile};
     char *argv[5];
@@ -283,55 +284,57 @@ BOOST_DATA_TEST_CASE (simple_recorder_test_message_files_cmd,
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (5); });
     cfed.enterExecutingMode ();
     auto retTime = cfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
     e1.send ("src1", "this is a test message");
 
     retTime = cfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = cfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     e1.send ("src1", "this is a test message2");
     pub1.publish (4.7);
 
     retTime = cfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = cfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     cfed.finalize ();
     fut.get ();
     rec1.finalize ();
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 4u);
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.pointCount (), 4u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
 
     auto v1 = rec1.getValue (0);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.4));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (3.4));
     v1 = rec1.getValue (1);
-    BOOST_CHECK_EQUAL (v1.first, "pub2");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (5.7));
+    EXPECT_EQ (v1.first, "pub2");
+    EXPECT_EQ (v1.second, std::to_string (5.7));
 
     v1 = rec1.getValue (2);
-    BOOST_CHECK_EQUAL (v1.first, "pub1");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (4.7));
+    EXPECT_EQ (v1.first, "pub1");
+    EXPECT_EQ (v1.second, std::to_string (4.7));
 
     v1 = rec1.getValue (3);
-    BOOST_CHECK_EQUAL (v1.first, "pub2");
-    BOOST_CHECK_EQUAL (v1.second, std::to_string (3.9));
+    EXPECT_EQ (v1.first, "pub2");
+    EXPECT_EQ (v1.second, std::to_string (3.9));
 
     auto m = rec1.getMessage (1);
-    BOOST_REQUIRE (m);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message2");
+    ASSERT_TRUE (m);
+    EXPECT_EQ (m->data.to_string (), "this is a test message2");
     std::this_thread::sleep_for (std::chrono::milliseconds (500));
 }
 #endif
 
-BOOST_AUTO_TEST_CASE (recorder_test_destendpoint_clone)
+INSTANTIATE_TEST_SUITE_P (recorder_tests, recorder_message_file_tests, ::testing::ValuesIn (simple_message_files));
+
+TEST (recorder_tests, recorder_test_destendpoint_clone)
 {
     helics::FederateInfo fi;
     fi.coreType = helics::core_type::TEST;
@@ -359,25 +362,25 @@ BOOST_AUTO_TEST_CASE (recorder_test_destendpoint_clone)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_GE (rec1.messageCount (), 2u);
+    EXPECT_GE (rec1.messageCount (), 2u);
 
     auto m = rec1.getMessage (0);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message");
+    EXPECT_EQ (m->data.to_string (), "this is a test message");
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_srcendpoint_clone)
+TEST (recorder_tests, recorder_test_srcendpoint_clone)
 {
     helics::FederateInfo fi;
     fi.coreType = helics::core_type::TEST;
@@ -405,25 +408,25 @@ BOOST_AUTO_TEST_CASE (recorder_test_srcendpoint_clone)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_GE (rec1.messageCount (), 2u);
+    EXPECT_GE (rec1.messageCount (), 2u);
 
     auto m = rec1.getMessage (0);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message");
+    EXPECT_EQ (m->data.to_string (), "this is a test message");
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_endpoint_clone)
+TEST (recorder_tests, recorder_test_endpoint_clone)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -451,33 +454,32 @@ BOOST_AUTO_TEST_CASE (recorder_test_endpoint_clone)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
 
     auto m = rec1.getMessage (0);
-    BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message");
+    EXPECT_EQ (m->data.to_string (), "this is a test message");
 }
 
-static constexpr const char *simple_clone_test_files[] = {"clone_example1.txt",  "clone_example2.txt",
-                                                          "clone_example3.txt",  "clone_example4.txt",
-                                                          "clone_example5.txt",  "clone_example6.txt",
-                                                          "clone_example7.json", "clone_example8.JSON"};
+class recorder_clone_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
 
-BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simple_clone_test_files), file)
+TEST_P (recorder_clone_file_tests, simple_clone_test_file)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("rcore4") + file;
+    fi.coreName = std::string ("rcore4") + GetParam ();
     fi.coreInitString = "-f 3 --autobroker";
     helics::apps::Recorder rec1 ("rec1", fi);
     fi.setProperty (helics_property_time_period, 1.0);
@@ -488,7 +490,7 @@ BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simp
     helics::Endpoint e1 (helics::GLOBAL, &mfed, "d1");
     helics::Endpoint e2 (helics::GLOBAL, &mfed2, "d2");
 
-    rec1.loadFile (std::string (TEST_DIR) + file);
+    rec1.loadFile (std::string (TEST_DIR) + GetParam ());
 
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (5.0); });
     mfed2.enterExecutingModeAsync ();
@@ -500,29 +502,38 @@ BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simp
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_GE (rec1.messageCount (), 2u);
+    EXPECT_GE (rec1.messageCount (), 2u);
 
     auto m = rec1.getMessage (0);
-    BOOST_CHECK (m);
+    EXPECT_TRUE (m);
     if (m)
     {
-        BOOST_CHECK_EQUAL (m->data.to_string (), "this is a test message");
+        EXPECT_EQ (m->data.to_string (), "this is a test message");
     }
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_saveFile1)
+static constexpr const char *simple_clone_test_files[] = {"clone_example1.txt",  "clone_example2.txt",
+                                                          "clone_example3.txt",  "clone_example4.txt",
+                                                          "clone_example5.txt",  "clone_example6.txt",
+                                                          "clone_example7.json", "clone_example8.JSON"};
+
+INSTANTIATE_TEST_SUITE_P (recorder_tests,
+                          recorder_clone_file_tests,
+                          ::testing::ValuesIn (simple_clone_test_files));
+
+TEST (recorder_tests, recorder_test_saveFile1)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "rcore5";
@@ -549,34 +560,34 @@ BOOST_AUTO_TEST_CASE (recorder_test_saveFile1)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
 
     auto filename = ghc::filesystem::temp_directory_path () / "savefile.txt";
     rec1.saveFile (filename.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename));
+    EXPECT_TRUE (ghc::filesystem::exists (filename));
 
     auto filename2 = ghc::filesystem::temp_directory_path () / "savefile.json";
     rec1.saveFile (filename2.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename2));
+    EXPECT_TRUE (ghc::filesystem::exists (filename2));
     ghc::filesystem::remove (filename);
     ghc::filesystem::remove (filename2);
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_saveFile2)
+TEST (recorder_tests, recorder_test_saveFile2)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "rcore6";
@@ -590,36 +601,36 @@ BOOST_AUTO_TEST_CASE (recorder_test_saveFile2)
     auto fut = std::async (std::launch::async, [&rec1]() { rec1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
     rec1.finalize ();
 
     auto m2 = rec1.getMessage (4);
-    BOOST_CHECK (!m2);
+    EXPECT_TRUE (!m2);
     auto filename = ghc::filesystem::temp_directory_path () / "savefile.txt";
     rec1.saveFile (filename.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename));
+    EXPECT_TRUE (ghc::filesystem::exists (filename));
 
     auto filename2 = ghc::filesystem::temp_directory_path () / "savefile.json";
     rec1.saveFile (filename2.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename2));
+    EXPECT_TRUE (ghc::filesystem::exists (filename2));
     ghc::filesystem::remove (filename);
     ghc::filesystem::remove (filename2);
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_saveFile3)
+TEST (recorder_tests, recorder_test_saveFile3)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "rcore7";
@@ -651,13 +662,13 @@ BOOST_AUTO_TEST_CASE (recorder_test_saveFile3)
 
     e1.send ("d2", "this is a test message");
     pub1.publish (4.7);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
 
     mfed2.requestTimeComplete ();
     pub1.publish (4.7);
@@ -665,33 +676,31 @@ BOOST_AUTO_TEST_CASE (recorder_test_saveFile3)
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 3u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.pointCount (), 3u);
 
     auto filename = ghc::filesystem::temp_directory_path () / "savefile.txt";
     rec1.saveFile (filename.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename));
+    EXPECT_TRUE (ghc::filesystem::exists (filename));
 
     auto filename2 = ghc::filesystem::temp_directory_path () / "savefile.json";
     rec1.saveFile (filename2.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename2));
+    EXPECT_TRUE (ghc::filesystem::exists (filename2));
     ghc::filesystem::remove (filename);
     ghc::filesystem::remove (filename2);
 }
 
-BOOST_AUTO_TEST_CASE (recorder_test_help)
+TEST (recorder_tests, recorder_test_help)
 {
     std::vector<std::string> args{"--quiet", "--version"};
     helics::apps::Recorder rec1 (args);
 
-    BOOST_CHECK (!rec1.isActive ());
+    EXPECT_TRUE (!rec1.isActive ());
 
     args.emplace_back ("-?");
     helics::apps::Recorder rec2 (args);
 
-    BOOST_CHECK (!rec2.isActive ());
+    EXPECT_TRUE (!rec2.isActive ());
 }
-
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/SourceTests.cpp
+++ b/tests/helics/apps/SourceTests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #include "exeTestHelper.h"
 #include "helics/application_api/Subscriptions.hpp"
@@ -13,12 +12,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/BrokerFactory.hpp"
 #include <future>
 
-namespace utf = boost::unit_test;
-
-// BOOST_AUTO_TEST_SUITE (source_tests, *boost::unit_test::disabled())
-BOOST_AUTO_TEST_SUITE (source_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_CASE (simple_source_test)
+TEST (source_tests, simple_source_test)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "score-source";
@@ -26,7 +20,7 @@ BOOST_AUTO_TEST_CASE (simple_source_test)
     helics::apps::Source src1 ("player1", fi);
     auto index = src1.addSignalGenerator ("ramp", "ramp");
     auto gen = src1.getGenerator (index);
-    BOOST_REQUIRE (gen);
+    ASSERT_TRUE (gen);
     gen->set ("ramp", 0.3);
     gen->set ("level", 1.0);
     src1.addPublication ("pub1", helics::data_type::helics_double, 1.0);
@@ -39,34 +33,34 @@ BOOST_AUTO_TEST_CASE (simple_source_test)
     });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.3);
+    EXPECT_EQ (val, 1.3);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.6);
+    EXPECT_EQ (val, 1.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.9);
+    EXPECT_EQ (val, 1.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 4.0);
+    EXPECT_EQ (retTime, 4.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.2);
+    EXPECT_EQ (val, 2.2);
 
     retTime = vfed.requestTime (6);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.5);
+    EXPECT_EQ (val, 2.5);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_source_test2)
+TEST (source_tests, simple_source_test2)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreType = helics::core_type::TEST;
@@ -78,8 +72,8 @@ BOOST_AUTO_TEST_CASE (simple_source_test2)
     auto index2 = src1.addSignalGenerator ("ramp2", "ramp");
     auto gen = src1.getGenerator (index);
     auto gen2 = src1.getGenerator (index2);
-    BOOST_CHECK (gen);
-    BOOST_CHECK (gen2);
+    EXPECT_TRUE (gen);
+    EXPECT_TRUE (gen2);
     gen->set ("ramp", 0.3);
     gen->set ("level", 1.0);
     src1.addPublication ("pub1", "ramp", helics::data_type::helics_double, 1.0);
@@ -97,40 +91,40 @@ BOOST_AUTO_TEST_CASE (simple_source_test2)
     });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1.1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.3);
+    EXPECT_EQ (val, 1.3);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.6);
+    EXPECT_EQ (val, 1.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.9);
+    EXPECT_EQ (val, 1.9);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 3.8);
+    EXPECT_EQ (val, 3.8);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 4.0);
+    EXPECT_EQ (retTime, 4.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.2);
+    EXPECT_EQ (val, 2.2);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 3.8);
+    EXPECT_EQ (val, 3.8);
 
     retTime = vfed.requestTime (6);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.5);
+    EXPECT_EQ (val, 2.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 5.0);
+    EXPECT_EQ (val, 5.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (sine_source_test)
+TEST (source_tests, sine_source_test)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreType = helics::core_type::TEST;
@@ -140,7 +134,7 @@ BOOST_AUTO_TEST_CASE (sine_source_test)
 
     auto index = src1.addSignalGenerator ("sine", "sine");
     auto gen = src1.getGenerator (index);
-    BOOST_CHECK (gen);
+    EXPECT_TRUE (gen);
     if (gen)
     {
         gen->set ("freq", 0.5);
@@ -157,39 +151,39 @@ BOOST_AUTO_TEST_CASE (sine_source_test)
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (5);
 
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     double val = sub1.getValue<double> ();
-    BOOST_CHECK_SMALL (val, 1e-12);
+    EXPECT_NEAR (val, 0.0, 1e-12);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, -1.0, 1e-9);
+    EXPECT_DOUBLE_EQ (val, -1.0);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_SMALL (val, 1e-12);
+    EXPECT_NEAR (val, 0.0, 1e-12);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.5);
+    EXPECT_EQ (retTime, 2.5);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 1.0, 1e-9);
+    EXPECT_DOUBLE_EQ (val, 1.0);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_SMALL (val, 1e-12);
+    EXPECT_NEAR (val, 0.0, 1e-12);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.5);
+    EXPECT_EQ (retTime, 3.5);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, -1.0, 1e-9);
+    EXPECT_DOUBLE_EQ (val, -1.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_source_test_file)
+TEST (source_tests, simple_source_test_file)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "scorep";
@@ -205,34 +199,34 @@ BOOST_AUTO_TEST_CASE (simple_source_test_file)
     });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1.1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.3);
+    EXPECT_EQ (val, 1.3);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.6);
+    EXPECT_EQ (val, 1.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.9);
+    EXPECT_EQ (val, 1.9);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 4.0);
+    EXPECT_EQ (retTime, 4.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.2);
+    EXPECT_EQ (val, 2.2);
 
     retTime = vfed.requestTime (6);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.5);
+    EXPECT_EQ (val, 2.5);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (simple_source_test2_file)
+TEST (source_tests, simple_source_test2_file)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "score2";
@@ -249,40 +243,40 @@ BOOST_AUTO_TEST_CASE (simple_source_test2_file)
     });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     auto val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.3);
+    EXPECT_EQ (val, 1.3);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.6);
+    EXPECT_EQ (val, 1.6);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 1.9);
+    EXPECT_EQ (val, 1.9);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 3.8);
+    EXPECT_EQ (val, 3.8);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 4.0);
+    EXPECT_EQ (retTime, 4.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.2);
+    EXPECT_EQ (val, 2.2);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 3.8);
+    EXPECT_EQ (val, 3.8);
 
     retTime = vfed.requestTime (6);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 2.5);
+    EXPECT_EQ (val, 2.5);
     val = sub2.getValue<double> ();
-    BOOST_CHECK_EQUAL (val, 5.0);
+    EXPECT_EQ (val, 5.0);
     vfed.finalize ();
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (sine_source_test_file)
+TEST (source_tests, sine_source_test_file)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
 
@@ -300,35 +294,34 @@ BOOST_AUTO_TEST_CASE (sine_source_test_file)
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (5);
 
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     double val = sub1.getValue<double> ();
-    BOOST_CHECK_SMALL (val, 1e-12);
+    EXPECT_NEAR (val, 0.0, 1e-12);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, -1.0, 1e-9);
+    EXPECT_DOUBLE_EQ (val, -1.0);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_SMALL (val, 1e-12);
+    EXPECT_NEAR (val, 0.0, 1e-12);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 2.5);
+    EXPECT_EQ (retTime, 2.5);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, 1.0, 1e-9);
+    EXPECT_DOUBLE_EQ (val, 1.0);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_SMALL (val, 1e-12);
+    EXPECT_NEAR (val, 0.0, 1e-12);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 3.5);
+    EXPECT_EQ (retTime, 3.5);
     val = sub1.getValue<double> ();
-    BOOST_CHECK_CLOSE (val, -1.0, 1e-9);
+    EXPECT_DOUBLE_EQ (val, -1.0);
     vfed.finalize ();
     fut.get ();
 }
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/TracerTests.cpp
+++ b/tests/helics/apps/TracerTests.cpp
@@ -4,9 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
-#include <boost/test/tools/floating_point_comparison.hpp>
+#include "gtest/gtest.h"
 
 #include <cstdio>
 
@@ -20,12 +18,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <future>
 #include <iostream>
 
-namespace utf = boost::unit_test;
 using namespace std::literals::chrono_literals;
 
-BOOST_AUTO_TEST_SUITE (tracer_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_CASE (simple_tracer_test)
+TEST (tracer_tests, simple_tracer_test)
 {
     std::atomic<double> lastVal{-1e49};
     std::atomic<double> lastTime{0.0};
@@ -45,11 +40,11 @@ BOOST_AUTO_TEST_CASE (simple_tracer_test)
     auto fut = std::async (std::launch::async, [&trace1]() { trace1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     int cnt = 0;
     while (lastTime < 0.5)
     {
@@ -59,20 +54,20 @@ BOOST_AUTO_TEST_CASE (simple_tracer_test)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 1.0, 0.00000001);
-    BOOST_CHECK_CLOSE (lastVal.load (), 3.4, 0.000000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 1.0);
+    EXPECT_DOUBLE_EQ (lastVal.load (), 3.4);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
     vfed.finalize ();
     fut.get ();
-    BOOST_CHECK_CLOSE (lastTime.load (), 2.0, 0.000000001);
-    BOOST_CHECK_CLOSE (lastVal.load (), 4.7, 0.000000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 2.0);
+    EXPECT_DOUBLE_EQ (lastVal.load (), 4.7);
     trace1.finalize ();
 }
 
-BOOST_AUTO_TEST_CASE (tracer_test_message)
+TEST (tracer_tests, tracer_test_message)
 {
     gmlc::libguarded::guarded<std::unique_ptr<helics::Message>> mguard;
     std::atomic<double> lastTime{0.0};
@@ -96,7 +91,7 @@ BOOST_AUTO_TEST_CASE (tracer_test_message)
 
     auto retTime = mfed.requestTime (1.0);
     e1.send ("src1", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     retTime = mfed.requestTime (2.0);
     int cnt = 0;
     while (lastTime < 0.5)
@@ -107,16 +102,16 @@ BOOST_AUTO_TEST_CASE (tracer_test_message)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 1.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 1.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d1");
-        BOOST_CHECK_EQUAL ((*mhandle)->dest, "src1");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message");
+        EXPECT_EQ ((*mhandle)->source, "d1");
+        EXPECT_EQ ((*mhandle)->dest, "src1");
     }
     e1.send ("src1", "this is a test message2");
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed.finalize ();
     cnt = 0;
     while (lastTime < 1.5)
@@ -127,13 +122,13 @@ BOOST_AUTO_TEST_CASE (tracer_test_message)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 2.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 2.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message2");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d1");
-        BOOST_CHECK_EQUAL ((*mhandle)->dest, "src1");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message2");
+        EXPECT_EQ ((*mhandle)->source, "d1");
+        EXPECT_EQ ((*mhandle)->dest, "src1");
     }
 
     fut.get ();
@@ -142,11 +137,15 @@ BOOST_AUTO_TEST_CASE (tracer_test_message)
 static constexpr const char *simple_files[] = {"example1.recorder", "example2.record",    "example3rec.json",
                                                "example4rec.json",  "exampleCapture.txt", "exampleCapture.json"};
 
-BOOST_DATA_TEST_CASE (simple_tracer_test_files, boost::unit_test::data::make (simple_files), file)
+class tracer_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P (tracer_file_tests, simple_tracer_test_files)
 {
     static char indx = 'a';
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("tcore1") + file;
+    fi.coreName = std::string ("tcore1") + GetParam ();
     fi.coreName.push_back (indx++);
     fi.coreInitString = "-f 2 --autobroker";
     helics::apps::Tracer trace1 ("trace1", fi);
@@ -154,7 +153,7 @@ BOOST_DATA_TEST_CASE (simple_tracer_test_files, boost::unit_test::data::make (si
     std::atomic<int> counter{0};
     auto cb = [&counter](helics::Time, const std::string &, const std::string &) { ++counter; };
     trace1.setValueCallback (cb);
-    trace1.loadFile (std::string (TEST_DIR) + file);
+    trace1.loadFile (std::string (TEST_DIR) + GetParam ());
 
     helics::ValueFederate vfed ("block1", fi);
     helics::Publication pub1 (helics::GLOBAL, &vfed, "pub1", helics::data_type::helics_double);
@@ -163,42 +162,48 @@ BOOST_DATA_TEST_CASE (simple_tracer_test_files, boost::unit_test::data::make (si
     auto fut = std::async (std::launch::async, [&trace1]() { trace1.runTo (4); });
     vfed.enterExecutingMode ();
     auto retTime = vfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
 
     retTime = vfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = vfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     pub1.publish (4.7);
 
     retTime = vfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = vfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     vfed.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (counter.load (), 4);
+    EXPECT_EQ (counter.load (), 4);
     trace1.finalize ();
 }
 
+INSTANTIATE_TEST_SUITE_P (tracer_tests, tracer_file_tests, ::testing::ValuesIn (simple_files));
+
 static constexpr const char *simple_message_files[] = {"example4.recorder", "example5.record", "example6rec.json"};
 
-BOOST_DATA_TEST_CASE (simple_tracer_test_message_files, boost::unit_test::data::make (simple_message_files), file)
+class tracer_message_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P (tracer_message_file_tests, test_message_files)
 {
     static char indx = 'a';
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("tcore1b") + file;
+    fi.coreName = std::string ("tcore1b") + GetParam ();
     fi.coreName.push_back (indx++);
     fi.coreInitString = " -f 2 --autobroker";
     helics::apps::Tracer trace1 ("trace1", fi);
 
-    trace1.loadFile (std::string (TEST_DIR) + file);
+    trace1.loadFile (std::string (TEST_DIR) + GetParam ());
 
     std::atomic<int> counter{0};
     auto cb = [&counter](helics::Time, const std::string &, const std::string &) { ++counter; };
@@ -216,42 +221,40 @@ BOOST_DATA_TEST_CASE (simple_tracer_test_message_files, boost::unit_test::data::
     auto fut = std::async (std::launch::async, [&trace1]() { trace1.runTo (5); });
     cfed.enterExecutingMode ();
     auto retTime = cfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
     e1.send ("src1", "this is a test message");
 
     retTime = cfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = cfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     e1.send ("src1", "this is a test message2");
     pub1.publish (4.7);
 
     retTime = cfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = cfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     cfed.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (counter.load (), 4);
-    BOOST_CHECK_EQUAL (mcounter.load (), 2);
+    EXPECT_EQ (counter.load (), 4);
+    EXPECT_EQ (mcounter.load (), 2);
     trace1.finalize ();
 }
 
 #ifdef ENABLE_IPC_CORE
-BOOST_DATA_TEST_CASE (simple_tracer_test_message_files_cmd,
-                      boost::unit_test::data::make (simple_message_files),
-                      file)
+TEST_P (tracer_message_file_tests, test_message_files_cmd)
 {
     std::this_thread::sleep_for (300ms);
     auto brk = helics::BrokerFactory::create (helics::core_type::IPC, "ipc_broker", "-f 2");
     brk->connect ();
-    std::string exampleFile = std::string (TEST_DIR) + file;
+    std::string exampleFile = std::string (TEST_DIR) + GetParam ();
     std::vector<std::string> args{"", "--name=rec", "--coretype=ipc", exampleFile};
 
     char *argv[4];
@@ -277,35 +280,37 @@ BOOST_DATA_TEST_CASE (simple_tracer_test_message_files_cmd,
     auto fut = std::async (std::launch::async, [&trace1]() { trace1.runTo (5); });
     cfed.enterExecutingMode ();
     auto retTime = cfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
     e1.send ("src1", "this is a test message");
 
     retTime = cfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = cfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     e1.send ("src1", "this is a test message2");
     pub1.publish (4.7);
 
     retTime = cfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = cfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     cfed.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (counter.load (), 4);
+    EXPECT_EQ (counter.load (), 4);
     trace1.finalize ();
     std::this_thread::sleep_for (300ms);
 }
 #endif
 
-BOOST_AUTO_TEST_CASE (tracer_test_destendpoint_clone)
+INSTANTIATE_TEST_SUITE_P (tracer_tests, tracer_message_file_tests, ::testing::ValuesIn (simple_message_files));
+
+TEST (tracer_tests, tracer_test_destendpoint_clone)
 {
     gmlc::libguarded::guarded<std::unique_ptr<helics::Message>> mguard;
     std::atomic<double> lastTime{0.0};
@@ -339,11 +344,11 @@ BOOST_AUTO_TEST_CASE (tracer_test_destendpoint_clone)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
 
     int cnt = 0;
@@ -355,13 +360,13 @@ BOOST_AUTO_TEST_CASE (tracer_test_destendpoint_clone)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 1.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 1.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d1");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d2");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message");
+        EXPECT_EQ ((*mhandle)->source, "d1");
+        EXPECT_EQ ((*mhandle)->original_dest, "d2");
     }
     e2.send ("d1", "this is a test message2");
     mfed.finalize ();
@@ -375,18 +380,18 @@ BOOST_AUTO_TEST_CASE (tracer_test_destendpoint_clone)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 2.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 2.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message2");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d2");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d1");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message2");
+        EXPECT_EQ ((*mhandle)->source, "d2");
+        EXPECT_EQ ((*mhandle)->original_dest, "d1");
     }
     fut.get ();
 }
 
-BOOST_AUTO_TEST_CASE (tracer_test_srcendpoint_clone)
+TEST (tracer_tests, srcendpoint_clone)
 {
     gmlc::libguarded::guarded<std::unique_ptr<helics::Message>> mguard;
     std::atomic<double> lastTime{0.0};
@@ -421,11 +426,11 @@ BOOST_AUTO_TEST_CASE (tracer_test_srcendpoint_clone)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
     int cnt = 0;
     while (lastTime < 0.5)
@@ -436,30 +441,30 @@ BOOST_AUTO_TEST_CASE (tracer_test_srcendpoint_clone)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 1.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 1.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d1");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d2");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message");
+        EXPECT_EQ ((*mhandle)->source, "d1");
+        EXPECT_EQ ((*mhandle)->original_dest, "d2");
     }
     e2.send ("d1", "this is a test message2");
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_CLOSE (lastTime.load (), 2.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 2.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message2");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d2");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d1");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message2");
+        EXPECT_EQ ((*mhandle)->source, "d2");
+        EXPECT_EQ ((*mhandle)->original_dest, "d1");
     }
 }
 
-BOOST_AUTO_TEST_CASE (tracer_test_endpoint_clone)
+TEST (tracer_tests, tracer_test_endpoint_clone)
 {
     gmlc::libguarded::guarded<std::unique_ptr<helics::Message>> mguard;
     std::atomic<double> lastTime{0.0};
@@ -495,11 +500,11 @@ BOOST_AUTO_TEST_CASE (tracer_test_endpoint_clone)
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
     int cnt = 0;
     while (lastTime < 0.5)
@@ -510,26 +515,26 @@ BOOST_AUTO_TEST_CASE (tracer_test_endpoint_clone)
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 1.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 1.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d1");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d2");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message");
+        EXPECT_EQ ((*mhandle)->source, "d1");
+        EXPECT_EQ ((*mhandle)->original_dest, "d2");
     }
     e2.send ("d1", "this is a test message2");
 
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_CLOSE (lastTime.load (), 2.0, 0.00000001);
+    EXPECT_DOUBLE_EQ (lastTime.load (), 2.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message2");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d2");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d1");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message2");
+        EXPECT_EQ ((*mhandle)->source, "d2");
+        EXPECT_EQ ((*mhandle)->original_dest, "d1");
     }
 }
 
@@ -538,13 +543,17 @@ static constexpr const char *simple_clone_test_files[] = {"clone_example1.txt", 
                                                           "clone_example5.txt",  "clone_example6.txt",
                                                           "clone_example7.json", "clone_example8.JSON"};
 
-BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simple_clone_test_files), file)
+class tracer_clone_file_tests : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P (tracer_clone_file_tests, simple_clone_test_file)
 {
     static char indx = 'a';
     gmlc::libguarded::guarded<std::unique_ptr<helics::Message>> mguard;
     std::atomic<double> lastTime{0.0};
     helics::FederateInfo fi (helics::core_type::TEST);
-    fi.coreName = std::string ("tcore4") + file;
+    fi.coreName = std::string ("tcore4") + GetParam ();
     fi.coreName.push_back (indx++);
     fi.coreInitString = "-f3 --autobroker";
     helics::apps::Tracer trace1 ("trace1", fi);
@@ -556,7 +565,7 @@ BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simp
     helics::Endpoint &e1 = mfed.registerGlobalEndpoint ("d1");
     helics::Endpoint &e2 = mfed2.registerGlobalEndpoint ("d2");
 
-    trace1.loadFile (std::string (TEST_DIR) + file);
+    trace1.loadFile (std::string (TEST_DIR) + GetParam ());
     auto cb = [&mguard, &lastTime](helics::Time tm, std::unique_ptr<helics::Message> mess) {
         mguard = std::move (mess);
         lastTime = static_cast<double> (tm);
@@ -572,11 +581,11 @@ BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simp
     mfed2.requestTimeComplete ();
 
     e1.send ("d2", "this is a test message");
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     mfed2.requestTimeComplete ();
     int cnt = 0;
     while (lastTime < 0.5)
@@ -587,43 +596,43 @@ BOOST_DATA_TEST_CASE (simple_clone_test_file, boost::unit_test::data::make (simp
             break;
         }
     }
-    BOOST_CHECK_CLOSE (lastTime.load (), 1.0, 0.00000001);
+    EXPECT_FLOAT_EQ (lastTime.load (), 1.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d1");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d2");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message");
+        EXPECT_EQ ((*mhandle)->source, "d1");
+        EXPECT_EQ ((*mhandle)->original_dest, "d2");
     }
 
     e2.send ("d1", "this is a test message2");
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_CLOSE (lastTime.load (), 2.0, 0.00000001);
+    EXPECT_FLOAT_EQ (lastTime.load (), 2.0);
     {
         auto mhandle = mguard.lock ();
-        BOOST_REQUIRE (*mhandle);
-        BOOST_CHECK_EQUAL ((*mhandle)->data.to_string (), "this is a test message2");
-        BOOST_CHECK_EQUAL ((*mhandle)->source, "d2");
-        BOOST_CHECK_EQUAL ((*mhandle)->original_dest, "d1");
+        ASSERT_TRUE (*mhandle);
+        EXPECT_EQ ((*mhandle)->data.to_string (), "this is a test message2");
+        EXPECT_EQ ((*mhandle)->source, "d2");
+        EXPECT_EQ ((*mhandle)->original_dest, "d1");
     }
 }
 
-#ifdef ENABLE_ZMQ_TESTS
+INSTANTIATE_TEST_SUITE_P (tracer_tests, tracer_clone_file_tests, ::testing::ValuesIn (simple_clone_test_files));
+
+#ifdef ENABLE_ZMQ_CORE
 #ifndef DISABLE_SYSTEM_CALL_TESTS
-BOOST_DATA_TEST_CASE (simple_tracer_test_message_files_exe,
-                      boost::unit_test::data::make (simple_message_files),
-                      file)
+TEST_P (tracer_message_file_tests, test_message_files_exe)
 {
     std::this_thread::sleep_for (300ms);
     auto brk = helics::BrokerFactory::create (helics::core_type::ZMQ, "z_broker", "-f 2");
     brk->connect ();
-    std::string exampleFile = std::string (TEST_DIR) + file;
+    std::string exampleFile = std::string (TEST_DIR) + GetParam ();
 
     std::string cmdArg ("--name=tracer --coretype=zmq --stop=5s --print --skiplog " + exampleFile);
     exeTestRunner tracerExe (HELICS_INSTALL_LOC, HELICS_BUILD_LOC "apps/", "helics_app");
-    BOOST_REQUIRE (tracerExe.isActive ());
+    ASSERT_TRUE (tracerExe.isActive ());
     auto out = tracerExe.runCaptureOutputAsync (std::string ("tracer " + cmdArg));
     helics::FederateInfo fi (helics::core_type::ZMQ);
     fi.coreInitString = "";
@@ -635,36 +644,37 @@ BOOST_DATA_TEST_CASE (simple_tracer_test_message_files_exe,
 
     cfed.enterExecutingMode ();
     auto retTime = cfed.requestTime (1);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     pub1.publish (3.4);
     e1.send ("src1", "this is a test message");
 
     retTime = cfed.requestTime (1.5);
-    BOOST_CHECK_EQUAL (retTime, 1.5);
+    EXPECT_EQ (retTime, 1.5);
     pub2.publish (5.7);
 
     retTime = cfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
     e1.send ("src1", "this is a test message2");
     pub1.publish (4.7);
 
     retTime = cfed.requestTime (3.0);
-    BOOST_CHECK_EQUAL (retTime, 3.0);
+    EXPECT_EQ (retTime, 3.0);
     pub2.publish ("3.9");
 
     retTime = cfed.requestTime (5);
-    BOOST_CHECK_EQUAL (retTime, 5.0);
+    EXPECT_EQ (retTime, 5.0);
 
     cfed.finalize ();
     std::string outAct = out.get ();
     int mcount = 0;
     int valcount = 0;
-    auto vec = stringOps::splitline (outAct, "\n\r", stringOps::delimiter_compression::on);
+    auto vec = gmlc::utilities::stringOps::splitline (outAct, "\n\r",
+                                                      gmlc::utilities::stringOps::delimiter_compression::on);
     auto cnt = std::count_if (vec.begin (), vec.end (),
                               [](const std::string &str) { return (!(str.empty ()) && (str[0] == '[')); });
     // 6 messages, 1 return line, 1 empty line
-    BOOST_CHECK_EQUAL (cnt, 6);
-    BOOST_CHECK_EQUAL (*(vec.end () - 2), "execution returned 0");
+    EXPECT_EQ (cnt, 6);
+    EXPECT_EQ (*(vec.end () - 1), "execution returned 0");
     for (const auto &line : vec)
     {
         if (line.find ("]value") != std::string::npos)
@@ -676,10 +686,9 @@ BOOST_DATA_TEST_CASE (simple_tracer_test_message_files_exe,
             ++mcount;
         }
     }
-    BOOST_CHECK_EQUAL (mcount, 2);
-    BOOST_CHECK_EQUAL (valcount, 4);
+    EXPECT_EQ (mcount, 2);
+    EXPECT_EQ (valcount, 4);
 }
 
 #endif
 #endif
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/combo_tests.cpp
+++ b/tests/helics/apps/combo_tests.cpp
@@ -4,8 +4,7 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
+#include "gtest/gtest.h"
 
 #ifdef _MSC_VER
 #pragma warning(push, 0)
@@ -26,12 +25,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/BrokerFactory.hpp"
 #include <future>
 
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (combo_tests, *utf::label ("ci"))
-
 // this is the same as another test in test recorders
-BOOST_AUTO_TEST_CASE (save_load_file1)
+TEST (combo_tests, save_load_file1)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "ccore2";
@@ -63,13 +58,13 @@ BOOST_AUTO_TEST_CASE (save_load_file1)
 
     e1.send ("d2", "this is a test message");
     pub1.publish (4.7);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
 
     e2.send ("d1", "this is a test message2");
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
 
     mfed2.requestTimeComplete ();
     pub1.publish (4.7);
@@ -77,21 +72,21 @@ BOOST_AUTO_TEST_CASE (save_load_file1)
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 3u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.pointCount (), 3u);
 
     auto filename = ghc::filesystem::temp_directory_path () / "savefile.txt";
     rec1.saveFile (filename.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename));
+    EXPECT_TRUE (ghc::filesystem::exists (filename));
 
     auto filename2 = ghc::filesystem::temp_directory_path () / "savefile.json";
     rec1.saveFile (filename2.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename2));
+    EXPECT_TRUE (ghc::filesystem::exists (filename2));
 }
 
-BOOST_AUTO_TEST_CASE (save_load_file_binary)
+TEST (combo_tests, save_load_file_binary)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "ccore3";
@@ -127,7 +122,7 @@ BOOST_AUTO_TEST_CASE (save_load_file_binary)
     }
     e1.send ("d2", n5);
     pub1.publish (4.7);
-    BOOST_CHECK_EQUAL (retTime, 1.0);
+    EXPECT_EQ (retTime, 1.0);
     helics::data_block n6 (256);
     for (int ii = 0; ii < 256; ++ii)
     {
@@ -137,7 +132,7 @@ BOOST_AUTO_TEST_CASE (save_load_file_binary)
 
     mfed2.requestTimeAsync (2.0);
     retTime = mfed.requestTime (2.0);
-    BOOST_CHECK_EQUAL (retTime, 2.0);
+    EXPECT_EQ (retTime, 2.0);
 
     mfed2.requestTimeComplete ();
     pub1.publish (4.7);
@@ -145,21 +140,21 @@ BOOST_AUTO_TEST_CASE (save_load_file_binary)
     mfed.finalize ();
     mfed2.finalize ();
     fut.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 3u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.pointCount (), 3u);
 
     auto filename = ghc::filesystem::temp_directory_path () / "savefile_binary.txt";
     rec1.saveFile (filename.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename));
+    EXPECT_TRUE (ghc::filesystem::exists (filename));
 
     auto filename2 = ghc::filesystem::temp_directory_path () / "savefile_binary.json";
     rec1.saveFile (filename2.string ());
 
-    BOOST_CHECK (ghc::filesystem::exists (filename2));
+    EXPECT_TRUE (ghc::filesystem::exists (filename2));
 }
 
-BOOST_AUTO_TEST_CASE (check_created_files1, *boost::unit_test::depends_on ("combo_tests/save_load_file1"))
+TEST (combo_tests, check_created_files1, *boost::unit_test::depends_on ("combo_tests/save_load_file1"))
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "ccore4";
@@ -171,16 +166,16 @@ BOOST_AUTO_TEST_CASE (check_created_files1, *boost::unit_test::depends_on ("comb
     play1.loadFile (filename.string ());
 
     play1.initialize ();
-    BOOST_CHECK_EQUAL (play1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (play1.publicationCount (), 1u);
-    BOOST_CHECK_EQUAL (play1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (play1.endpointCount (), 2u);
+    EXPECT_EQ (play1.pointCount (), 3u);
+    EXPECT_EQ (play1.publicationCount (), 1u);
+    EXPECT_EQ (play1.messageCount (), 2u);
+    EXPECT_EQ (play1.endpointCount (), 2u);
 
     play1.finalize ();
     ghc::filesystem::remove (filename);
 }
 
-BOOST_AUTO_TEST_CASE (check_created_files2, *boost::unit_test::depends_on ("combo_tests/save_load_file1"))
+TEST (combo_tests, check_created_files2, *boost::unit_test::depends_on ("combo_tests/save_load_file1"))
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "ccore5";
@@ -192,17 +187,18 @@ BOOST_AUTO_TEST_CASE (check_created_files2, *boost::unit_test::depends_on ("comb
     play1.loadFile (filename.string ());
 
     play1.initialize ();
-    BOOST_CHECK_EQUAL (play1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (play1.publicationCount (), 1u);
-    BOOST_CHECK_EQUAL (play1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (play1.endpointCount (), 2u);
+    EXPECT_EQ (play1.pointCount (), 3u);
+    EXPECT_EQ (play1.publicationCount (), 1u);
+    EXPECT_EQ (play1.messageCount (), 2u);
+    EXPECT_EQ (play1.endpointCount (), 2u);
 
     play1.finalize ();
     ghc::filesystem::remove (filename);
 }
 
-BOOST_AUTO_TEST_CASE (check_created_files_binary1,
-                      *boost::unit_test::depends_on ("combo_tests/save_load_file_binary"))
+TEST (combo_tests,
+      check_created_files_binary1,
+      *boost::unit_test::depends_on ("combo_tests/save_load_file_binary"))
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreType = helics::core_type::TEST;
@@ -215,10 +211,10 @@ BOOST_AUTO_TEST_CASE (check_created_files_binary1,
     play1.loadFile (filename.string ());
 
     play1.initialize ();
-    BOOST_CHECK_EQUAL (play1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (play1.publicationCount (), 1u);
-    BOOST_CHECK_EQUAL (play1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (play1.endpointCount (), 2u);
+    EXPECT_EQ (play1.pointCount (), 3u);
+    EXPECT_EQ (play1.publicationCount (), 1u);
+    EXPECT_EQ (play1.messageCount (), 2u);
+    EXPECT_EQ (play1.endpointCount (), 2u);
 
     auto &b1 = play1.getMessage (0);
     helics::data_block n5 (256);
@@ -226,7 +222,7 @@ BOOST_AUTO_TEST_CASE (check_created_files_binary1,
     {
         n5[ii] = ii;
     }
-    BOOST_CHECK_EQUAL (b1.mess.data.to_string (), n5.to_string ());
+    EXPECT_EQ (b1.mess.data.to_string (), n5.to_string ());
 
     auto &b2 = play1.getMessage (1);
     helics::data_block n6 (256);
@@ -234,13 +230,14 @@ BOOST_AUTO_TEST_CASE (check_created_files_binary1,
     {
         n6[ii] = 255 - ii;
     }
-    BOOST_CHECK_EQUAL (b2.mess.data.to_string (), n6.to_string ());
+    EXPECT_EQ (b2.mess.data.to_string (), n6.to_string ());
     play1.finalize ();
     ghc::filesystem::remove (filename);
 }
 
-BOOST_AUTO_TEST_CASE (check_created_files_binary2,
-                      *boost::unit_test::depends_on ("combo_tests/save_load_file_binary"))
+TEST (combo_tests,
+      check_created_files_binary2,
+      *boost::unit_test::depends_on ("combo_tests/save_load_file_binary"))
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreType = helics::core_type::TEST;
@@ -253,11 +250,11 @@ BOOST_AUTO_TEST_CASE (check_created_files_binary2,
     play1.loadFile (filename.string ());
 
     play1.initialize ();
-    BOOST_CHECK_EQUAL (play1.pointCount (), 3u);
-    BOOST_CHECK_EQUAL (play1.publicationCount (), 1u);
-    BOOST_CHECK_EQUAL (play1.messageCount (), 2u);
+    EXPECT_EQ (play1.pointCount (), 3u);
+    EXPECT_EQ (play1.publicationCount (), 1u);
+    EXPECT_EQ (play1.messageCount (), 2u);
 
-    BOOST_CHECK_EQUAL (play1.endpointCount (), 2u);
+    EXPECT_EQ (play1.endpointCount (), 2u);
 
     auto &b1 = play1.getMessage (0);
     helics::data_block n5 (256);
@@ -265,7 +262,7 @@ BOOST_AUTO_TEST_CASE (check_created_files_binary2,
     {
         n5[ii] = ii;
     }
-    BOOST_CHECK_EQUAL (b1.mess.data.to_string (), n5.to_string ());
+    EXPECT_EQ (b1.mess.data.to_string (), n5.to_string ());
 
     auto &b2 = play1.getMessage (1);
     helics::data_block n6 (256);
@@ -273,13 +270,13 @@ BOOST_AUTO_TEST_CASE (check_created_files_binary2,
     {
         n6[ii] = 255 - ii;
     }
-    BOOST_CHECK_EQUAL (b2.mess.data.to_string (), n6.to_string ());
+    EXPECT_EQ (b2.mess.data.to_string (), n6.to_string ());
 
     play1.finalize ();
     ghc::filesystem::remove (filename);
 }
 
-BOOST_AUTO_TEST_CASE (check_combination_file_load)
+TEST (combo_tests, check_combination_file_load)
 {
     helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "ccore_combo";
@@ -316,12 +313,10 @@ BOOST_AUTO_TEST_CASE (check_combination_file_load)
             fed.getPublication (1).publish (1);
         }
     }
-    BOOST_CHECK_EQUAL (fed.pendingMessages (), 3u);
+    EXPECT_EQ (fed.pendingMessages (), 3u);
     fed.finalize ();
     fut_play.get ();
     fut_rec.get ();
-    BOOST_CHECK_EQUAL (rec1.messageCount (), 2u);
-    BOOST_CHECK_EQUAL (rec1.pointCount (), 2u);
+    EXPECT_EQ (rec1.messageCount (), 2u);
+    EXPECT_EQ (rec1.pointCount (), 2u);
 }
-
-BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/apps/exeTestHelper.h
+++ b/tests/helics/apps/exeTestHelper.h
@@ -9,9 +9,6 @@
  * For details, see the LICENSE file.
  * LLNS Copyright End
  */
-
-#ifndef EXE_HELPER_HEADER_
-#define EXE_HELPER_HEADER_
 #pragma once
 #include <future>
 #include <string>
@@ -33,9 +30,14 @@ class exeTestRunner
     bool isActive () const { return active; };
 
     int run (const std::string &args) const;
+    /** run the executable in an async context with the given args and return a future of the return code
+    @param args a string containing the command line arguments for the executable
+    @return a future with the return value of the executable*/
     std::future<int> runAsync (const std::string &args) const;
     std::string runCaptureOutput (const std::string &args) const;
+    /** run the executable in an async context with the given args and capture the command line output and return a
+    future
+    @param args a string containing the command line arguments for the executable
+    @return a future with the executable command line output*/
     std::future<std::string> runCaptureOutputAsync (const std::string &args) const;
 };
-
-#endif

--- a/tests/helics/apps/helics_apps_tests.cpp
+++ b/tests/helics/apps/helics_apps_tests.cpp
@@ -4,24 +4,15 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include "helics/helics-config.h"
-
-#ifndef BOOST_STATIC
-#define BOOST_TEST_DYN_LINK
-#endif
-
-#define BOOST_TEST_MODULE helics_apps - tests
-#define BOOST_TEST_DETECT_MEMORY_LEAK 0
 
 #include "../../../src/helics/application_api/Federate.hpp"
-#include <boost/test/unit_test.hpp>
+#include <gtest/gtest.h>
 
-struct globalTestConfig
+struct globalTestConfig : public ::testing::Environment
 {
-    globalTestConfig () = default;
-    ~globalTestConfig () { helics::cleanupHelicsLibrary (); }
+    virtual void TearDown () override { helics::cleanupHelicsLibrary (); }
 };
 
+// register the global setup and teardown structure
+::testing::Environment *const foo_env = ::testing::AddGlobalTestEnvironment (new globalTestConfig);
 //____________________________________________________________________________//
-
-BOOST_GLOBAL_FIXTURE (globalTestConfig);

--- a/tests/helics/apps/multi_player_tests.cpp
+++ b/tests/helics/apps/multi_player_tests.cpp
@@ -1,14 +1,7 @@
 /*
-
 Copyright © 2017-2019,
 Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (multi_player_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_SUITE_END ()
+#include "gtest/gtest.h"

--- a/tests/helics/apps/multi_tests.cpp
+++ b/tests/helics/apps/multi_tests.cpp
@@ -4,10 +4,4 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 */
-#include <boost/test/unit_test.hpp>
-
-namespace utf = boost::unit_test;
-
-BOOST_AUTO_TEST_SUITE (multi_tests, *utf::label ("ci"))
-
-BOOST_AUTO_TEST_SUITE_END ()
+#include "gtest/gtest.h"

--- a/tests/helics/core/TcpCore-tests.cpp
+++ b/tests/helics/core/TcpCore-tests.cpp
@@ -496,8 +496,8 @@ TEST (TcpCore_tests, tcpCore_core_broker_default_test)
 
     auto ccore = static_cast<helics::tcp::TcpCore *> (core.get ());
     // this will test the automatic port allocation
-    int match = ccore->getAddress ().compare (0, 13, "localhost:242");
-    EXPECT_EQ (match, 0) << ccore->getAddress () << " does not match expected>localhost:242XX\n";
+    int match = ccore->getAddress ().compare (0, 12, "localhost:24");
+    EXPECT_EQ (match, 0) << ccore->getAddress () << " does not match expected>localhost:24XXX\n";
 
     core->disconnect ();
     broker->disconnect ();

--- a/tests/helics/core/TcpCore-tests.cpp
+++ b/tests/helics/core/TcpCore-tests.cpp
@@ -43,13 +43,13 @@ TEST (TcpCore_tests, tcpComms_broker_test)
     auto server = helics::tcp::TcpServer::create (srv->getBaseContext (), DEFAULT_TCP_BROKER_PORT_NUMBER);
     auto contextLoop = srv->startContextLoop ();
     std::vector<char> data (1024);
-    server->setDataCall ([&counter] (helics::tcp::TcpConnection::pointer, const char *, size_t data_avail) {
+    server->setDataCall ([&counter](helics::tcp::TcpConnection::pointer, const char *, size_t data_avail) {
         ++counter;
         return data_avail;
     });
     server->start ();
 
-    comm.setCallback ([&counter] (helics::ActionMessage /*m*/) { ++counter; });
+    comm.setCallback ([&counter](helics::ActionMessage /*m*/) { ++counter; });
     comm.setBrokerPort (DEFAULT_TCP_BROKER_PORT_NUMBER);
     comm.setName ("tests");
     comm.setTimeout (400ms);
@@ -76,7 +76,7 @@ TEST (TcpCore_tests, tcpComms_broker_test_transmit)
     auto contextLoop = srv->startContextLoop ();
     std::vector<char> data (1024);
     server->setDataCall (
-      [&data, &counter, &len] (helics::tcp::TcpConnection::pointer, const char *data_rec, size_t data_Size) {
+      [&data, &counter, &len](helics::tcp::TcpConnection::pointer, const char *data_rec, size_t data_Size) {
           std::copy (data_rec, data_rec + data_Size, data.begin ());
           len = data_Size;
           ++counter;
@@ -85,7 +85,7 @@ TEST (TcpCore_tests, tcpComms_broker_test_transmit)
     ASSERT_TRUE (server->isReady ());
     server->start ();
 
-    comm.setCallback ([] (helics::ActionMessage /*m*/) {});
+    comm.setCallback ([](helics::ActionMessage /*m*/) {});
     comm.setBrokerPort (DEFAULT_TCP_BROKER_PORT_NUMBER);
     comm.setPortNumber (TCP_SECONDARY_PORT);
     comm.setName ("tests");
@@ -134,7 +134,7 @@ TEST (TcpCore_tests, tcpComms_rx_test)
     auto contextLoop = srv->startContextLoop ();
     std::vector<char> data (1024);
     server->setDataCall (
-      [&data, &ServerCounter, &len] (helics::tcp::TcpConnection::pointer, const char *data_rec, size_t data_Size) {
+      [&data, &ServerCounter, &len](helics::tcp::TcpConnection::pointer, const char *data_rec, size_t data_Size) {
           std::copy (data_rec, data_rec + data_Size, data.begin ());
           len = data_Size;
           ++ServerCounter;
@@ -143,7 +143,7 @@ TEST (TcpCore_tests, tcpComms_rx_test)
     ASSERT_TRUE (server->isReady ());
     server->start ();
 
-    comm.setCallback ([&CommCounter, &act, &actguard] (helics::ActionMessage m) {
+    comm.setCallback ([&CommCounter, &act, &actguard](helics::ActionMessage m) {
         ++CommCounter;
         std::lock_guard<std::mutex> lock (actguard);
         act = m;
@@ -188,8 +188,8 @@ TEST (TcpCore_tests, test_tcpServerConnections1)
     std::vector<char> data (1024);
     std::atomic<bool> validData{true};
 
-    auto dataCheck = [&counter, &validData] (helics::tcp::TcpConnection::pointer, const char *datablock,
-                                             size_t datasize) {
+    auto dataCheck = [&counter, &validData](helics::tcp::TcpConnection::pointer, const char *datablock,
+                                            size_t datasize) {
         size_t used = 0;
         while (datasize - used >= 20)
         {
@@ -231,7 +231,7 @@ TEST (TcpCore_tests, test_tcpServerConnections1)
     res = conn4->waitUntilConnected (1000ms);
     EXPECT_EQ (res, true);
 
-    auto transmitFunc = [] (helics::tcp::TcpConnection::pointer obj) {
+    auto transmitFunc = [](helics::tcp::TcpConnection::pointer obj) {
         std::vector<char> dataB (20);
         for (char ii = 0; ii < 50; ++ii)
         {
@@ -290,11 +290,11 @@ TEST (TcpCore_tests, tcpComm_transmit_through)
     comm2.setFlag ("reuse_address", true);
     comm.setPortNumber (TCP_SECONDARY_PORT);
 
-    comm.setCallback ([&counter, &act] (helics::ActionMessage m) {
+    comm.setCallback ([&counter, &act](helics::ActionMessage m) {
         ++counter;
         act = m;
     });
-    comm2.setCallback ([&counter2, &act2] (helics::ActionMessage m) {
+    comm2.setCallback ([&counter2, &act2](helics::ActionMessage m) {
         ++counter2;
         act2 = m;
     });
@@ -358,15 +358,15 @@ TEST (TcpCore_tests, tcpComm_transmit_add_route)
     guarded<helics::ActionMessage> act2;
     guarded<helics::ActionMessage> act3;
 
-    comm.setCallback ([&counter, &act] (helics::ActionMessage &&m) {
+    comm.setCallback ([&counter, &act](helics::ActionMessage &&m) {
         ++counter;
         act = std::move (m);
     });
-    comm2.setCallback ([&counter2, &act2] (helics::ActionMessage &&m) {
+    comm2.setCallback ([&counter2, &act2](helics::ActionMessage &&m) {
         ++counter2;
         act2 = std::move (m);
     });
-    comm3.setCallback ([&counter3, &act3] (helics::ActionMessage &&m) {
+    comm3.setCallback ([&counter3, &act3](helics::ActionMessage &&m) {
         ++counter3;
         act3 = std::move (m);
     });
@@ -435,7 +435,7 @@ TEST (TcpCore_tests, tcpCore_initialization_test)
     std::vector<char> data (1024);
     std::atomic<size_t> len{0};
     server->setDataCall (
-      [&data, &counter, &len] (helics::tcp::TcpConnection::pointer, const char *data_rec, size_t data_Size) {
+      [&data, &counter, &len](helics::tcp::TcpConnection::pointer, const char *data_rec, size_t data_Size) {
           std::copy (data_rec, data_rec + data_Size, data.begin ());
           len = data_Size;
           ++counter;
@@ -496,7 +496,9 @@ TEST (TcpCore_tests, tcpCore_core_broker_default_test)
 
     auto ccore = static_cast<helics::tcp::TcpCore *> (core.get ());
     // this will test the automatic port allocation
-    EXPECT_EQ (ccore->getAddress ().compare (0, 13, "localhost:242"), 0);
+    int match = ccore->getAddress ().compare (0, 13, "localhost:242");
+    EXPECT_EQ (match, 0) << ccore->getAddress () << " does not match expected>localhost:242XX\n";
+
     core->disconnect ();
     broker->disconnect ();
     core = nullptr;


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will convert the apps test to use gtest

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- convert helics_apps test to use gtest instead of boost
- add some debugging output to an occasional failing test in tcpcore tests
- add apps_tests to circle ci build tests
