### PR TITLE
Add timeout test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ A note on future revisions.
 Bug fix release
 
 ### Fixed
--  links in the README changed with an automated move to travis-ci.com
--  Issue #853,  which was causing core connections to timeout if no direct communication was observed for a period of time.  This bug fix release fixes that issue where the pings were not being correctly accounted for in the timeout detection. 
+-  Links in the README changed with an automated move to travis-ci.com
+-  Fix issue #853, which was causing core connections to timeout if no direct communication was observed for a period of time.  This bug fix release fixes that issue where the pings were not being correctly accounted for in the timeout detection. 
 - Fix Ctrl-C issue when using HELICS in some language api's
 
 ## \[2.2.1\] ~ 2019-09-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 A note on future revisions.  
   Everything within a major version number should be code compatible (with the exception of experimental interfaces).  The most notable example of an experimental interface is the support for multiple source inputs.  The APIs to deal with this will change in future minor releases.  Everything within a single minor release should be network compatible with other federates on the same minor release number.  Compatibility across minor release numbers may be possible in some situations but we are not going to guarantee this as those components are subject to performance improvements and may need to be modified at some point.  Patch releases will be limited to bug fixes and other improvements not impacting the public API or network compatibility.  Check the [Public API](./docs/Public_API.md) for details on what is included and excluded from the public API and version stability.
+## \[2.2.2\] ~ 2019-10-27
+Bug fix release
+
+### Fixed
+-  links in the README changed with an automated move to travis-ci.com
+-  Issue #853,  which was causing core connections to timeout if no direct communication was observed for a period of time.  This bug fix release fixes that issue where the pings were not being correctly accounted for in the timeout detection. 
+- Fix Ctrl-C issue when using HELICS in some language api's
 
 ## \[2.2.1\] ~ 2019-09-27
 Minor release with bug fixes and a few additional features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@
 cmake_minimum_required(VERSION 3.4)
 cmake_policy(VERSION 3.4)
 
-project(HELICS VERSION 2.2.1)
+project(HELICS VERSION 2.2.2)
 
 # -----------------------------------------------------------------------------
 # HELICS Version number
 # -----------------------------------------------------------------------------
 set(HELICS_VERSION_BUILD)
