### PR TITLE
Create and upload source archive with all submodules for releases

### DIFF
--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -16,7 +16,7 @@ jobs:
         echo $(jq --raw-output '.action' $GITHUB_EVENT_PATH)
         echo $(jq --raw-output '.release.upload_url' $GITHUB_EVENT_PATH)
     - name: Create archive
-      run: ./scripts/_git-all-archive.sh -t $GITHUB_REF
+      run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")"
     - name: Upload archive to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
         echo $GITHUB_REF
         AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
         RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
-        FILE="Helics-${GITHUB_REF}.tar.gz"
+        FILE="Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}").tar.gz"
         CONTENT_TYPE="$(file -b --mime-type $FILE)"
         CONTENT_LENGTH="$(stat -c%s "$FILE")"
         UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILE}"

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -21,6 +21,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        echo $GITHUB_REF
         AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
         RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
         FILE="Helics-${GITHUB_REF}.tar.gz"

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -5,7 +5,7 @@ on: release
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.action == "published"
+    if: github.event.action == 'published'
     steps:
     - uses: actions/checkout@v1
     - name: Create archive

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -1,11 +1,11 @@
 name: Release all submodules archive
 
-on: [release]
+on: release
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.action == published
+    if: github.event.action == "published"
     steps:
     - uses: actions/checkout@v1
     - name: Create archive

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -15,3 +15,23 @@ jobs:
       run: |
         echo $(jq --raw-output '.action' $GITHUB_EVENT_PATH)
         echo $(jq --raw-output '.release.upload_url' $GITHUB_EVENT_PATH)
+    - name: Create archive
+      run: ./scripts/_git-all-archive.sh -t $GITHUB_REF
+    - name: Upload archive to release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
+        RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
+        FILE="Helics-${GITHUB_REF}.tar.gz"
+        CONTENT_TYPE="$(file -b --mime-type $FILE)"
+        CONTENT_LENGTH="$(stat -c%s "$FILE")"
+        UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILE}"
+        curl \
+        -sSL \
+        -XPOST \
+        -H "${AUTH_HEADER}" \
+        -H "Content-Length ${CONTENT_LENGTH}" \
+        -H "Content-Type: ${CONTENT_TYPE}" \
+        --upload-file "${FILE}" \
+        "${UPLOAD_URL}"

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -1,0 +1,15 @@
+name: Release all submodules archive
+
+on: [release]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run a multi-line script
+      run: |
+        echo $(jq --raw-output '.action' $GITHUB_EVENT_PATH)
+        echo $(jq --raw-output '.release.upload_url' $GITHUB_EVENT_PATH)

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -4,30 +4,21 @@ on: [release]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
+    if: github.event.action == published
     steps:
     - uses: actions/checkout@v1
-    - name: Event dump
-      run: cat $GITHUB_EVENT_PATH
-    - name: Run a multi-line script
-      run: |
-        echo $(jq --raw-output '.action' $GITHUB_EVENT_PATH)
-        echo $(jq --raw-output '.release.upload_url' $GITHUB_EVENT_PATH)
     - name: Create archive
       run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")"
     - name: Upload archive to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOAD_URL: ${{ github.event.release.upload_url }}
       run: |
-        echo $GITHUB_REF
         AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
-        RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
         FILE="Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}").tar.gz"
         CONTENT_TYPE="$(file -b --mime-type $FILE)"
         CONTENT_LENGTH="$(stat -c%s "$FILE")"
-        UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILE}"
         curl \
         -sSL \
         -XPOST \
@@ -35,4 +26,4 @@ jobs:
         -H "Content-Length ${CONTENT_LENGTH}" \
         -H "Content-Type: ${CONTENT_TYPE}" \
         --upload-file "${FILE}" \
-        "${UPLOAD_URL}"
+        "${UPLOAD_URL%\{*}?name=${FILE}"

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -9,6 +9,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+    - name: Event dump
+      run: cat $GITHUB_EVENT_PATH
     - name: Run a multi-line script
       run: |
         echo $(jq --raw-output '.action' $GITHUB_EVENT_PATH)

--- a/.github/workflows/release-all-submodules-archive.yml
+++ b/.github/workflows/release-all-submodules-archive.yml
@@ -3,14 +3,16 @@ name: Release all submodules archive
 on: release
 
 jobs:
-  build:
+  create-archive:
     runs-on: ubuntu-latest
-    if: github.event.action == 'published'
     steps:
     - uses: actions/checkout@v1
+      if: github.event.action == 'published'
     - name: Create archive
+      if: github.event.action == 'published'
       run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")"
     - name: Upload archive to release
+      if: github.event.action == 'published'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UPLOAD_URL: ${{ github.event.release.upload_url }}
@@ -27,3 +29,4 @@ jobs:
         -H "Content-Type: ${CONTENT_TYPE}" \
         --upload-file "${FILE}" \
         "${UPLOAD_URL%\{*}?name=${FILE}"
+        


### PR DESCRIPTION

### Summary
<!-- please finish the following statement -->
If merged this pull request will add a GitHub Action that runs when a release is published (release + prerelease) to create and upload a source archive with the code for all submodules included.

Example release: https://github.com/nightlark/HELICS/releases/tag/v2.2.0.4

### Proposed changes
- Create separate bash-only and python versions of the git all archive script
- Create archive for the tagged git ref and upload to the published release
