### PR TITLE
Race cond fix in queries

### DIFF
--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -1679,7 +1679,8 @@ void CommonCore::deliverMessage (ActionMessage &message)
                         {
                             if (FiltI->filterOp != nullptr)
                             {
-								//this is a cloning filter the whole point is that it would not modify the message so the return is irrelevent
+                                // this is a cloning filter the whole point is that it would not modify the message
+                                // so the return is irrelevent
                                 (void)(FiltI->filterOp->process (createMessageFromCommand (message)));
                             }
                         }
@@ -1951,7 +1952,7 @@ void CommonCore::setQueryCallback (local_federate_id federateID,
     fed->setQueryCallback (std::move (queryFunction));
 }
 
-std::string CommonCore::federateQuery (const FederateState *fed, const std::string &queryStr) const
+std::string CommonCore::federateQuery (const FederateState *fed, const std::string &queryStr, bool waitable) const
 {
     if (fed == nullptr)
     {
@@ -1974,7 +1975,7 @@ std::string CommonCore::federateQuery (const FederateState *fed, const std::stri
         return std::to_string (static_cast<int> (fed->getState ()));
     }
 
-    return fed->processQuery (queryStr);
+    return fed->processQuery (queryStr, waitable);
 }
 
 std::string CommonCore::coreQuery (const std::string &queryStr) const
@@ -2153,7 +2154,7 @@ std::string CommonCore::query (const std::string &target, const std::string &que
     auto fed = (target != "federate") ? getFederate (target) : getFederateAt (local_federate_id (0));
     if (fed != nullptr)
     {
-        return federateQuery (fed, queryStr);
+        return federateQuery (fed, queryStr, true);
     }
     ActionMessage querycmd (CMD_QUERY);
     querycmd.source_id = global_id.load ();
@@ -2333,7 +2334,7 @@ void CommonCore::processPriorityCommand (ActionMessage &&command)
         else
         {
             auto fedptr = getFederateCore (target);
-            repStr = federateQuery (fedptr, command.payload);
+            repStr = federateQuery (fedptr, command.payload, false);
         }
 
         queryResp.payload = std::move (repStr);
@@ -4075,7 +4076,7 @@ ActionMessage &CommonCore::processMessage (ActionMessage &m)
                 {
                     if (filt->cloning)
                     {
-						//cloning filter the return is not useful
+                        // cloning filter the return is not useful
                         (void)(filt->filterOp->process (createMessageFromCommand (m)));
                     }
                     else

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -409,10 +409,10 @@ class CommonCore : public Core, public BrokerBase
     /** generate a query response for a federate if possible
     @param fed a pointer to the federateState object to query
     @param queryStr  the string containing the actual query
-    @param waitable  if set to true the query will wait until the federate becomes available if set to false and
-    the federate can't answer immediately a #wait string will be returned.
+    @return "#wait" if the lock cannot be granted immediately and no result can be obtained otherwise an answer to
+    the query
     */
-    std::string federateQuery (const FederateState *fed, const std::string &queryStr, bool waitable) const;
+    std::string federateQuery (const FederateState *fed, const std::string &queryStr) const;
 
     /** send an error code to all the federates*/
     void sendErrorToFederates (int error_code);

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -409,8 +409,10 @@ class CommonCore : public Core, public BrokerBase
     /** generate a query response for a federate if possible
     @param fed a pointer to the federateState object to query
     @param queryStr  the string containing the actual query
+    @param waitable  if set to true the query will wait until the federate becomes available if set to false and
+    the federate can't answer immediately a #wait string will be returned.
     */
-    std::string federateQuery (const FederateState *fed, const std::string &queryStr) const;
+    std::string federateQuery (const FederateState *fed, const std::string &queryStr, bool waitable) const;
 
     /** send an error code to all the federates*/
     void sendErrorToFederates (int error_code);

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1791,7 +1791,7 @@ std::string FederateState::processQueryActual (const std::string &query) const
     return "#invalid";
 }
 
-std::string FederateState::processQuery (const std::string &query, bool waitable) const
+std::string FederateState::processQuery (const std::string &query) const
 {
     std::string qstring;
     if (query == "publications" || query == "inputs" || query == "endpoints")
@@ -1800,17 +1800,7 @@ std::string FederateState::processQuery (const std::string &query, bool waitable
     }
     else
     {  // the rest might to prevent a race condition
-        bool locked = false;
-        if (waitable)
-        {
-            sleeplock ();
-            locked = true;
-        }
-        else
-        {
-            locked = try_lock ();
-        }
-        if (locked)
+        if (try_lock ())
         {
             qstring = processQueryActual (query);
             unlock ();

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1012,10 +1012,7 @@ message_processing_result FederateState::processActionMessage (ActionMessage &cm
                 timeCoord->disconnect ();
                 cmd.dest_id = parent_broker_id;
                 setState (HELICS_TERMINATING);
-                if (parent_ != nullptr)
-                {
-                    parent_->addActionMessage (cmd);
-                }
+                routeMessage (cmd);
             }
         }
         else
@@ -1296,6 +1293,22 @@ message_processing_result FederateState::processActionMessage (ActionMessage &cm
     case CMD_INTERFACE_CONFIGURE:
         setInterfaceProperty (cmd);
         break;
+    case CMD_QUERY:
+    {
+        std::string repStr;
+        ActionMessage queryResp (CMD_QUERY_REPLY);
+        queryResp.dest_id = cmd.source_id;
+        queryResp.source_id = cmd.dest_id;
+        queryResp.messageID = cmd.messageID;
+        queryResp.counter = cmd.counter;
+        const std::string &target = cmd.getString (targetStringLoc);
+
+        queryResp.source_id = global_id;
+
+        queryResp.payload = processQueryActual (cmd.payload);
+        routeMessage (queryResp);
+    }
+    break;
     }
     return message_processing_result::continue_processing;
 }

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -326,8 +326,8 @@ class FederateState
     }
     /** generate the result of a query string
     @param query a query string
-    @return the resulting string from the query*/
-    std::string processQuery (const std::string &query, bool waitable) const;
+    @return the resulting string from the query or "#wait" if the federate is not available to answer immediately*/
+    std::string processQuery (const std::string &query) const;
     /** check if a value should be published or not
     @param pub_id the handle of the publication
     @param data the raw data to check

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -102,7 +102,7 @@ class FederateState
     std::vector<global_federate_id> delayedFederates;  //!< list of federates to delay messages from
     Time time_granted = startupTime;  //!< the most recent granted time;
     Time allowed_send_time = startupTime;  //!< the next time a message can be sent;
-    std::atomic_flag processing = ATOMIC_FLAG_INIT;  //!< the federate is processing
+    mutable std::atomic_flag processing = ATOMIC_FLAG_INIT;  //!< the federate is processing
   private:
     /** a logging function for logging or printing messages*/
     std::function<void (int, const std::string &, const std::string &)> loggerFunction;
@@ -179,7 +179,7 @@ class FederateState
     int endpointCount () const;
     /** get the number of inputs*/
     int inputCount () const;
-    /** locks the processing*/
+    /** locks the processing with a busy loop*/
     void lock ()
     {
         while (processing.test_and_set ())
@@ -187,8 +187,26 @@ class FederateState
             ;  // spin
         }
     }
+    /** locks the processing with a busy loop*/
+    void spinlock () const
+    {
+        while (processing.test_and_set ())
+        {
+            ;  // spin
+        }
+    }
+    /** locks the processing with a sleep loop*/
+    void sleeplock () const
+    {
+        while (processing.test_and_set ())
+        {
+            std::this_thread::sleep_for (std::chrono::milliseconds (50));
+        }
+    }
+    /** trys to lock the processing return true if successful and false if not*/
+    bool try_lock () const { return !processing.test_and_set (); }
     /** unlocks the processing*/
-    void unlock () { processing.clear (std::memory_order_release); }
+    void unlock () const { processing.clear (std::memory_order_release); }
 
   private:
     /** process the federate queue until returnable event
@@ -232,6 +250,8 @@ class FederateState
     void addDependent (global_federate_id fedThatDependsOnThis);
     /** check the interfaces for any issues*/
     int checkInterfaces ();
+    /** generate results from a query*/
+    std::string processQueryActual (const std::string &query) const;
 
   public:
     /** get the granted time of a federate*/
@@ -307,7 +327,7 @@ class FederateState
     /** generate the result of a query string
     @param query a query string
     @return the resulting string from the query*/
-    std::string processQuery (const std::string &query) const;
+    std::string processQuery (const std::string &query, bool waitable) const;
     /** check if a value should be published or not
     @param pub_id the handle of the publication
     @param data the raw data to check


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will fix the race condition in queries to federates coming from a core

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add support for CMD_QUERY in the federateState object
- actually lock the federateState when doing the query (with a few known exceptions)  
- if the try_lock fails then generate a actionMessage request
- use the lock function throughout the federateState instead of manually locking of the atomic_flag

