### PR TITLE
Remove `brew install helics` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ Each [release](https://github.com/GMLC-TDC/HELICS/releases/latest) comes with a 
 
 Some support to Conda is provided see [conda install](https://helics.readthedocs.io/en/latest/installation/package_manager.html#install-using-conda-windows-macos-linux) for the Instructions.  It is  supported through a separate [repo](https://github.com/GMLC-TDC/helics-conda).
 
-### Brew
-
-On MacOS there is a [brew package](https://helics.readthedocs.io/en/latest/installation/package_manager.html#install-using-brew-macos) for HELICS supported in a separate [repository](https://github.com/GMLC-TDC/homebrew-helics).  
-
-
 ## Build from Source Instructions
 
 [Windows](https://helics.readthedocs.io/en/latest/installation/windows.html)
@@ -113,7 +108,7 @@ We are always looking for help adding support for more tools, so please contact 
 -   [PSST](https://github.com/kdheepak/psst), an open-source python-based unit-commitment and dispatch market simulator. HELICS examples are included in the  [HELICS-Tutorial](https://github.com/GMLC-TDC/HELICS-Tutorial)
 -   [MATPOWER](http://www.pserc.cornell.edu/matpower/), an open-source Matlab based power flow and optimal power flow tool. HELICS support currently (4/14/2018) under development.
 -   [InterPSS](http://www.interpss.org/), a Java-based power systems simulator. HELICS support currently (4/14/2018) under development.
--   Commercial tools that have interacted with HELICS, include Power World, PSS/e, PSLF, and Cyme.  
+-   Commercial tools that have interacted with HELICS, include Power World, PSS/e, PSLF, and Cyme.
 
 ### Communication Tools
 
@@ -125,8 +120,8 @@ We are always looking for help adding support for more tools, so please contact 
 -   [HELICS CLI](https://github.com/GMLC-TDC/helics-cli) provides a simple way to automate configuring, starting, and stopping HELICS co-simulations.
 -   [Player](https://helics.readthedocs.io/en/latest/apps/Player.html), which acts as a simple send-only federate that simply publishes a stream of timed HELICS messages from a user-defined file. HELICS Player is included in the HELICS distribution.
 -   [Recorder](https://helics.readthedocs.io/en/latest/apps/Recorder.html), which acts as a simple receive-only federate that prints out or saves messages from one or more subscribed streams. HELICS Recorder is included in the HELICS distribution.
--   [Broker](https://helics.readthedocs.io/en/latest/apps/Broker.html),  which is a command line tool for running a Broker.  There is also a Broker Server which can generate brokers as needed.  
--   [App](https://helics.readthedocs.io/en/latest/apps/App.htm) is a general app executable which can run a number of other apps including Player and Recorder, as well as a [Tracer](https://helics.readthedocs.io/en/latest/apps/App.html#tracer), [Echo](https://helics.readthedocs.io/en/latest/apps/App.html#echo), [Source](https://helics.readthedocs.io/en/latest/apps/App.html#source), and [Clone](https://helics.readthedocs.io/en/latest/apps/App.html#clone).   
+-   [Broker](https://helics.readthedocs.io/en/latest/apps/Broker.html),  which is a command line tool for running a Broker.  There is also a Broker Server which can generate brokers as needed.
+-   [App](https://helics.readthedocs.io/en/latest/apps/App.htm) is a general app executable which can run a number of other apps including Player and Recorder, as well as a [Tracer](https://helics.readthedocs.io/en/latest/apps/App.html#tracer), [Echo](https://helics.readthedocs.io/en/latest/apps/App.html#echo), [Source](https://helics.readthedocs.io/en/latest/apps/App.html#source), and [Clone](https://helics.readthedocs.io/en/latest/apps/App.html#clone).
 
 ## Contributing
 Contributors are welcome see the [Contributing](CONTRIBUTING.md) guidelines for more details on the process of contributing.  And the [Code of Conduct](.github/CODE_OF_CONDUCT.md) for guidelines on the community expectations.  All prior contributors can be found [here](CONTRIBUTORS.md)

--- a/docs/installation/package_manager.md
+++ b/docs/installation/package_manager.md
@@ -12,34 +12,3 @@ You can then use `conda` to install HELICS.
 conda install -c gmlc-tdc helics
 ```
 
-## Install using brew (MacOS)
-
-Install [brew](https://brew.sh/). It is a package manager for MacOS.
-
-Once you install brew, you can open a terminal and type the following.
-
-```bash
-brew tap GMLC-TDC/helics
-brew install helics
-```
-
-OR
-
-```bash
-brew install GMLC-TDC/helics/helics
-```
-
-If you want to install it with the Python extension, you can use the
-following.
-
-```bash
-brew reinstall helics --with-python
-```
-
-If you want to install using Python2 instead, you should build from source.
-It is important that the Python interpreter used to run `import helics`.
-That is to say, you cannot build using Python3 and run using Python2.
-
-Additionally, if required, you can add `--HEAD` to install from the
-latest `develop` branch.
-

--- a/docs/introduction/python.md
+++ b/docs/introduction/python.md
@@ -12,7 +12,6 @@ We recommend using Anaconda3/Miniconda3, although this should work with most ver
 To make an interface that is similar across different languages, we use SWIG to generate the Python bindings to the `helicsSharedLib` shared library.
 SWIG claims to be compatible with most Python versions, dating back to Python 2.0. And recommends that for the best results, one should consider using Python 2.3 or newer.
 
-Installation of HELICS on a Mac can be done using `brew` which comes with the ability to build the Python extension as well.
 HELICS can also be built from source and linked with the required Python version.
 See the page on the Installation instructions for more information regarding this.
 


### PR DESCRIPTION
Resolves #843 

Most people likely want to use HELICS with Python. `conda` is the recommended way to install HELICS with Python. The `brew` recipe builds from source anyway and only allows configuring a limited number of options. 

Users can just directly build from source and configure any option they want manually. This allows them to build Python2/Python3, build with GCC/Clang or any of the other options available in `cmake`. 