### PR TITLE
Fix an issue with very small periods and large time requested

### DIFF
--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -310,7 +310,7 @@ Time TimeCoordinator::generateAllowedTime (Time testTime) const
         }
         if (testTime - time_grantBase > info.period)
         {
-            auto blk = static_cast<int> (std::ceil ((testTime - time_grantBase) / info.period));
+            auto blk = std::ceil ((testTime - time_grantBase) / info.period);
             testTime = time_grantBase + blk * info.period;
         }
         else

--- a/tests/helics/system_tests/TimingTests2.cpp
+++ b/tests/helics/system_tests/TimingTests2.cpp
@@ -89,6 +89,89 @@ TEST_F (timing_tests2, small_time_test)
     vFed2->finalize ();
 }
 
+/** based on bug found by Manoj Kumar Cebol Sundarrajan
+where a very small period could cause the time to be negative
+*/
+TEST_F (timing_tests2, small_period_test)
+{
+    SetupTest<helics::MessageFederate> ("test", 3);
+    auto rx = GetFederateAs<helics::MessageFederate> (0);
+    rx->setProperty (helics::defs::properties::time_delta, 1.0);
+    rx->setProperty (helics::defs::properties::period, 0.000001);
+    rx->setProperty (helics::defs::properties::offset, 0.0);
+    auto send1 = GetFederateAs<helics::MessageFederate> (1);
+    auto send2 = GetFederateAs<helics::MessageFederate> (2);
+
+    auto &erx = rx->registerEndpoint ("data");
+    auto &s1 = send1->registerEndpoint ("data");
+    auto &s2 = send2->registerEndpoint ("data");
+
+    int cnt = 0;
+    int cmess = 0;
+    auto rxrun = [rx, &erx, &cnt, &cmess] () {
+        rx->enterExecutingMode ();
+        helics::Time maxtime = 1e9;
+        helics::Time ctime = -1;
+        while (ctime < maxtime)
+        {
+            ctime = rx->requestTime (maxtime);
+            // std::cout << "receiver: granted time " << static_cast<double> (ctime) << std::endl;
+            ++cnt;
+            while (erx.hasMessage ())
+            {
+                auto m = erx.getMessage ();
+                // std::cout << "receiver: message from " << m->source << " with data " << m->data.to_string ()
+                //           << std::endl;
+                ++cmess;
+            }
+            if (cnt > 300)
+            {
+                break;
+            }
+        }
+        rx->finalize ();
+    };
+    auto send1run = [send1, &s1] () {
+        send1->enterExecutingMode ();
+        helics::Time maxtime = 1e6;
+        helics::Time ctime = helics::timeZero;
+        while (ctime <= 10.0)
+        {
+            ctime += 1.0;
+            ctime = send1->requestTime (ctime);
+            std::this_thread::sleep_for (std::chrono::milliseconds (10));
+            //   std::cout << "sender1: sending message at time " << static_cast<double> (ctime) << std::endl;
+            s1.send ("fed0/data", "3.14");
+        }
+        send1->finalize ();
+    };
+
+    auto send2run = [send2, &s2] () {
+        send2->enterExecutingMode ();
+        helics::Time maxtime = 1e6;
+        helics::Time ctime = helics::timeZero;
+        while (ctime <= 10.0)
+        {
+            ctime += 1.0;
+            ctime = send2->requestTime (ctime);
+            std::this_thread::sleep_for (std::chrono::milliseconds (20));
+            // std::cout << "sender2: sending message at time " << static_cast<double> (ctime) << std::endl;
+            s2.send ("fed0/data", "3.14");
+        }
+        send2->finalize ();
+    };
+
+    auto futrx = std::async (std::launch::async, rxrun);
+    auto futs1 = std::async (std::launch::async, send1run);
+    auto futs2 = std::async (std::launch::async, send2run);
+
+    futs1.get ();
+    futs2.get ();
+    futrx.get ();
+    EXPECT_EQ (cnt, 12);
+    EXPECT_EQ (cmess, 22);
+}
+
 /** this test requires a major change to the timing subsystem
 TEST_F(timing_tests2,ring_test3)
 {


### PR DESCRIPTION
generating negative times on overflow.  This fix will resolve it for the time being but some changes are needed in the timeRepresentation to completely resolve it.  This fix just makes it significantly harder to generate the bug.  like (2^24X harder) in numerical terms.

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will fix an issue with small periods and large time request generating an int overflow.  

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add a test of this situation
- change the int and leave it as a double so it can't overflow.  longer term fix is to make some changes in the timeRepresentation library to handle int64 multiplies better.  
