### PR TITLE
Get XCode 8.3 building again on Travis

### DIFF
--- a/.ci/Brewfile-minimal.travis
+++ b/.ci/Brewfile-minimal.travis
@@ -1,0 +1,3 @@
+brew "ccache"
+brew "cmake"
+brew "zeromq"

--- a/.ci/Brewfile.travis
+++ b/.ci/Brewfile.travis
@@ -1,2 +1,3 @@
+brew "ccache"
 brew "cmake"
 brew "zeromq"

--- a/.ci/Brewfile.travis
+++ b/.ci/Brewfile.travis
@@ -1,4 +1,3 @@
 brew "cmake"
 brew "swig"
 brew "zeromq"
-brew "boost"

--- a/.ci/Brewfile.travis
+++ b/.ci/Brewfile.travis
@@ -1,4 +1,3 @@
-brew "ccache"
 brew "cmake"
 brew "swig"
 brew "zeromq"

--- a/.ci/Brewfile.travis
+++ b/.ci/Brewfile.travis
@@ -1,6 +1,5 @@
-brew "pcre"
 brew "ccache"
 brew "cmake"
 brew "swig"
 brew "zeromq"
-brew "boost@1.69"
+brew "boost"

--- a/.ci/Brewfile.travis
+++ b/.ci/Brewfile.travis
@@ -1,3 +1,4 @@
 brew "ccache"
 brew "cmake"
+brew "swig"
 brew "zeromq"

--- a/.ci/Brewfile.travis
+++ b/.ci/Brewfile.travis
@@ -1,3 +1,2 @@
 brew "cmake"
-brew "swig"
 brew "zeromq"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,14 +64,14 @@ jobs:
         - HOMEBREW_NO_AUTO_UPDATE=1
       osx_image: xcode10.2
 
-    # XCode 9.2, OS X 10.12
+    # XCode 9.4, OS X 10.13
     - <<: *osx_base
-      name: "XCode 9.2, macOS 10.12"
+      name: "XCode 9.4, macOS 10.13"
       #if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
       env:
-        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=92"
+        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=94"
         - HOMEBREW_NO_AUTO_UPDATE=1
-      osx_image: xcode9.2
+      osx_image: xcode9.4
 
     - <<: *linux_base
       name: "GCC 6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,14 +64,14 @@ jobs:
         - HOMEBREW_NO_AUTO_UPDATE=1
       osx_image: xcode10.2
 
-    # XCode 8.3, OS X 10.12
+    # XCode 9.2, OS X 10.12
     - <<: *osx_base
-      name: "XCode 8.3, macOS 10.12"
+      name: "XCode 9.2, macOS 10.12"
       if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
       env:
-        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
+        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=92"
         - HOMEBREW_NO_AUTO_UPDATE=1
-      osx_image: xcode8.3
+      osx_image: xcode9.2
 
     - <<: *linux_base
       name: "GCC 6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,10 @@ jobs:
         - HOMEBREW_NO_AUTO_UPDATE=1
         - USE_SWIG=false
       osx_image: xcode8.3
+      addons:
+        homebrew:
+          brewfile: .ci/Brewfile-minimal.travis
+          update: true
 
     - <<: *linux_base
       name: "GCC 6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
     # XCode 8.3, OS X 10.12
     - <<: *osx_base
       name: "XCode 8.3, macOS 10.12"
-      #if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
+      if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ jobs:
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1
+        - USE_SWIG=false
         - JOB_OPTION_FLAGS="-DBUILD_HELICS_BOOST_TESTS=OFF -DDISABLE_BOOST=ON"
       osx_image: xcode8.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
     # XCode 9.2, OS X 10.12
     - <<: *osx_base
       name: "XCode 9.2, macOS 10.12"
-      if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
+      #if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=92"
         - HOMEBREW_NO_AUTO_UPDATE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,14 +64,14 @@ jobs:
         - HOMEBREW_NO_AUTO_UPDATE=1
       osx_image: xcode10.2
 
-    # XCode 9.4, OS X 10.13
+    # XCode 8.3, OS X 10.12
     - <<: *osx_base
-      name: "XCode 9.4, macOS 10.13"
+      name: "XCode 8.3, macOS 10.12"
       #if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
       env:
-        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=94"
+        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1
-      osx_image: xcode9.4
+      osx_image: xcode8.3
 
     - <<: *linux_base
       name: "GCC 6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1
-        - JOB_OPTION_FLAGS="-DBUILD_HELICS_BOOST_TESTS=OFF"
+        - JOB_OPTION_FLAGS="-DBUILD_HELICS_BOOST_TESTS=OFF -DDISABLE_BOOST=ON"
       osx_image: xcode8.3
 
     - <<: *linux_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ jobs:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1
         - USE_SWIG=false
-        - JOB_OPTION_FLAGS="-DBUILD_HELICS_BOOST_TESTS=OFF -DDISABLE_BOOST=ON"
       osx_image: xcode8.3
 
     - <<: *linux_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ jobs:
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=83"
         - HOMEBREW_NO_AUTO_UPDATE=1
+        - JOB_OPTION_FLAGS="-DBUILD_HELICS_BOOST_TESTS=OFF"
       osx_image: xcode8.3
 
     - <<: *linux_base


### PR DESCRIPTION

### Summary

If merged this pull request will get the XCode 8.3 build passing again on Travis. Build results: https://travis-ci.com/GMLC-TDC/HELICS/builds/130787542

### Proposed changes

- Separate XCode 8.3 build brewfile from the brewfile used for newer macOS versions
- Removes Boost from the Travis brewfiles; version installed on the VMs is new enough
- Remove swig and pcre from the Travis brewfile used for the XCode 8.3 build
