### PR TITLE
Add inproc core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,7 @@ cmake_dependent_advanced_option(
     OFF
 )
 option(ENABLE_TEST_CORE "Enable test inprocess core type" ON)
+option(ENABLE_INPROC_CORE "Enable inprocess core type" ON)
 option(ENABLE_ZMQ_CORE "Enable ZeroMQ networking library" ON)
 
 mark_as_advanced(

--- a/benchmarks/helics/echoBenchmarks.cpp
+++ b/benchmarks/helics/echoBenchmarks.cpp
@@ -41,7 +41,7 @@ class EchoHub
   public:
     EchoHub () = default;
 
-    void run (std::function<void()> callOnReady = {})
+    void run (std::function<void ()> callOnReady = {})
     {
         if (!readyToRun)
         {
@@ -114,7 +114,7 @@ class EchoLeaf
   public:
     EchoLeaf () = default;
 
-    void run (std::function<void()> callOnReady = {})
+    void run (std::function<void ()> callOnReady = {})
     {
         if (!readyToRun)
         {
@@ -185,8 +185,8 @@ static void BM_echo_singleCore (benchmark::State &state)
 
         int feds = static_cast<int> (state.range (0));
         gmlc::concurrency::Barrier brr (feds + 1);
-        auto wcore = helics::CoreFactory::create (core_type::TEST, std::string ("--autobroker --federates=") +
-                                                                     std::to_string (feds + 1));
+        auto wcore = helics::CoreFactory::create (core_type::INPROC, std::string ("--autobroker --federates=") +
+                                                                       std::to_string (feds + 1));
         EchoHub hub;
         hub.initialize (wcore->getIdentifier (), feds);
         std::vector<EchoLeaf> leafs (feds);
@@ -199,12 +199,12 @@ static void BM_echo_singleCore (benchmark::State &state)
         for (int ii = 0; ii < feds; ++ii)
         {
             threadlist[ii] =
-              std::thread ([&](EchoLeaf &lf) { lf.run ([&brr]() { brr.wait (); }); }, std::ref (leafs[ii]));
+              std::thread ([&] (EchoLeaf &lf) { lf.run ([&brr] () { brr.wait (); }); }, std::ref (leafs[ii]));
         }
         hub.makeReady ();
         brr.wait ();
         state.ResumeTiming ();
-        hub.run ([]() {});
+        hub.run ([] () {});
         state.PauseTiming ();
         for (auto &thrd : threadlist)
         {
@@ -252,12 +252,12 @@ static void BM_echo_multiCore (benchmark::State &state, core_type cType)
         for (int ii = 0; ii < feds; ++ii)
         {
             threadlist[ii] =
-              std::thread ([&](EchoLeaf &lf) { lf.run ([&brr]() { brr.wait (); }); }, std::ref (leafs[ii]));
+              std::thread ([&] (EchoLeaf &lf) { lf.run ([&brr] () { brr.wait (); }); }, std::ref (leafs[ii]));
         }
         hub.makeReady ();
         brr.wait ();
         state.ResumeTiming ();
-        hub.run ([]() {});
+        hub.run ([] () {});
         state.PauseTiming ();
         for (auto &thrd : threadlist)
         {
@@ -274,8 +274,8 @@ static void BM_echo_multiCore (benchmark::State &state, core_type cType)
 }
 
 static constexpr int64_t maxscale{1 << 4};
-// Register the test core benchmarks
-BENCHMARK_CAPTURE (BM_echo_multiCore, testCore, core_type::TEST)
+// Register the inproc core benchmarks
+BENCHMARK_CAPTURE (BM_echo_multiCore, inprocCore, core_type::INPROC)
   ->RangeMultiplier (2)
   ->Range (1, maxscale)
   ->Unit (benchmark::TimeUnit::kMillisecond)

--- a/benchmarks/helics/messageLookupBenchmarks.cpp
+++ b/benchmarks/helics/messageLookupBenchmarks.cpp
@@ -42,7 +42,7 @@ class messageGenerator
   public:
     messageGenerator () = default;
 
-    void run (std::function<void()> callOnReady = {})
+    void run (std::function<void ()> callOnReady = {})
     {
         if (!readyToRun)
         {
@@ -168,7 +168,7 @@ static void BM_mgen_multiCore (benchmark::State &state, core_type cType)
         std::vector<std::thread> threadlist (feds - 1);
         for (int ii = 0; ii < feds - 1; ++ii)
         {
-            threadlist[ii] = std::thread ([&](messageGenerator &gen) { gen.run ([&brr]() { brr.wait (); }); },
+            threadlist[ii] = std::thread ([&] (messageGenerator &gen) { gen.run ([&brr] () { brr.wait (); }); },
                                           std::ref (gens[ii + 1]));
         }
 
@@ -191,7 +191,7 @@ static void BM_mgen_multiCore (benchmark::State &state, core_type cType)
 }
 
 // Register the test core benchmarks
-BENCHMARK_CAPTURE (BM_mgen_multiCore, testCore, core_type::TEST)
+BENCHMARK_CAPTURE (BM_mgen_multiCore, inprocCore, core_type::INPROC)
   ->Unit (benchmark::TimeUnit::kMillisecond)
   ->Ranges ({{32, 1 << 19}, {2, 64 * 4}})
   ->UseRealTime ();

--- a/config/helics-config.h.in
+++ b/config/helics-config.h.in
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #cmakedefine ENABLE_IPC_CORE
 #cmakedefine ENABLE_UDP_CORE
 #cmakedefine ENABLE_TEST_CORE
+#cmakedefine ENABLE_INPROC_CORE
 
 
 #cmakedefine HELICS_ENABLE_LOGGING

--- a/src/helics/core/BrokerFactory.cpp
+++ b/src/helics/core/BrokerFactory.cpp
@@ -38,6 +38,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "tcp/TcpBroker.h"
 #endif
 
+#ifdef ENABLE_INPROC_CORE
+#include "inproc/InprocBroker.h"
+#endif
+
 #include <cassert>
 
 namespace helics
@@ -122,6 +126,20 @@ std::shared_ptr<Broker> makeBroker (core_type type, const std::string &name)
         break;
 #else
         throw (HelicsException ("Test broker type is not available"));
+#endif
+    case core_type::INPROC:
+#ifdef ENABLE_INPROC_CORE
+        if (name.empty ())
+        {
+            broker = std::make_shared<inproc::InprocBroker> ();
+        }
+        else
+        {
+            broker = std::make_shared<inproc::InprocBroker> (name);
+        }
+        break;
+#else
+        throw (HelicsException ("in process broker type is not available"));
 #endif
     case core_type::INTERPROCESS:
     case core_type::IPC:
@@ -301,6 +319,12 @@ static bool isJoinableBrokerOfType (core_type type, const std::shared_ptr<Broker
 #else
             return false;
 #endif
+        case core_type::INPROC:
+#ifdef ENABLE_INPROC_CORE
+            return (dynamic_cast<inproc::InprocBroker *> (ptr.get ()) != nullptr);
+#else
+            return false;
+#endif
         case core_type::INTERPROCESS:
         case core_type::IPC:
 #ifdef ENABLE_IPC_CORE
@@ -327,9 +351,18 @@ static bool isJoinableBrokerOfType (core_type type, const std::shared_ptr<Broker
     return false;
 }
 
+static bool isJoinableBrokerForType (core_type type, const std::shared_ptr<Broker> &ptr)
+{
+    if (type == core_type::INPROC || type == core_type::TEST)
+    {
+        return isJoinableBrokerOfType (core_type::INPROC, ptr) || isJoinableBrokerOfType (core_type::TEST, ptr);
+    }
+    return isJoinableBrokerOfType (type, ptr);
+}
+
 std::shared_ptr<Broker> findJoinableBrokerOfType (core_type type)
 {
-    return searchableObjects.findObject ([type] (auto &ptr) { return isJoinableBrokerOfType (type, ptr); });
+    return searchableObjects.findObject ([type] (auto &ptr) { return isJoinableBrokerForType (type, ptr); });
 }
 
 std::vector<std::shared_ptr<Broker>> getAllBrokers () { return searchableObjects.getObjects (); }

--- a/src/helics/core/CMakeLists.txt
+++ b/src/helics/core/CMakeLists.txt
@@ -138,7 +138,7 @@ set(
 set(TESTCORE_HEADER_FILES test/TestCore.h test/TestBroker.h test/TestComms.h)
 
 
-set(INPROCCORE_HEADER_FILES inproc/InprocCore.h inproc/inprocBroker.h inproc/InprocComms.h)
+set(INPROCCORE_HEADER_FILES inproc/InprocCore.h inproc/InprocBroker.h inproc/InprocComms.h)
 
 
 set(

--- a/src/helics/core/CMakeLists.txt
+++ b/src/helics/core/CMakeLists.txt
@@ -41,6 +41,9 @@ set(
 
 set(TESTCORE_SOURCE_FILES test/TestBroker.cpp test/TestCore.cpp test/TestComms.cpp)
 
+set(INPROCCORE_SOURCE_FILES inproc/InprocBroker.cpp inproc/InprocCore.cpp inproc/InprocComms.cpp)
+
+
 set(
     IPC_SOURCE_FILES
     ipc/IpcCore.cpp ipc/IpcBroker.cpp ipc/IpcComms.cpp ipc/IpcQueueHelper.cpp
@@ -134,6 +137,10 @@ set(
 
 set(TESTCORE_HEADER_FILES test/TestCore.h test/TestBroker.h test/TestComms.h)
 
+
+set(INPROCCORE_HEADER_FILES inproc/InprocCore.h inproc/inprocBroker.h inproc/InprocComms.h)
+
+
 set(
     IPC_HEADER_FILES
     ipc/IpcCore.h ipc/IpcBroker.h ipc/IpcComms.h ipc/IpcQueueHelper.h
@@ -168,6 +175,11 @@ set(
 if(ENABLE_TEST_CORE)
     list(APPEND SRC_FILES ${TESTCORE_SOURCE_FILES})
     list(APPEND INCLUDE_FILES ${TESTCORE_HEADER_FILES})
+endif()
+
+if(ENABLE_INPROC_CORE)
+    list(APPEND SRC_FILES ${INPROCCORE_SOURCE_FILES})
+    list(APPEND INCLUDE_FILES ${INPROCCORE_HEADER_FILES})
 endif()
 
 if(ENABLE_UDP_CORE)
@@ -263,6 +275,10 @@ endif()
 
 if(ENABLE_TCP_CORE)
     source_group("tcp" FILES ${TCP_SOURCE_FILES} ${TCP_HEADER_FILES})
+endif()
+
+if(ENABLE_INPROC_CORE)
+    source_group("inproc" FILES ${INPROCCORE_SOURCE_FILES} ${INPROCCORE_HEADER_FILES})
 endif()
 
 if(ENABLE_MPI_CORE)

--- a/src/helics/core/CommsBroker.cpp
+++ b/src/helics/core/CommsBroker.cpp
@@ -34,6 +34,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "tcp/TcpCommsSS.h"
 #endif
 
+#ifdef ENABLE_INPROC_CORE
+#include "inproc/InprocComms.h"
+#endif
+
 #ifdef ENABLE_MPI_CORE
 #include "mpi/MpiComms.h"
 #endif
@@ -67,6 +71,11 @@ template class CommsBroker<tcp::TcpComms, CommonCore>;
 template class CommsBroker<tcp::TcpComms, CoreBroker>;
 template class CommsBroker<tcp::TcpCommsSS, CommonCore>;
 template class CommsBroker<tcp::TcpCommsSS, CoreBroker>;
+#endif
+
+#ifdef ENABLE_INPROC_CORE
+template class CommsBroker<inproc::InprocComms, CommonCore>;
+template class CommsBroker<inproc::InprocComms, CoreBroker>;
 #endif
 
 #ifdef ENABLE_MPI_CORE

--- a/src/helics/core/core-types.cpp
+++ b/src/helics/core/core-types.cpp
@@ -39,6 +39,10 @@ std::string to_string (core_type type)
         return "udp_";
     case core_type::NNG:
         return "nng_";
+    case core_type::INPROC:
+        return "inproc_";
+    case core_type::WEBSOCKET:
+        return "websocket_";
     default:
         return std::string ();
     }
@@ -84,7 +88,10 @@ static const std::unordered_map<std::string, core_type> coreTypes{{"default", co
                                                                   {"test", core_type::TEST},
                                                                   {"UDP", core_type::UDP},
                                                                   {"local", core_type::TEST},
-                                                                  {"inprocess", core_type::TEST},
+                                                                  {"inprocess", core_type::INPROC},
+                                                                  {"websocket", core_type::WEBSOCKET},
+                                                                  {"web", core_type::WEBSOCKET},
+                                                                  {"inproc", core_type::INPROC},
                                                                   {"http", core_type::HTTP},
                                                                   {"HTTP", core_type::HTTP},
                                                                   {"web", core_type::HTTP},
@@ -147,6 +154,14 @@ core_type coreTypeFromString (std::string type) noexcept
     {
         return core_type::MPI;
     }
+    if (type.compare (0, 6, "inproc") == 0)
+    {
+        return core_type::INPROC;
+    }
+    if (type.compare (0, 3, "web") == 0)
+    {
+        return core_type::WEBSOCKET;
+    }
     return core_type::UNRECOGNIZED;
 }
 
@@ -186,6 +201,12 @@ core_type coreTypeFromString (std::string type) noexcept
 #define TEST_AVAILABILITY true
 #endif
 
+#ifndef ENABLE_INPROC_CORE
+#define INPROC_AVAILABILITY false
+#else
+#define INPROC_AVAILABILITY true
+#endif
+
 bool isCoreTypeAvailable (core_type type) noexcept
 {
     bool available = false;
@@ -218,7 +239,11 @@ bool isCoreTypeAvailable (core_type type) noexcept
     case core_type::DEFAULT:  // default should always be available
         available = true;
         break;
+    case core_type::INPROC:
+        available = INPROC_AVAILABILITY;
+        break;
     case core_type::HTTP:
+    case core_type::WEBSOCKET:
         available = false;
         break;
     default:

--- a/src/helics/core/core-types.hpp
+++ b/src/helics/core/core-types.hpp
@@ -45,6 +45,8 @@ enum class core_type : int
     NNG = helics_core_type_nng,  //!< reserved for future Nanomsg implementation
     ZMQ_SS = helics_core_type_zmq_test,  //!< single socket version of ZMQ core for better scalability performance
     HTTP = helics_core_type_http,  //!< core/broker using web traffic
+    WEBSOCKET = helics_core_type_websocket,  //!< core/broker using web sockets
+    INPROC = helics_core_type_inproc,  //!< core/broker using a stripped down in process core type
     UNRECOGNIZED = 22,  //!< unknown
 
 };

--- a/src/helics/core/inproc/InprocBroker.cpp
+++ b/src/helics/core/inproc/InprocBroker.cpp
@@ -1,0 +1,14 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#include "InprocBroker.h"
+#include "../NetworkBroker_impl.hpp"
+#include "InprocComms.h"
+
+namespace helics
+{
+template class NetworkBroker<inproc::InprocComms, interface_type::inproc, static_cast<int> (core_type::INPROC)>;
+}  // namespace helics

--- a/src/helics/core/inproc/InprocBroker.h
+++ b/src/helics/core/inproc/InprocBroker.h
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#pragma once
+
+#include "../NetworkBroker.hpp"
+
+namespace helics
+{
+namespace inproc
+{
+class InprocComms;
+
+/** implementation for the core that uses IPC messages to communicate*/
+using InprocBroker = NetworkBroker<InprocComms, interface_type::inproc, static_cast<int> (core_type::INPROC)>;
+
+}  // namespace inproc
+}  // namespace helics

--- a/src/helics/core/inproc/InprocComms.cpp
+++ b/src/helics/core/inproc/InprocComms.cpp
@@ -1,0 +1,290 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#include "InprocComms.h"
+#include "../../common/fmt_format.h"
+#include "../ActionMessage.hpp"
+#include "../BrokerFactory.hpp"
+#include "../CommonCore.hpp"
+#include "../CoreBroker.hpp"
+#include "../CoreFactory.hpp"
+#include "../NetworkBrokerData.hpp"
+
+#include <memory>
+
+namespace helics
+{
+namespace inproc
+{
+InprocComms::InprocComms () : CommsInterface (CommsInterface::thread_generation::single) {}
+
+using namespace std::chrono;
+/** destructor*/
+InprocComms::~InprocComms () { disconnect (); }
+
+void InprocComms::loadNetworkInfo (const NetworkBrokerData &netInfo)
+{
+    CommsInterface::loadNetworkInfo (netInfo);
+    if (!propertyLock ())
+    {
+        return;
+    }
+    // brokerPort = netInfo.brokerPort;
+    // PortNumber = netInfo.portNumber;
+    if (localTargetAddress.empty ())
+    {
+        localTargetAddress = name;
+    }
+
+    // if (PortNumber > 0)
+    //{
+    //    autoPortNumber = false;
+    //}
+    propertyUnLock ();
+}
+
+void InprocComms::queue_rx_function () {}
+
+void InprocComms::queue_tx_function ()
+{
+    // make sure the link to the localTargetAddress is in place
+    if (name != localTargetAddress)
+    {
+        if (!brokerName.empty ())
+        {
+            if (!CoreFactory::copyCoreIdentifier (name, localTargetAddress))
+            {
+                if (!BrokerFactory::copyBrokerIdentifier (name, localTargetAddress))
+                {
+                    setRxStatus (connection_status::error);
+                    setTxStatus (connection_status::error);
+                    return;
+                }
+            }
+        }
+        else
+        {
+            if (!BrokerFactory::copyBrokerIdentifier (name, localTargetAddress))
+            {
+                setRxStatus (connection_status::error);
+                setTxStatus (connection_status::error);
+                return;
+            }
+        }
+    }
+    setRxStatus (connection_status::connected);
+    std::shared_ptr<CoreBroker> tbroker;
+
+    if (brokerName.empty ())
+    {
+        if (!brokerTargetAddress.empty ())
+        {
+            brokerName = brokerTargetAddress;
+        }
+    }
+
+    if (!brokerName.empty ())
+    {
+        milliseconds totalSleep (0);
+        while (!tbroker)
+        {
+            auto broker = BrokerFactory::findBroker (brokerName);
+            tbroker = std::dynamic_pointer_cast<CoreBroker> (broker);
+            if (!tbroker)
+            {
+                if (autoBroker)
+                {
+                    tbroker = std::static_pointer_cast<CoreBroker> (
+                      BrokerFactory::create (core_type::INPROC, brokerName, brokerInitString));
+                    tbroker->connect ();
+                }
+                else
+                {
+                    if (totalSleep > connectionTimeout)
+                    {
+                        setTxStatus (connection_status::error);
+                        setRxStatus (connection_status::error);
+                        return;
+                    }
+                    std::this_thread::sleep_for (milliseconds (200));
+                    totalSleep += milliseconds (200);
+                }
+            }
+            else
+            {
+                if (!tbroker->isOpenToNewFederates ())
+                {
+                    logError ("broker is not open to new federates " + brokerName);
+                    tbroker = nullptr;
+                    broker = nullptr;
+                    BrokerFactory::cleanUpBrokers (milliseconds (200));
+                    totalSleep += milliseconds (200);
+                    if (totalSleep > milliseconds (connectionTimeout))
+                    {
+                        setTxStatus (connection_status::error);
+                        setRxStatus (connection_status::error);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+    else if (!serverMode)
+    {
+        milliseconds totalSleep (0);
+        while (!tbroker)
+        {
+            auto broker = BrokerFactory::findJoinableBrokerOfType (core_type::INPROC);
+            tbroker = std::dynamic_pointer_cast<CoreBroker> (broker);
+            if (!tbroker)
+            {
+                if (autoBroker)
+                {
+                    tbroker = std::static_pointer_cast<CoreBroker> (
+                      BrokerFactory::create (core_type::INPROC, "", brokerInitString));
+                    tbroker->connect ();
+                }
+                else
+                {
+                    if (totalSleep > connectionTimeout)
+                    {
+                        setTxStatus (connection_status::error);
+                        setRxStatus (connection_status::error);
+                        return;
+                    }
+                    std::this_thread::sleep_for (milliseconds (200));
+                    totalSleep += milliseconds (200);
+                }
+            }
+        }
+    }
+    if (tbroker)
+    {
+        if (tbroker->getIdentifier () == localTargetAddress)
+        {
+            logError ("broker == target");
+        }
+        if (!tbroker->isOpenToNewFederates ())
+        {
+            logError ("broker is not open to new federates");
+        }
+    }
+
+    setTxStatus (connection_status::connected);
+    std::map<route_id, std::shared_ptr<BrokerBase>> routes;
+    bool haltLoop{false};
+    while (!haltLoop)
+    {
+        route_id rid;
+        ActionMessage cmd;
+
+        std::tie (rid, cmd) = txQueue.pop ();
+        bool processed = false;
+        if (isProtocolCommand (cmd))
+        {
+            if (rid == control_route)
+            {
+                switch (cmd.messageID)
+                {
+                case NEW_ROUTE:
+                {
+                    auto &newroute = cmd.payload;
+                    bool foundRoute = false;
+                    auto core = CoreFactory::findCore (newroute);
+                    if (core)
+                    {
+                        auto tcore = std::dynamic_pointer_cast<CommonCore> (core);
+                        if (tcore)
+                        {
+                            routes.emplace (route_id{cmd.getExtraData ()}, std::move (tcore));
+                            foundRoute = true;
+                        }
+                    }
+                    auto brk = BrokerFactory::findBroker (newroute);
+
+                    if (brk)
+                    {
+                        auto cbrk = std::dynamic_pointer_cast<CoreBroker> (brk);
+                        if (cbrk)
+                        {
+                            routes.emplace (route_id{cmd.getExtraData ()}, std::move (cbrk));
+                            foundRoute = true;
+                        }
+                    }
+                    if (!foundRoute)
+                    {
+                        logError (std::string ("unable to establish Route to ") + newroute);
+                    }
+                    processed = true;
+                }
+                break;
+                case REMOVE_ROUTE:
+                    routes.erase (route_id{cmd.getExtraData ()});
+                    processed = true;
+                    break;
+                case CLOSE_RECEIVER:
+                    setRxStatus (connection_status::terminated);
+                    processed = true;
+                    break;
+                case DISCONNECT:
+                    haltLoop = true;
+                    continue;
+                }
+            }
+        }
+        if (processed)
+        {
+            continue;
+        }
+
+        if (rid == parent_route_id)
+        {
+            if (tbroker)
+            {
+                tbroker->addActionMessage (std::move (cmd));
+            }
+            else
+            {
+                logWarning (
+                  fmt::format ("message directed to broker of comm system with no broker, message dropped {}",
+                               prettyPrintString (cmd)));
+            }
+        }
+        else
+        {
+            auto rt_find = routes.find (rid);
+            if (rt_find != routes.end ())
+            {
+                rt_find->second->addActionMessage (std::move (cmd));
+            }
+            else
+            {
+                if (tbroker)
+                {
+                    tbroker->addActionMessage (std::move (cmd));
+                }
+                else
+                {
+                    if (!isDisconnectCommand (cmd))
+                    {
+                        logWarning (std::string ("unknown route, message dropped ") + prettyPrintString (cmd));
+                    }
+                }
+            }
+        }
+    }  // while (!haltLoop)
+
+    routes.clear ();
+    tbroker = nullptr;
+
+    setTxStatus (connection_status::terminated);
+}
+
+std::string InprocComms::getAddress () const { return localTargetAddress; }
+
+}  // namespace inproc
+
+}  // namespace helics

--- a/src/helics/core/inproc/InprocComms.h
+++ b/src/helics/core/inproc/InprocComms.h
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include "../CommsInterface.hpp"
+#include "helics/helics-config.h"
+#include <future>
+#include <set>
+
+namespace helics
+{
+namespace inproc
+{
+/** implementation for the communication interface that uses ZMQ messages to communicate*/
+class InprocComms final : public CommsInterface
+{
+  public:
+    /** default constructor*/
+    InprocComms ();
+    /** destructor*/
+    ~InprocComms ();
+
+    virtual void loadNetworkInfo (const NetworkBrokerData &netInfo) override;
+
+  private:
+    virtual void queue_rx_function () override;  //!< the functional loop for the receive queue
+    virtual void queue_tx_function () override;  //!< the loop for transmitting data
+  public:
+    /** return a dummy port number*/
+    int getPort () const { return -1; };
+
+    std::string getAddress () const;
+};
+
+}  // namespace inproc
+}  // namespace helics

--- a/src/helics/core/inproc/InprocCore.cpp
+++ b/src/helics/core/inproc/InprocCore.cpp
@@ -1,0 +1,14 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#include "InprocCore.h"
+#include "../NetworkCore_impl.hpp"
+#include "InprocComms.h"
+
+namespace helics
+{
+template class NetworkCore<inproc::InprocComms, interface_type::inproc>;
+}  // namespace helics

--- a/src/helics/core/inproc/InprocCore.h
+++ b/src/helics/core/inproc/InprocCore.h
@@ -1,0 +1,18 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#include "../NetworkCore.hpp"
+
+namespace helics
+{
+namespace inproc
+{
+class InprocComms;
+/** implementation for the core that can only communicate in process*/
+using InprocCore = NetworkCore<InprocComms, interface_type::inproc>;
+
+}  // namespace inproc
+}  // namespace helics

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -39,7 +39,10 @@ extern "C"
         helics_core_type_nng = 9, /*!< for using the nanomsg communications */
         helics_core_type_tcp_ss =
           11, /*!< a single socket version of the TCP core for more easily handling firewalls*/
-        helics_core_type_http = 12 /*!< a core type using http for communication*/
+        helics_core_type_http = 12, /*!< a core type using http for communication*/
+        helics_core_type_websocket = 14, /*!< a core using websockets for communication*/
+        helics_core_type_inproc = 18, /*!< an in process core type for handling communications in shared memory
+                                   it is pretty similar to the test core but stripped from the "test" components*/
     } helics_core_type;
 
     /** enumeration of allowable data types for publications and inputs*/

--- a/tests/helics/core/CMakeLists.txt
+++ b/tests/helics/core/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
     ForwardingTimeCoordinatorTests.cpp
     TimeCoordinatorTests.cpp
     networkInfoTests.cpp
+	InprocCore-Tests.cpp
 )
 
 if(ENABLE_TEST_CORE)

--- a/tests/helics/core/InprocCore-Tests.cpp
+++ b/tests/helics/core/InprocCore-Tests.cpp
@@ -1,0 +1,255 @@
+/*
+Copyright (c) 2017-2019,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
+the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#include "gtest/gtest.h"
+
+#include "helics/core/BrokerFactory.hpp"
+#include "helics/core/Core.hpp"
+#include "helics/core/CoreFactory.hpp"
+#include "helics/core/CoreFederateInfo.hpp"
+#include "helics/core/core-exceptions.hpp"
+#include "helics/core/core-types.hpp"
+#include "helics/core/inproc/InprocCore.h"
+
+using helics::Core;
+using namespace helics::CoreFactory;
+
+TEST (InprocCore_tests, initialization_test)
+{
+    auto broker = helics::BrokerFactory::create (helics::core_type::INPROC, std::string{});
+    ASSERT_TRUE (broker);
+    EXPECT_TRUE (broker->isConnected ());
+    std::string configureString = std::string ("-f 4") + " --broker=" + broker->getIdentifier ();
+    auto core = create (helics::core_type::INPROC, configureString);
+
+    auto Tcore = std::dynamic_pointer_cast<helics::inproc::InprocCore> (core);
+
+    ASSERT_TRUE (core);
+    ASSERT_TRUE (Tcore);
+    EXPECT_TRUE (core->isConfigured ());
+
+    core->connect ();
+
+    EXPECT_TRUE (core->isConnected ());
+    core->disconnect ();
+    broker->disconnect ();
+    EXPECT_EQ (core->isConnected (), false);
+    EXPECT_EQ (broker->isConnected (), false);
+    core = nullptr;
+    broker = nullptr;
+}
+
+TEST (InprocCore_tests, initialization_test_with_test_broker)
+{
+    auto broker = helics::BrokerFactory::create (helics::core_type::TEST, std::string{});
+    ASSERT_TRUE (broker);
+    EXPECT_TRUE (broker->isConnected ());
+    std::string configureString = std::string ("-f 4") + " --broker=" + broker->getIdentifier ();
+    auto core = create (helics::core_type::INPROC, configureString);
+
+    auto Tcore = std::dynamic_pointer_cast<helics::inproc::InprocCore> (core);
+
+    ASSERT_TRUE (core);
+    ASSERT_TRUE (Tcore);
+    EXPECT_TRUE (core->isConfigured ());
+
+    core->connect ();
+
+    EXPECT_TRUE (core->isConnected ());
+    core->disconnect ();
+    broker->disconnect ();
+    EXPECT_EQ (core->isConnected (), false);
+    EXPECT_EQ (broker->isConnected (), false);
+    core = nullptr;
+    broker = nullptr;
+}
+
+TEST (InprocCore_tests, pubsub_value_test)
+{
+    const char *configureString = "-f 1 --autobroker";
+    auto core = create (helics::core_type::INPROC, configureString);
+
+    ASSERT_TRUE (core != nullptr);
+    EXPECT_TRUE (core->isConfigured ());
+    EXPECT_EQ (core->getFederationSize (), 0);
+    core->connect ();
+    ASSERT_TRUE (core->isConnected ());
+
+    auto id = core->registerFederate ("sim1", helics::CoreFederateInfo ());
+
+    EXPECT_EQ (core->getFederationSize (), 1);
+    EXPECT_EQ (core->getFederateName (id), "sim1");
+    EXPECT_TRUE (core->getFederateId ("sim1") == id);
+
+    core->setTimeProperty (id, helics_property_time_delta, 1.0);
+
+    auto sub1 = core->registerInput (id, "", "type", "units");
+    core->addSourceTarget (sub1, "sim1_pub");
+    EXPECT_EQ (core->getExtractionType (sub1), "type");
+    EXPECT_EQ (core->getExtractionUnits (sub1), "units");
+
+    auto pub1 = core->registerPublication (id, "sim1_pub", "type", "units");
+    EXPECT_TRUE (core->getPublication (id, "sim1_pub") == pub1);
+    EXPECT_EQ (core->getExtractionType (pub1), "type");
+    EXPECT_EQ (core->getExtractionUnits (pub1), "units");
+
+    core->enterInitializingMode (id);
+
+    core->enterExecutingMode (id);
+
+    core->timeRequest (id, 50.0);
+    std::string str1 = "hello world";
+    core->setValue (pub1, str1.data (), str1.size ());
+    auto valueUpdates = core->getValueUpdates (id);
+    EXPECT_TRUE (valueUpdates.empty ());
+    auto data = core->getValue (sub1);
+    EXPECT_TRUE (data == nullptr);
+
+    core->timeRequest (id, 100.0);
+    valueUpdates = core->getValueUpdates (id);
+    ASSERT_EQ (valueUpdates.size (), 1u);
+    EXPECT_EQ (valueUpdates[0], sub1);
+
+    data = core->getValue (sub1);
+    std::string str2 (data->to_string ());
+    EXPECT_EQ (str1, str2);
+    EXPECT_EQ (data->to_string (), "hello world");
+    EXPECT_EQ (data->size (), str1.size ());
+
+    core->setValue (pub1, "hello\n\0helloAgain", 17);
+    core->timeRequest (id, 150.0);
+    valueUpdates = core->getValueUpdates (id);
+    EXPECT_EQ (valueUpdates[0], sub1);
+    EXPECT_EQ (valueUpdates.size (), 1u);
+    data = core->getValue (sub1);
+    EXPECT_EQ (data->to_string (), std::string ("hello\n\0helloAgain", 17));
+    EXPECT_EQ (data->size (), 17u);
+
+    core->timeRequest (id, 200.0);
+    valueUpdates = core->getValueUpdates (id);
+    EXPECT_TRUE (valueUpdates.empty ());
+    core->finalize (id);
+    core->disconnect ();
+    core = nullptr;
+    helics::CoreFactory::cleanUpCores ();
+}
+
+TEST (InprocCore_tests, send_receive_test)
+{
+    const char *initializationString = "--autobroker --broker=\"brk1\" --brokerinit=\"--name=brk1\"";
+    auto core = create (helics::core_type::INPROC, initializationString);
+
+    ASSERT_TRUE (core != nullptr);
+    EXPECT_TRUE (core->isConfigured ());
+
+    EXPECT_EQ (core->getFederationSize (), 0);
+    core->connect ();
+    ASSERT_TRUE (core->isConnected ());
+    auto id = core->registerFederate ("sim1", helics::CoreFederateInfo ());
+
+    EXPECT_EQ (core->getFederateName (id), "sim1");
+    EXPECT_TRUE (core->getFederateId ("sim1") == id);
+
+    core->setTimeProperty (id, helics_property_time_delta, 1.0);
+
+    auto end1 = core->registerEndpoint (id, "end1", "type");
+    EXPECT_EQ (core->getInjectionType (end1), "type");
+
+    auto end2 = core->registerEndpoint (id, "end2", "type");
+    EXPECT_EQ (core->getInjectionType (end2), "type");
+
+    core->enterInitializingMode (id);
+
+    core->enterExecutingMode (id);
+
+    std::string str1 = "hello world";
+    core->timeRequest (id, 50.0);
+    core->send (end1, "end2", str1.data (), str1.size ());
+
+    core->timeRequest (id, 100.0);
+    EXPECT_EQ (core->receiveCount (end1), 0);
+    EXPECT_EQ (core->receiveCount (end2), 1u);
+    auto msg = core->receive (end1);
+    EXPECT_TRUE (msg == nullptr);
+    msg = core->receive (end2);
+    EXPECT_EQ (core->receiveCount (end2), 0);
+    std::string str2 (msg->data.to_string ());
+    EXPECT_EQ (str1, str2);
+    EXPECT_EQ (msg->data.size (), str1.size ());
+    core->disconnect ();
+    core = nullptr;
+    helics::CoreFactory::cleanUpCores ();
+}
+
+TEST (InprocCore_tests, messagefilter_callback_test)
+{
+    // Create filter operator
+    class TestOperator : public helics::FilterOperator
+    {
+      public:
+        explicit TestOperator (const std::string &name) : filterName (name) {}
+
+        std::unique_ptr<helics::Message> process (std::unique_ptr<helics::Message> msg) override
+        {
+            msg->source = filterName;
+
+            if (!msg->data.empty ())
+            {
+                ++msg->data[0];
+            }
+            return msg;
+        }
+
+        std::string filterName;
+    };
+
+    std::string configureString = "--autobroker";
+    auto core = create (helics::core_type::INPROC, configureString);
+
+    ASSERT_TRUE (core != nullptr);
+    EXPECT_TRUE (core->isConfigured ());
+    core->connect ();
+    ASSERT_TRUE (core->isConnected ());
+    auto id = core->registerFederate ("sim1", helics::CoreFederateInfo ());
+
+    auto end1 = core->registerEndpoint (id, "end1", "type");
+    auto end2 = core->registerEndpoint (id, "end2", "type");
+
+    auto srcFilter = core->registerFilter ("srcFilter", "type", "type");
+    core->addSourceTarget (srcFilter, "end1");
+    auto dstFilter = core->registerFilter ("dstFilter", "type", "type");
+    core->addDestinationTarget (dstFilter, "end2");
+
+    auto testSrcFilter = std::make_shared<TestOperator> ("sourceFilter");
+    EXPECT_EQ (testSrcFilter->filterName, "sourceFilter");
+
+    auto testDstFilter = std::make_shared<TestOperator> ("destinationFilter");
+    EXPECT_EQ (testDstFilter->filterName, "destinationFilter");
+
+    core->setFilterOperator (srcFilter, testSrcFilter);
+    core->setFilterOperator (dstFilter, testDstFilter);
+
+    core->enterInitializingMode (id);
+    core->enterExecutingMode (id);
+
+    std::string msgData = "hello world";
+    core->send (end1, "end2", msgData.data (), msgData.size () + 1);
+
+    core->timeRequest (id, 50.0);
+
+    // Receive the filtered message
+    EXPECT_EQ (core->receiveCount (end2), 1u);
+    auto msg = core->receive (end2);
+    EXPECT_EQ (msg->original_source, "end1");
+    auto res = msg->data.to_string ();
+    EXPECT_EQ (res.compare (0, 11, "jello world"), 0);
+    core->finalize (id);
+    testSrcFilter = nullptr;
+    testDstFilter = nullptr;
+    core->disconnect ();
+    core = nullptr;
+    helics::CoreFactory::cleanUpCores ();
+}

--- a/tests/helics/coreTypeLists.hpp
+++ b/tests/helics/coreTypeLists.hpp
@@ -66,26 +66,36 @@ SPDX-License-Identifier: BSD-3-Clause
 #define UDPTEST4
 
 #endif
+
+#ifdef ENABLE_INPROC_CORE
+#define INPROCTEST "inproc",
+#define INPROCTEST2 "inproc_2",
+#define INPROCTEST3 "inproc_3",
+#define INPROCTEST4 "inproc_4",
+#else
+#define INPROCTEST
+#define INPROCTEST2
+#define INPROCTEST3
+#define INPROCTEST4
+#endif
+
 #ifdef ENABLE_ZMQ_CORE
 constexpr const char *ztypes[] = {ZMQTEST ZMQSSTEST ZMQTEST2 ZMQTEST3 ZMQSSTEST2 ZMQTEST4};
 #endif
 
-constexpr const char *core_types[] = {"test", ZMQTEST3 IPCTEST2 TCPTEST "test_2",
-                                      ZMQTEST UDPTEST TCPSSTEST ZMQSSTEST "test_3"};
+constexpr const char *core_types[] = {"test", ZMQTEST3 IPCTEST2 TCPTEST INPROCTEST2 ZMQTEST UDPTEST TCPSSTEST
+                                                ZMQSSTEST INPROCTEST3};
 
 constexpr const char *core_types_2[] = {IPCTEST2 TCPTEST2 ZMQSSTEST2 "test_2", TCPSSTEST2 ZMQTEST2 UDPTEST2};
 
-constexpr const char *core_types_simple[] = {"test", TCPSSTEST ZMQSSTEST IPCTEST TCPTEST ZMQTEST UDPTEST};
-constexpr const char *core_types_single[] = {"test", TCPSSTEST IPCTEST TCPTEST ZMQTEST UDPTEST "test_3",
+constexpr const char *core_types_simple[] = {INPROCTEST TCPSSTEST ZMQSSTEST IPCTEST TCPTEST ZMQTEST UDPTEST};
+constexpr const char *core_types_single[] = {INPROCTEST TCPSSTEST IPCTEST TCPTEST ZMQTEST UDPTEST "test_3",
                                              ZMQTEST3 TCPTEST3 ZMQSSTEST UDPTEST3};
-constexpr const char *core_types_all[] = {"test", TCPSSTEST ZMQSSTEST IPCTEST2 TCPTEST "test_2",
-                                          ZMQTEST UDPTEST TCPSSTEST2 "test_3",
-                                          ZMQTEST3 IPCTEST ZMQTEST2 UDPTEST2 ZMQSSTEST2 TCPTEST2 UDPTEST3 TCPTEST3
-                                          "test_4",
-                                          ZMQTEST4 TCPTEST4 UDPTEST4};
+constexpr const char *core_types_all[] = {
+  INPROCTEST TCPSSTEST ZMQSSTEST IPCTEST2 TCPTEST INPROCTEST2 ZMQTEST UDPTEST TCPSSTEST2 "test_3",
+  ZMQTEST3 IPCTEST ZMQTEST2 UDPTEST2 ZMQSSTEST2 TCPTEST2 UDPTEST3 TCPTEST3 INPROCTEST4 ZMQTEST4 TCPTEST4 UDPTEST4};
 
-constexpr const char *core_types_extended[] = {IPCTEST ZMQTEST2 UDPTEST2 TCPTEST2 UDPTEST3 ZMQSSTEST2 TCPTEST3
-                                               "test_4",
-                                               ZMQTEST4 TCPTEST4 UDPTEST4};
+constexpr const char *core_types_extended[] = {
+  IPCTEST ZMQTEST2 UDPTEST2 TCPTEST2 UDPTEST3 ZMQSSTEST2 TCPTEST3 INPROCTEST4 ZMQTEST4 TCPTEST4 UDPTEST4};
 
 constexpr const char *defaultNamePrefix = "fed";


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will split the test core used in HELICS into two parts which can have different goals.  The inproc core will be intended to provide in process memory transfer between federates and can be optimized for that purpose.  The test core will be focused on provided convenient means of testing communication robustness in HELICS.  Previously the test core provided both of these purposes however these roles have started to come into conflict necessitating a split.  

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add two new core type definitions
- split the test core into two (mostly similar at this point) core types
- add dedicated tests for the in proc core
- add compiler option for the core
- change most tests to use the inproc core