-set(HELICS_DATE "09-27-19")
+set(HELICS_DATE "10-27-19")
 
 set(
     HELICS_VERSION_UNDERSCORE

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
   </tr>
   <tr>
   <td>Travis CI</td>
-  <td><a href="https://travis-ci.org/GMLC-TDC/HELICS"><img src="https://travis-ci.org/GMLC-TDC/HELICS.svg?branch=master" alt="Build Status" /></a></td>
-  <td><a href="https://travis-ci.org/GMLC-TDC/HELICS"><img src="https://travis-ci.org/GMLC-TDC/HELICS.svg?branch=develop" alt="Build Status" /></a></td>
+  <td><a href="https://travis-ci.com/GMLC-TDC/HELICS"><img src="https://travis-ci.com/GMLC-TDC/HELICS.svg?branch=master" alt="Build Status" /></a></td>
+  <td><a href="https://travis-ci.com/GMLC-TDC/HELICS"><img src="https://travis-ci.com/GMLC-TDC/HELICS.svg?branch=develop" alt="Build Status" /></a></td>
   </tr>
   <tr>
   <td>Appveyor</td>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 clone_depth: 1
 
-version: 2.2.1.{build}
+version: 2.2.2.{build}
 
 image: Visual Studio 2015
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,13 +4,23 @@
 This document contains tentative plans for changes and improvements of note in upcoming versions of the HELICS library.  All dates are approximate and subject to change, but this is a snapshot of the current planning thoughts. See the [projects](https://github.com/GMLC-TDC/HELICS/projects) for additional details
 
 
-## \[2.3\] ~ 2019-10-31
+## \[2.3\] ~ 2019-11-10
 
 -   See [HELICS 2.3](https://github.com/GMLC-TDC/HELICS/projects/15) for up to date information
 -   All features and dates here are tentative and subject to change
 
 ### Features and Improvements
+-   Additional unit tests and more porting to google tests
+-   modernization and cleanup of the HELICS cmake build system
+-   bug fixes
+-   construct a C++ shared library with the public API for helics that is more usable and restricted to the public interface
+-   additional CI builds
+-   library updates
+-   Benchmark tests
+-   automated generation of some parts of the code
 
+
+## \[2.4\] ~ Winter 2019-2020
 -   Network reliability related improvements
 -   Some additional logging capabilities
 -   Multi-broker to allow multiple communication cores to be connected in the same federation(possible)
@@ -18,10 +28,7 @@ This document contains tentative plans for changes and improvements of note in u
 -   Additional package manager integration
 -   Performance improvements and tests
 -   messageObject callbacks into the C library
--   Additional unit tests and more porting to google tests
 -   Separate out networking library
-
-## \[2.4\] ~ Winter 2019-2020
 -   Single thread cores
 -   Debugging tools
 -   SSL capable core

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -35,6 +35,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 namespace helics
 {
+// timeoutMon is a unique_ptr
 CommonCore::CommonCore () noexcept : timeoutMon (new TimeoutMonitor) {}
 
 CommonCore::CommonCore (bool /*arg*/) noexcept : timeoutMon (new TimeoutMonitor) {}
@@ -265,7 +266,7 @@ FederateState *CommonCore::getFederate (const std::string &federateName) const
 
 FederateState *CommonCore::getHandleFederate (interface_handle handle)
 {
-    auto local_fed_id = handles.read ([handle](auto &hand) { return hand.getLocalFedID (handle); });
+    auto local_fed_id = handles.read ([handle] (auto &hand) { return hand.getLocalFedID (handle); });
     if (local_fed_id.isValid ())
     {
         auto feds = federates.lock ();
@@ -289,7 +290,7 @@ FederateState *CommonCore::getFederateCore (const std::string &federateName)
 
 FederateState *CommonCore::getHandleFederateCore (interface_handle handle)
 {
-    auto local_fed_id = handles.read ([handle](auto &hand) { return hand.getLocalFedID (handle); });
+    auto local_fed_id = handles.read ([handle] (auto &hand) { return hand.getLocalFedID (handle); });
     if (local_fed_id.isValid ())
     {
         return loopFederates[local_fed_id.baseValue ()].fed;
@@ -300,12 +301,12 @@ FederateState *CommonCore::getHandleFederateCore (interface_handle handle)
 
 const BasicHandleInfo *CommonCore::getHandleInfo (interface_handle handle) const
 {
-    return handles.read ([handle](auto &hand) { return hand.getHandleInfo (handle.baseValue ()); });
+    return handles.read ([handle] (auto &hand) { return hand.getHandleInfo (handle.baseValue ()); });
 }
 
 const BasicHandleInfo *CommonCore::getLocalEndpoint (const std::string &name) const
 {
-    return handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
+    return handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
 }
 
 bool CommonCore::isLocal (global_federate_id global_fedid) const
@@ -372,7 +373,7 @@ bool CommonCore::allInitReady () const
     }
     // all federates must be requesting init
     return std::all_of (loopFederates.begin (), loopFederates.end (),
-                        [](const auto &fed) { return fed->init_transmitted.load (); });
+                        [] (const auto &fed) { return fed->init_transmitted.load (); });
 }
 
 bool CommonCore::allDisconnected () const
@@ -389,7 +390,7 @@ bool CommonCore::allDisconnected () const
 bool CommonCore::allFedDisconnected () const
 {
     // all federates must have hit finished state
-    auto pred = [](const auto &fed) { return fed.disconnected; };
+    auto pred = [] (const auto &fed) { return fed.disconnected; };
     return std::all_of (loopFederates.begin (), loopFederates.end (), pred);
 }
 
@@ -526,7 +527,7 @@ local_federate_id CommonCore::registerFederate (const std::string &name, const C
     // setting up the Logger
     // auto ptr = fed.get();
     // if we are using the Logger, log all messages coming from the federates so they can control the level*/
-    fed->setLogger ([this](int /*level*/, const std::string &ident, const std::string &message) {
+    fed->setLogger ([this] (int /*level*/, const std::string &ident, const std::string &message) {
         sendToLogger (parent_broker_id, log_level::error - 2, ident, message);
     });
 
@@ -809,7 +810,7 @@ const BasicHandleInfo &CommonCore::createBasicHandle (global_federate_id global_
                                                       const std::string &units,
                                                       uint16_t flags)
 {
-    return handles.modify ([&](auto &hand) -> const BasicHandleInfo & {
+    return handles.modify ([&] (auto &hand) -> const BasicHandleInfo & {
         auto &hndl = hand.addHandle (global_federateId, HandleType, key, type, units);
         hndl.local_fed_id = local_federateId;
         hndl.flags = flags;
@@ -829,7 +830,7 @@ interface_handle CommonCore::registerInput (local_federate_id federateID,
     {
         throw (InvalidIdentifier ("federateID not valid (registerNamedInput)"));
     }
-    auto ci = handles.read ([&key](auto &hand) { return hand.getInput (key); });
+    auto ci = handles.read ([&key] (auto &hand) { return hand.getInput (key); });
     if (ci != nullptr)  // this key is already found
     {
         throw (RegistrationFailure ("named Input already exists"));
@@ -854,7 +855,7 @@ interface_handle CommonCore::registerInput (local_federate_id federateID,
 
 interface_handle CommonCore::getInput (local_federate_id federateID, const std::string &key) const
 {
-    auto ci = handles.read ([&key](auto &hand) { return hand.getInput (key); });
+    auto ci = handles.read ([&key] (auto &hand) { return hand.getInput (key); });
     if (ci->local_fed_id != federateID)
     {
         return {};
@@ -873,7 +874,7 @@ interface_handle CommonCore::registerPublication (local_federate_id federateID,
         throw (InvalidIdentifier ("federateID not valid (registerPublication)"));
     }
     LOG_INTERFACES (parent_broker_id, fed->getIdentifier (), fmt::format ("registering PUB {}", key));
-    auto pub = handles.read ([&key](auto &hand) { return hand.getPublication (key); });
+    auto pub = handles.read ([&key] (auto &hand) { return hand.getPublication (key); });
     if (pub != nullptr)  // this key is already found
     {
         throw (RegistrationFailure ("Publication key already exists"));
@@ -897,7 +898,7 @@ interface_handle CommonCore::registerPublication (local_federate_id federateID,
 
 interface_handle CommonCore::getPublication (local_federate_id federateID, const std::string &key) const
 {
-    auto pub = handles.read ([&key](auto &hand) { return hand.getPublication (key); });
+    auto pub = handles.read ([&key] (auto &hand) { return hand.getPublication (key); });
     if (pub->local_fed_id != federateID)
     {
         return interface_handle ();
@@ -1022,7 +1023,7 @@ void CommonCore::setHandleOption (interface_handle handle, int32_t option, bool 
         return;
     }
     handles.modify (
-      [handle, option, option_value](auto &hand) { return hand.setHandleOption (handle, option, option_value); });
+      [handle, option, option_value] (auto &hand) { return hand.setHandleOption (handle, option, option_value); });
 
     ActionMessage fcn (CMD_INTERFACE_CONFIGURE);
     fcn.dest_handle = handle;
@@ -1059,7 +1060,7 @@ bool CommonCore::getHandleOption (interface_handle handle, int32_t option) const
     {
     case defs::options::connection_required:
     case defs::options::connection_optional:
-        return handles.read ([handle, option](auto &hand) { return hand.getHandleOption (handle, option); });
+        return handles.read ([handle, option] (auto &hand) { return hand.getHandleOption (handle, option); });
     default:
         break;
     }
@@ -1093,7 +1094,7 @@ void CommonCore::closeHandle (interface_handle handle)
     cmd.setSource (handleInfo->handle);
     cmd.messageID = static_cast<int32_t> (handleInfo->handleType);
     addActionMessage (cmd);
-    handles.modify ([handle](auto &hand) { setActionFlag (*hand.getHandleInfo (handle), disconnected_flag); });
+    handles.modify ([handle] (auto &hand) { setActionFlag (*hand.getHandleInfo (handle), disconnected_flag); });
 }
 
 void CommonCore::removeTarget (interface_handle handle, const std::string &targetToRemove)
@@ -1293,7 +1294,7 @@ CommonCore::registerEndpoint (local_federate_id federateID, const std::string &n
     {
         throw (InvalidIdentifier ("federateID not valid (registerEndpoint)"));
     }
-    auto ept = handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
+    auto ept = handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
     if (ept != nullptr)
     {
         throw (RegistrationFailure ("endpoint name is already used"));
@@ -1316,7 +1317,7 @@ CommonCore::registerEndpoint (local_federate_id federateID, const std::string &n
 
 interface_handle CommonCore::getEndpoint (local_federate_id federateID, const std::string &name) const
 {
-    auto ept = handles.read ([&name](auto &hand) { return hand.getEndpoint (name); });
+    auto ept = handles.read ([&name] (auto &hand) { return hand.getEndpoint (name); });
     if (ept->local_fed_id != federateID)
     {
         return interface_handle ();
@@ -1330,7 +1331,7 @@ CommonCore::registerFilter (const std::string &filterName, const std::string &ty
     // check to make sure the name isn't already used
     if (!filterName.empty ())
     {
-        if (handles.read ([&filterName](auto &hand) {
+        if (handles.read ([&filterName] (auto &hand) {
                 auto *res = hand.getFilter (filterName);
                 return (res != nullptr);
             }))
@@ -1371,7 +1372,7 @@ interface_handle CommonCore::registerCloningFilter (const std::string &filterNam
     // check to make sure the name isn't already used
     if (!filterName.empty ())
     {
-        if (handles.read ([&filterName](auto &hand) {
+        if (handles.read ([&filterName] (auto &hand) {
                 auto *res = hand.getFilter (filterName);
                 return (res != nullptr);
             }))
@@ -1409,7 +1410,7 @@ interface_handle CommonCore::registerCloningFilter (const std::string &filterNam
 
 interface_handle CommonCore::getFilter (const std::string &name) const
 {
-    auto filt = handles.read ([&name](auto &hand) { return hand.getFilter (name); });
+    auto filt = handles.read ([&name] (auto &hand) { return hand.getFilter (name); });
     if ((filt != nullptr) && (filt->handleType == handle_type::filter))
     {
         return filt->getInterfaceHandle ();
@@ -1818,7 +1819,7 @@ void CommonCore::setLogFile (const std::string &lfile) { setLoggingFile (lfile);
 
 void CommonCore::setLoggingCallback (
   local_federate_id federateID,
-  std::function<void(int, const std::string &, const std::string &)> logFunction)
+  std::function<void (int, const std::string &, const std::string &)> logFunction)
 {
     if (federateID == local_core_id)
     {
@@ -1967,29 +1968,29 @@ std::string CommonCore::coreQuery (const std::string &queryStr) const
 {
     if (queryStr == "federates")
     {
-        return generateStringVector (loopFederates, [](const auto &fed) { return fed->getIdentifier (); });
+        return generateStringVector (loopFederates, [] (const auto &fed) { return fed->getIdentifier (); });
     }
     if (queryStr == "publications")
     {
         return generateStringVector_if (
-          loopHandles, [](const auto &handle) { return handle.key; },
-          [](const auto &handle) { return (handle.handleType == handle_type::publication); });
+          loopHandles, [] (const auto &handle) { return handle.key; },
+          [] (const auto &handle) { return (handle.handleType == handle_type::publication); });
     }
     if (queryStr == "endpoints")
     {
         return generateStringVector_if (
-          loopHandles, [](const auto &handle) { return handle.key; },
-          [](const auto &handle) { return (handle.handleType == handle_type::endpoint); });
+          loopHandles, [] (const auto &handle) { return handle.key; },
+          [] (const auto &handle) { return (handle.handleType == handle_type::endpoint); });
     }
     if (queryStr == "dependson")
     {
         return generateStringVector (timeCoord->getDependencies (),
-                                     [](auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [] (auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (queryStr == "dependents")
     {
         return generateStringVector (timeCoord->getDependents (),
-                                     [](auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [] (auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (queryStr == "isinit")
     {
@@ -2277,6 +2278,7 @@ void CommonCore::processPriorityCommand (ActionMessage &&command)
             timeCoord->source_id = global_broker_id_local;
             higher_broker_id = global_broker_id (command.source_id);
             transmitDelayedMessages ();
+            timeoutMon->setParentId (higher_broker_id);
             timeoutMon->reset ();
         }
         break;
@@ -2512,7 +2514,7 @@ void CommonCore::processCommand (ActionMessage &&command)
     case CMD_CHECK_CONNECTIONS:
     {
         auto res = checkAndProcessDisconnect ();
-        auto pred = [](const auto &fed) {
+        auto pred = [] (const auto &fed) {
             auto state = fed->getState ();
             return (HELICS_FINISHED == state) || (HELICS_ERROR == state);
         };
@@ -2936,7 +2938,7 @@ void CommonCore::registerInterface (ActionMessage &command)
     {
         auto handle = command.source_handle;
         auto &lH = loopHandles;
-        handles.read ([handle, &lH](auto &hand) {
+        handles.read ([handle, &lH] (auto &hand) {
             auto ifc = hand.getHandleInfo (handle.baseValue ());
             if (ifc != nullptr)
             {
@@ -3033,7 +3035,7 @@ void CommonCore::setAsUsed (BasicHandleInfo *hand)
         return;
     }
     hand->used = true;
-    handles.modify ([&](auto &handle) { handle.getHandleInfo (hand->handle.handle)->used = true; });
+    handles.modify ([&] (auto &handle) { handle.getHandleInfo (hand->handle.handle)->used = true; });
 }
 void CommonCore::checkForNamedInterface (ActionMessage &command)
 {
@@ -3740,7 +3742,7 @@ void CommonCore::processCoreConfigureCommands (ActionMessage &cmd)
             auto op = dataAirlocks[cmd.counter].try_unload ();
             if (op)
             {
-                auto M = stx::any_cast<std::function<void(int, const std::string &, const std::string &)>> (
+                auto M = stx::any_cast<std::function<void (int, const std::string &, const std::string &)>> (
                   std::move (*op));
                 setLoggerFunction (std::move (M));
             }
@@ -4432,6 +4434,6 @@ const std::string &CommonCore::getInterfaceInfo (interface_handle handle) const
 
 void CommonCore::setInterfaceInfo (helics::interface_handle handle, std::string info)
 {
-    handles.modify ([&](auto &hdls) { hdls.getHandleInfo (handle.baseValue ())->interface_info = info; });
+    handles.modify ([&] (auto &hdls) { hdls.getHandleInfo (handle.baseValue ())->interface_info = info; });
 }
 }  // namespace helics

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -87,7 +87,7 @@ const BasicBrokerInfo *CoreBroker::getBrokerById (global_broker_id brokerid) con
 }
 
 void CoreBroker::setLoggingCallback (
-  const std::function<void(int, const std::string &, const std::string &)> &logFunction)
+  const std::function<void (int, const std::string &, const std::string &)> &logFunction)
 {
     ActionMessage loggerUpdate (CMD_BROKER_CONFIGURE);
     loggerUpdate.messageID = UPDATE_LOGGING_CALLBACK;
@@ -533,6 +533,8 @@ void CoreBroker::processPriorityCommand (ActionMessage &&command)
                     brk.parent = global_broker_id_local;
                 }
             }
+            timeoutMon->setParentId (higher_broker_id);
+            timeoutMon->reset ();
             return;
         }
         auto broker = _brokers.find (command.name);
@@ -660,14 +662,13 @@ std::string CoreBroker::generateFederationSummary () const
             break;
         }
     }
-    std::string output =
-      fmt::format ("Federation Summary> \n\t{} federates [min {}]\n\t{}/{} brokers/cores [min {}]\n\t{} "
-                   "publications\n\t{} inputs\n\t{} endpoints\n\t{} filters\n<<<<<<<<<",
-                   _federates.size (), minFederateCount,
-                   std::count_if (_brokers.begin (), _brokers.end (),
-                                  [](auto &brk) { return brk._core == false; }),
-                   std::count_if (_brokers.begin (), _brokers.end (), [](auto &brk) { return brk._core == true; }),
-                   minBrokerCount, pubs, ipts, epts, filt);
+    std::string output = fmt::format (
+      "Federation Summary> \n\t{} federates [min {}]\n\t{}/{} brokers/cores [min {}]\n\t{} "
+      "publications\n\t{} inputs\n\t{} endpoints\n\t{} filters\n<<<<<<<<<",
+      _federates.size (), minFederateCount,
+      std::count_if (_brokers.begin (), _brokers.end (), [] (auto &brk) { return brk._core == false; }),
+      std::count_if (_brokers.begin (), _brokers.end (), [] (auto &brk) { return brk._core == true; }),
+      minBrokerCount, pubs, ipts, epts, filt);
     return output;
 }
 
@@ -1302,7 +1303,7 @@ void CoreBroker::processBrokerConfigureCommands (ActionMessage &cmd)
             auto op = dataAirlocks[cmd.counter].try_unload ();
             if (op)
             {
-                auto M = stx::any_cast<std::function<void(int, const std::string &, const std::string &)>> (
+                auto M = stx::any_cast<std::function<void (int, const std::string &, const std::string &)>> (
                   std::move (*op));
                 setLoggerFunction (std::move (M));
             }
@@ -1783,7 +1784,7 @@ std::shared_ptr<helicsCLI11App> CoreBroker::generateCLI ()
     auto app = std::make_shared<helicsCLI11App> ("Option for Broker");
     app->remove_helics_specifics ();
     app->add_flag_callback (
-      "--root", [this]() { setAsRoot (); }, "specify whether the broker is a root");
+      "--root", [this] () { setAsRoot (); }, "specify whether the broker is a root");
     return app;
 }
 
@@ -2027,7 +2028,7 @@ void CoreBroker::executeInitializationOperations ()
                 eMiss.source_id = global_broker_id_local;
                 eMiss.messageID = defs::errors::connection_failure;
                 unknownHandles.processRequiredUnknowns (
-                  [this, &eMiss](const std::string &target, char type, global_handle handle) {
+                  [this, &eMiss] (const std::string &target, char type, global_handle handle) {
                       switch (type)
                       {
                       case 'p':
@@ -2062,7 +2063,7 @@ void CoreBroker::executeInitializationOperations ()
             wMiss.source_id = global_broker_id_local;
             wMiss.messageID = defs::errors::connection_failure;
             unknownHandles.processNonOptionalUnknowns (
-              [this, &wMiss](const std::string &target, char type, global_handle handle) {
+              [this, &wMiss] (const std::string &target, char type, global_handle handle) {
                   switch (type)
                   {
                   case 'p':
@@ -2521,35 +2522,35 @@ std::string CoreBroker::generateQueryAnswer (const std::string &request)
     }
     if (request == "federates")
     {
-        return generateStringVector (_federates, [](auto &fed) { return fed.name; });
+        return generateStringVector (_federates, [] (auto &fed) { return fed.name; });
     }
     if (request == "brokers")
     {
-        return generateStringVector (_brokers, [](auto &brk) { return brk.name; });
+        return generateStringVector (_brokers, [] (auto &brk) { return brk.name; });
     }
     if (request == "inputs")
     {
         return generateStringVector_if (
-          handles, [](auto &handle) { return handle.key; },
-          [](auto &handle) { return (handle.handleType == handle_type::input); });
+          handles, [] (auto &handle) { return handle.key; },
+          [] (auto &handle) { return (handle.handleType == handle_type::input); });
     }
     if (request == "publications")
     {
         return generateStringVector_if (
-          handles, [](auto &handle) { return handle.key; },
-          [](auto &handle) { return (handle.handleType == handle_type::publication); });
+          handles, [] (auto &handle) { return handle.key; },
+          [] (auto &handle) { return (handle.handleType == handle_type::publication); });
     }
     if (request == "filters")
     {
         return generateStringVector_if (
-          handles, [](auto &handle) { return handle.key; },
-          [](auto &handle) { return (handle.handleType == handle_type::filter); });
+          handles, [] (auto &handle) { return handle.key; },
+          [] (auto &handle) { return (handle.handleType == handle_type::filter); });
     }
     if (request == "endpoints")
     {
         return generateStringVector_if (
-          handles, [](auto &handle) { return handle.key; },
-          [](auto &handle) { return (handle.handleType == handle_type::endpoint); });
+          handles, [] (auto &handle) { return handle.key; },
+          [] (auto &handle) { return (handle.handleType == handle_type::endpoint); });
     }
     if (request == "federate_map")
     {
@@ -2588,12 +2589,12 @@ std::string CoreBroker::generateQueryAnswer (const std::string &request)
     if (request == "dependson")
     {
         return generateStringVector (timeCoord->getDependencies (),
-                                     [](const auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [] (const auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (request == "dependents")
     {
         return generateStringVector (timeCoord->getDependents (),
-                                     [](const auto &dep) { return std::to_string (dep.baseValue ()); });
+                                     [] (const auto &dep) { return std::to_string (dep.baseValue ()); });
     }
     if (request == "dependencies")
     {
@@ -2862,7 +2863,7 @@ void CoreBroker::processQuery (const ActionMessage &m)
         }
         else if (m.payload == "list")
         {
-            queryResp.payload = generateStringVector (global_values, [](const auto &gv) { return gv.first; });
+            queryResp.payload = generateStringVector (global_values, [] (const auto &gv) { return gv.first; });
         }
         else if (m.payload == "all")
         {
@@ -3120,13 +3121,13 @@ bool CoreBroker::allInitReady () const
     }
 
     return std::all_of (_brokers.begin (), _brokers.end (),
-                        [](const auto &brk) { return ((brk._nonLocal) || (brk._initRequested)); });
+                        [] (const auto &brk) { return ((brk._nonLocal) || (brk._initRequested)); });
 }
 
 bool CoreBroker::allDisconnected () const
 {
     return std::all_of (_brokers.begin (), _brokers.end (),
-                        [](const auto &brk) { return ((brk._nonLocal) || (brk.isDisconnected)); });
+                        [] (const auto &brk) { return ((brk._nonLocal) || (brk.isDisconnected)); });
 }
 
 }  // namespace helics

--- a/src/helics/core/TimeoutMonitor.h
+++ b/src/helics/core/TimeoutMonitor.h
@@ -39,6 +39,8 @@ class TimeoutMonitor
     void reset ();
     /** ping all a brokers sub connections*/
     void pingSub (CoreBroker *brk);
+    /** set the parent id*/
+    void setParentId (global_broker_id parent_id) { parentConnection.connection = parent_id; };
 
   private:
     std::chrono::milliseconds timeout{100000000};  //!< timeout for connections

--- a/tests/helics/system_tests/brokerTimeoutTests.cpp
+++ b/tests/helics/system_tests/brokerTimeoutTests.cpp
@@ -84,7 +84,7 @@ TEST (broker_timeout_tests, core_fail_error)
     Fed1->finalize ();
 }
 
-TEST (broker_timeout_tests, maintain_connection)
+TEST (broker_timeout_tests, maintain_connection_ci_skip)
 {
     auto brk = helics::BrokerFactory::create (helics::core_type::ZMQ, "--timeout=100ms");
     brk->connect ();

--- a/tests/helics/system_tests/brokerTimeoutTests.cpp
+++ b/tests/helics/system_tests/brokerTimeoutTests.cpp
@@ -84,7 +84,7 @@ TEST (broker_timeout_tests, core_fail_error)
     Fed1->finalize ();
 }
 
-TEST (broker_timeout_tests, maintain_connection_ci_skip)
+TEST (broker_timeout_tests, maintain_connection)
 {
     auto brk = helics::BrokerFactory::create (helics::core_type::ZMQ, "--timeout=100ms");
     brk->connect ();
@@ -99,7 +99,7 @@ TEST (broker_timeout_tests, maintain_connection_ci_skip)
     sub1.setDefault (std::string ("String1"));
 
     Fed1->enterExecutingMode ();
-    int counter = 45;
+    int counter = 50;
     while (counter > 0)
     {
         std::this_thread::sleep_for (std::chrono::seconds (1));

--- a/tests/helics/system_tests/brokerTimeoutTests.cpp
+++ b/tests/helics/system_tests/brokerTimeoutTests.cpp
@@ -53,10 +53,10 @@ TEST (broker_timeout_tests, core_fail_timeout)
 
 TEST (broker_timeout_tests, core_fail_error)
 {
-    auto brk = helics::BrokerFactory::create (CORE_TYPE_TO_TEST, "--timeout=200ms --tick 50ms");
+    auto brk = helics::BrokerFactory::create (helics::core_type::TEST, "--timeout=200ms --tick 50ms");
     brk->connect ();
 
-    helics::FederateInfo fi (CORE_TYPE_TO_TEST);
+    helics::FederateInfo fi (helics::core_type::TEST);
     fi.coreName = "c3";
 
     auto Fed1 = std::make_shared<helics::ValueFederate> ("test1", fi);
@@ -82,4 +82,31 @@ TEST (broker_timeout_tests, core_fail_error)
     cr->disconnect ();
     Fed2->finalize ();
     Fed1->finalize ();
+}
+
+TEST (broker_timeout_tests, maintain_connection_ci_skip)
+{
+    auto brk = helics::BrokerFactory::create (helics::core_type::ZMQ, "--timeout=100ms");
+    brk->connect ();
+
+    helics::FederateInfo fi (helics::core_type::ZMQ);
+    fi.coreName = "c3";
+    fi.setProperty (helics_property_time_delta, 0.01);
+    auto Fed1 = std::make_shared<helics::ValueFederate> ("test1", fi);
+
+    Fed1->registerGlobalPublication<std::string> ("pub1");
+    auto &sub1 = Fed1->registerSubscription ("pub1");
+    sub1.setDefault (std::string ("String1"));
+
+    Fed1->enterExecutingMode ();
+    int counter = 45;
+    while (counter > 0)
+    {
+        std::this_thread::sleep_for (std::chrono::seconds (1));
+        --counter;
+    }
+    EXPECT_TRUE (brk->isConnected ());
+    EXPECT_TRUE (Fed1->getCorePointer ()->isConnected ());
+    Fed1->finalize ();
+    brk->waitForDisconnect ();
 }


### PR DESCRIPTION
### Summary

If merged this pull request will add a new timeout test in Python for a value federate. It initializes a federate, enters execution and waits 60 seconds, and then checks if the broker is still connected.

This test can be run explicitly by using the following:

```
pytest -sv tests/python/test_value_federate.py -k test_value_federate_runFederateTimeoutTest
```

Related to #853 

