### PR TITLE
Update

### DIFF
--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -283,7 +283,7 @@ extern "C"
     @param[out] actualSize  the actual length of data copied to data
     @param[in,out] err a pointer to an error object for catching errors
     */
-    HELICS_EXPORT void helicsMessageGetRawData (helics_message_object message, void *data, int maxlen, int *actualSize, helics_error *err);
+    HELICS_EXPORT void helicsMessageGetRawData (helics_message_object message, void *data, int maxMessagelen, int *actualSize, helics_error *err);
 
     /** get a pointer to the raw data of a message
     @param message a message object to get the data for


### PR DESCRIPTION
Make helicsMessageGetRawData() declaration arguments to match definition arguments.

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123--> This fixes issue #832 
### Summary
<!-- please finish the following statement -->
If merged this pull request will remove the following error when extracting the data from helics_message_object using helicsMessageGetRawData().
````
Traceback (most recent call last):
  File "receiver.py", line 14, in <module>
    data = h.helicsMessageGetRawData(message)
TypeError: helicsMessageGetRawData() missing 2 required positional arguments: 'data' and 'maxlen'
```` 

### Proposed changes
Make the arguments of helicsMessageGetRawData() function declation and definition equal.

