### PR TITLE
Spurious removal failure

### DIFF
--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -265,7 +265,7 @@ FederateState *CommonCore::getFederate (const std::string &federateName) const
 
 FederateState *CommonCore::getHandleFederate (interface_handle handle)
 {
-    auto local_fed_id = handles.read ([handle](auto &hand) { return hand.getLocalFedID (handle); });
+    auto local_fed_id = handles.read ([handle] (auto &hand) { return hand.getLocalFedID (handle); });
     if (local_fed_id.isValid ())
     {
         auto feds = federates.lock ();
@@ -289,7 +289,7 @@ FederateState *CommonCore::getFederateCore (const std::string &federateName)
 
 FederateState *CommonCore::getHandleFederateCore (interface_handle handle)
 {
-    auto local_fed_id = handles.read ([handle](auto &hand) { return hand.getLocalFedID (handle); });
+    auto local_fed_id = handles.read ([handle] (auto &hand) { return hand.getLocalFedID (handle); });
     if (local_fed_id.isValid ())
     {
         return loopFederates[local_fed_id.baseValue ()].fed;
@@ -300,12 +300,12 @@ FederateState *CommonCore::getHandleFederateCore (interface_handle handle)
 
 const BasicHandleInfo *CommonCore::getHandleInfo (interface_handle handle) const
 {
-    return handles.read ([handle](auto &hand) { return hand.getHandleInfo (handle.baseValue ()); });
+    return handles.read ([handle] (auto &hand) { return hand.getHandleInfo (handle.baseValue ()); });
 }
 
 const BasicHandleInfo *CommonCore::getLocalEndpoint (const std::string &name) const
 {
-    return handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
+    return handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
 }
 
 bool CommonCore::isLocal (global_federate_id global_fedid) const
@@ -372,7 +372,7 @@ bool CommonCore::allInitReady () const
     }
     // all federates must be requesting init
     return std::all_of (loopFederates.begin (), loopFederates.end (),
-                        [](const auto &fed) { return fed->init_transmitted.load (); });
+                        [] (const auto &fed) { return fed->init_transmitted.load (); });
 }
 
 bool CommonCore::allDisconnected () const
@@ -389,7 +389,7 @@ bool CommonCore::allDisconnected () const
 bool CommonCore::allFedDisconnected () const
 {
     // all federates must have hit finished state
-    auto pred = [](const auto &fed) { return fed.disconnected; };
+    auto pred = [] (const auto &fed) { return fed.disconnected; };
     return std::all_of (loopFederates.begin (), loopFederates.end (), pred);
 }
 
@@ -526,7 +526,7 @@ local_federate_id CommonCore::registerFederate (const std::string &name, const C
     // setting up the Logger
     // auto ptr = fed.get();
     // if we are using the Logger, log all messages coming from the federates so they can control the level*/
-    fed->setLogger ([this](int /*level*/, const std::string &ident, const std::string &message) {
+    fed->setLogger ([this] (int /*level*/, const std::string &ident, const std::string &message) {
         sendToLogger (parent_broker_id, log_level::error - 2, ident, message);
     });
 
@@ -809,7 +809,7 @@ const BasicHandleInfo &CommonCore::createBasicHandle (global_federate_id global_
                                                       const std::string &units,
                                                       uint16_t flags)
 {
-    return handles.modify ([&](auto &hand) -> const BasicHandleInfo & {
+    return handles.modify ([&] (auto &hand) -> const BasicHandleInfo & {
         auto &hndl = hand.addHandle (global_federateId, HandleType, key, type, units);
         hndl.local_fed_id = local_federateId;
         hndl.flags = flags;
@@ -829,7 +829,7 @@ interface_handle CommonCore::registerInput (local_federate_id federateID,
     {
         throw (InvalidIdentifier ("federateID not valid (registerNamedInput)"));
     }
-    auto ci = handles.read ([&key](auto &hand) { return hand.getInput (key); });
+    auto ci = handles.read ([&key] (auto &hand) { return hand.getInput (key); });
     if (ci != nullptr)  // this key is already found
     {
         throw (RegistrationFailure ("named Input already exists"));
@@ -854,7 +854,7 @@ interface_handle CommonCore::registerInput (local_federate_id federateID,
 
 interface_handle CommonCore::getInput (local_federate_id federateID, const std::string &key) const
 {
-    auto ci = handles.read ([&key](auto &hand) { return hand.getInput (key); });
+    auto ci = handles.read ([&key] (auto &hand) { return hand.getInput (key); });
     if (ci->local_fed_id != federateID)
     {
         return {};
@@ -873,7 +873,7 @@ interface_handle CommonCore::registerPublication (local_federate_id federateID,
         throw (InvalidIdentifier ("federateID not valid (registerPublication)"));
     }
     LOG_INTERFACES (parent_broker_id, fed->getIdentifier (), fmt::format ("registering PUB {}", key));
-    auto pub = handles.read ([&key](auto &hand) { return hand.getPublication (key); });
+    auto pub = handles.read ([&key] (auto &hand) { return hand.getPublication (key); });
     if (pub != nullptr)  // this key is already found
     {
         throw (RegistrationFailure ("Publication key already exists"));
@@ -897,7 +897,7 @@ interface_handle CommonCore::registerPublication (local_federate_id federateID,
 
 interface_handle CommonCore::getPublication (local_federate_id federateID, const std::string &key) const
 {
-    auto pub = handles.read ([&key](auto &hand) { return hand.getPublication (key); });
+    auto pub = handles.read ([&key] (auto &hand) { return hand.getPublication (key); });
     if (pub->local_fed_id != federateID)
     {
         return interface_handle ();
@@ -1022,7 +1022,7 @@ void CommonCore::setHandleOption (interface_handle handle, int32_t option, bool 
         return;
     }
     handles.modify (
-      [handle, option, option_value](auto &hand) { return hand.setHandleOption (handle, option, option_value); });
+      [handle, option, option_value] (auto &hand) { return hand.setHandleOption (handle, option, option_value); });
 
     ActionMessage fcn (CMD_INTERFACE_CONFIGURE);
     fcn.dest_handle = handle;
@@ -1059,7 +1059,7 @@ bool CommonCore::getHandleOption (interface_handle handle, int32_t option) const
     {
     case defs::options::connection_required:
     case defs::options::connection_optional:
-        return handles.read ([handle, option](auto &hand) { return hand.getHandleOption (handle, option); });
+        return handles.read ([handle, option] (auto &hand) { return hand.getHandleOption (handle, option); });
     default:
         break;
     }
@@ -1093,7 +1093,7 @@ void CommonCore::closeHandle (interface_handle handle)
     cmd.setSource (handleInfo->handle);
     cmd.messageID = static_cast<int32_t> (handleInfo->handleType);
     addActionMessage (cmd);
-    handles.modify ([handle](auto &hand) { setActionFlag (*hand.getHandleInfo (handle), disconnected_flag); });
+    handles.modify ([handle] (auto &hand) { setActionFlag (*hand.getHandleInfo (handle), disconnected_flag); });
 }
 
 void CommonCore::removeTarget (interface_handle handle, const std::string &targetToRemove)
@@ -1335,7 +1335,7 @@ CommonCore::registerEndpoint (local_federate_id federateID, const std::string &n
     {
         throw (InvalidIdentifier ("federateID not valid (registerEndpoint)"));
     }
-    auto ept = handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
+    auto ept = handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
     if (ept != nullptr)
     {
         throw (RegistrationFailure ("endpoint name is already used"));
@@ -1358,7 +1358,7 @@ CommonCore::registerEndpoint (local_federate_id federateID, const std::string &n
 
 interface_handle CommonCore::getEndpoint (local_federate_id federateID, const std::string &name) const
 {
-    auto ept = handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
+    auto ept = handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
     if (ept->local_fed_id != federateID)
     {
         return interface_handle ();
@@ -1372,7 +1372,7 @@ CommonCore::registerFilter (const std::string &filterName, const std::string &ty
     // check to make sure the name isn't already used
     if (!filterName.empty ())
     {
-        if (handles.read ([&filterName](auto &hand) {
+        if (handles.read ([&filterName] (auto &hand) {
                 auto *res = hand.getFilter (filterName);
                 return (res != nullptr);
             }))
@@ -1413,7 +1413,7 @@ interface_handle CommonCore::registerCloningFilter (const std::string &filterNam
     // check to make sure the name isn't already used
     if (!filterName.empty ())
     {
-        if (handles.read ([&filterName](auto &hand) {
+        if (handles.read ([&filterName] (auto &hand) {
                 auto *res = hand.getFilter (filterName);
                 return (res != nullptr);
             }))
@@ -1451,7 +1451,7 @@ interface_handle CommonCore::registerCloningFilter (const std::string &filterNam
 
 interface_handle CommonCore::getFilter (const std::string &name) const
 {
-    auto filt = handles.read ([&name](auto &hand) { return hand.getFilter (name); });
+    auto filt = handles.read ([&name] (auto &hand) { return hand.getFilter (name); });
     if ((filt != nullptr) && (filt->handleType == handle_type::filter))
     {
         return filt->getInterfaceHandle ();
@@ -1860,7 +1860,7 @@ void CommonCore::setLogFile (const std::string &lfile) { setLoggingFile (lfile);
 
 void CommonCore::setLoggingCallback (
   local_federate_id federateID,
-  std::function<void(int, const std::string &, const std::string &)> logFunction)
+  std::function<void (int, const std::string &, const std::string &)> logFunction)
 {
     if (federateID == local_core_id)
     {
@@ -2009,31 +2009,29 @@ std::string CommonCore::coreQuery (const std::string &queryStr) const
 {
     if (queryStr == "federates")
     {
-        return generateStringVector (loopFederates, [](const auto &fed) { return fed->getIdentifier (); });
+        return generateStringVector (loopFederates, [] (const auto &fed) { return fed->getIdentifier (); });
     }
     if (queryStr == "publications")
     {
-        return generateStringVector_if (loopHandles, [](const auto &handle) { return handle.key; },
-                                        [](const auto &handle) {
-                                            return (handle.handleType == handle_type::publication);
-                                        });
+        return generateStringVector_if (
+          loopHandles, [] (const auto &handle) { return handle.key; },
+          [] (const auto &handle) { return (handle.handleType == handle_type::publication); });
     }
     if (queryStr == "endpoints")
     {
-        return generateStringVector_if (loopHandles, [](const auto &handle) { return handle.key; },
-                                        [](const auto &handle) {
-                                            return (handle.handleType == handle_type::endpoint);
-                                        });
+        return generateStringVector_if (
+          loopHandles, [] (const auto &handle) { return handle.key; },
+          [] (const auto &handle) { return (handle.handleType == handle_type::endpoint); });
     }
     if (queryStr == "dependson")
     {
         return generateStringVector (timeCoord->getDependencies (),
-                                     [](auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [] (auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (queryStr == "dependents")
     {
         return generateStringVector (timeCoord->getDependents (),
-                                     [](auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [] (auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (queryStr == "isinit")
     {
@@ -2572,7 +2570,7 @@ void CommonCore::processCommand (ActionMessage &&command)
     case CMD_CHECK_CONNECTIONS:
     {
         auto res = checkAndProcessDisconnect ();
-        auto pred = [](const auto &fed) {
+        auto pred = [] (const auto &fed) {
             auto state = fed->getState ();
             return (HELICS_FINISHED == state) || (HELICS_ERROR == state);
         };
@@ -2974,7 +2972,7 @@ void CommonCore::registerInterface (ActionMessage &command)
     {
         auto handle = command.source_handle;
         auto &lH = loopHandles;
-        handles.read ([handle, &lH](auto &hand) {
+        handles.read ([handle, &lH] (auto &hand) {
             auto ifc = hand.getHandleInfo (handle.baseValue ());
             if (ifc != nullptr)
             {
@@ -3071,7 +3069,7 @@ void CommonCore::setAsUsed (BasicHandleInfo *hand)
         return;
     }
     hand->used = true;
-    handles.modify ([&](auto &handle) { handle.getHandleInfo (hand->handle.handle)->used = true; });
+    handles.modify ([&] (auto &handle) { handle.getHandleInfo (hand->handle.handle)->used = true; });
 }
 void CommonCore::checkForNamedInterface (ActionMessage &command)
 {
@@ -3107,7 +3105,7 @@ void CommonCore::checkForNamedInterface (ActionMessage &command)
     break;
     case CMD_ADD_NAMED_INPUT:
     {
-        auto inputName = std::move(command.name);
+        auto inputName = command.name;
         auto inp = loopHandles.getInput (inputName);
         if (inp != nullptr)
         {
@@ -3782,7 +3780,7 @@ void CommonCore::processCoreConfigureCommands (ActionMessage &cmd)
             auto op = dataAirlocks[cmd.counter].try_unload ();
             if (op)
             {
-                auto M = stx::any_cast<std::function<void(int, const std::string &, const std::string &)>> (
+                auto M = stx::any_cast<std::function<void (int, const std::string &, const std::string &)>> (
                   std::move (*op));
                 setLoggerFunction (std::move (M));
             }
@@ -4474,6 +4472,6 @@ const std::string &CommonCore::getInterfaceInfo (interface_handle handle) const
 
 void CommonCore::setInterfaceInfo (helics::interface_handle handle, std::string info)
 {
-    handles.modify ([&](auto &hdls) { hdls.getHandleInfo (handle.baseValue ())->interface_info = info; });
+    handles.modify ([&] (auto &hdls) { hdls.getHandleInfo (handle.baseValue ())->interface_info = info; });
 }
 }  // namespace helics

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -1347,6 +1347,7 @@ void CoreBroker::checkForNamedInterface (ActionMessage &command)
                 routeMessage (command);
                 command.setAction (CMD_ADD_PUBLISHER);
                 command.swapSourceDest ();
+                command.name = pub->key;
                 command.setStringData (pub->type, pub->units);
                 routeMessage (command);
             }
@@ -1383,6 +1384,7 @@ void CoreBroker::checkForNamedInterface (ActionMessage &command)
                 command.setAction (CMD_ADD_SUBSCRIBER);
                 command.swapSourceDest ();
                 command.clearStringData ();
+                command.name = inp->key;
                 routeMessage (command);
             }
             else

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1235,7 +1235,7 @@ message_processing_result FederateState::processActionMessage (ActionMessage &cm
         auto subI = interfaceInformation.getInput (cmd.dest_handle);
         if (subI != nullptr)
         {
-            subI->addSource (cmd.getSource (), cmd.getString (typeStringLoc), cmd.getString (unitStringLoc));
+            subI->addSource (cmd.getSource (), cmd.name, cmd.getString (typeStringLoc), cmd.getString (unitStringLoc));
             addDependency (cmd.source_id);
         }
     }
@@ -1262,6 +1262,15 @@ message_processing_result FederateState::processActionMessage (ActionMessage &cm
         }
 
         break;
+    case CMD_REMOVE_NAMED_PUBLICATION:
+    {
+        auto subI = interfaceInformation.getInput (cmd.source_handle);
+        if (subI != nullptr)
+        {
+            subI->removeSource (cmd.name, (cmd.actionTime != timeZero) ? cmd.actionTime : time_granted);
+        }
+        break;
+    }
     case CMD_REMOVE_PUBLICATION:
     {
         auto subI = interfaceInformation.getInput (cmd.dest_handle);

--- a/src/helics/core/InterfaceInfo.cpp
+++ b/src/helics/core/InterfaceInfo.cpp
@@ -279,21 +279,21 @@ std::vector<std::pair<int, std::string>> InterfaceInfo::checkInterfacesForIssues
                   fmt::format ("Input {} is single source only but has more than one connection", ipt->key));
             }
         }
-        for (auto &source : ipt->source_types)
+        for (auto &source : ipt->source_info)
         {
-            if (!checkTypeMatch (ipt->type, source.first, ipt->strict_type_matching))
+            if (!checkTypeMatch (ipt->type, std::get<1>(source), ipt->strict_type_matching))
             {
                 issues.emplace_back (
                   helics::defs::errors::connection_failure,
                   fmt::format ("Input \"{}\" source has mismatched types: {} is not compatible with {}", ipt->key,
-                               ipt->type, source.first));
+                               ipt->type, std::get<1> (source)));
             }
-            if ((!ipt->ignore_unit_mismatch) && (!checkUnitMatch (ipt->units, source.second, false)))
+            if ((!ipt->ignore_unit_mismatch) && (!checkUnitMatch (ipt->units, std::get<2> (source), false)))
             {
                 issues.emplace_back (
                   helics::defs::errors::connection_failure,
                   fmt::format ("Input \"{}\" source has incompatible unit: {} is not convertible to {}", ipt->key,
-                               source.second, ipt->units));
+                               std::get<2> (source), ipt->units));
             }
         }
     }

--- a/src/helics/core/NamedInputInfo.cpp
+++ b/src/helics/core/NamedInputInfo.cpp
@@ -92,7 +92,7 @@ void NamedInputInfo::addData (global_handle source_id,
     }
 }
 
-void NamedInputInfo::addSource (global_handle newSource, const std::string &stype, const std::string &sunits)
+void NamedInputInfo::addSource (global_handle newSource, const std::string &sourceName, const std::string &stype, const std::string &sunits)
 {
     if (input_sources.empty ())
     {
@@ -100,7 +100,7 @@ void NamedInputInfo::addSource (global_handle newSource, const std::string &styp
         inputUnits = sunits;
     }
     input_sources.push_back (newSource);
-    source_types.emplace_back (stype, sunits);
+    source_info.emplace_back (sourceName, stype, sunits);
     data_queues.resize (input_sources.size ());
     current_data.resize (input_sources.size ());
     deactivated.push_back (Time::maxVal ());
@@ -117,7 +117,29 @@ void NamedInputInfo::removeSource (global_handle sourceToRemove, Time minTime)
             {
                 data_queues[ii].pop_back ();
             }
-            deactivated[ii] = minTime;
+            if (minTime < deactivated[ii])
+            {
+                deactivated[ii] = minTime;
+            }
+        }
+        // there could be duplicate sources so we need to do the full loop
+    }
+}
+
+void NamedInputInfo::removeSource (const std::string &sourceName, Time minTime)
+{
+    for (size_t ii = 0; ii < source_info.size (); ++ii)
+    {
+        if (std::get<0>(source_info[ii]) == sourceName)
+        {
+            while ((!data_queues[ii].empty ()) && (data_queues[ii].back ().time > minTime))
+            {
+                data_queues[ii].pop_back ();
+            }
+            if (minTime < deactivated[ii])
+            {
+                deactivated[ii] = minTime;
+            }
         }
         // there could be duplicate sources so we need to do the full loop
     }

--- a/src/helics/core/NamedInputInfo.hpp
+++ b/src/helics/core/NamedInputInfo.hpp
@@ -8,7 +8,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "basic_core_types.hpp"
 
-#include <utility>
+#include <tuple>
 #include <vector>
 
 namespace helics
@@ -61,7 +61,7 @@ class NamedInputInfo
     std::vector<dataRecord> current_data;  //!< the most recent published data
     std::vector<global_handle> input_sources;  //!< the sources of the input signals
     std::vector<Time> deactivated;
-    std::vector<std::pair<std::string, std::string>> source_types;  //!< the type and units of the sources
+    std::vector<std::tuple<std::string, std::string,std::string>> source_info;  //!< the name,type,units of the sources
   private:
     std::vector<std::vector<dataRecord>> data_queues;  //!< queue of the data
 
@@ -97,9 +97,11 @@ class NamedInputInfo
     /** get the event based on the event queue*/
     Time nextValueTime () const;
     /** add a new source target to the input*/
-    void addSource (global_handle newSource, const std::string &stype, const std::string &sunits);
+    void addSource (global_handle newSource,const std::string &sourceName, const std::string &stype, const std::string &sunits);
     /** remove a source */
     void removeSource (global_handle sourceToRemove, Time minTime);
+    /** remove a source */
+    void removeSource (const std::string &sourceName, Time minTime);
     /** clear all non-current data*/
     void clearFutureData ();
 

--- a/tests/helics/core/InfoClass-tests.cpp
+++ b/tests/helics/core/InfoClass-tests.cpp
@@ -273,7 +273,7 @@ TEST (InfoClass_tests, inputinfo_test)
     EXPECT_EQ (subI.required, false);
 
     helics::global_handle testHandle (helics::global_federate_id (5), helics::interface_handle (45));
-    subI.addSource (testHandle, "double", std::string ());
+    subI.addSource (testHandle, "","double", std::string ());
     // No data available, shouldn't get a data_block back
     ret_data = subI.getData (0);
     EXPECT_TRUE (!ret_data);


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will fix the spurious "remove target" failure with CI builds

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add a test which forced the failure
- fix the failure by storing the target name directly and then removing it inline with the other federate messages,  
- make sure the appropriate message information propagates through the to the correct destinations
- allow double removal which can happen now.  
