### PR TITLE
Add -doxygen flag to Python and Java swig interface generation-only option

### DIFF
--- a/interfaces/java/javaSwigGenerateOnly.cmake
+++ b/interfaces/java/javaSwigGenerateOnly.cmake
@@ -11,11 +11,15 @@
 
 file(GLOB SHARED_LIB_HEADERS ${CMAKE_SOURCE_DIR}/src/helics/shared_api_library/*.h)
 
+if(SWIG_VERSION VERSION_GREATER "4.0.0")
+  set(SWIG_DOXYGEN_FLAG "-doxygen")
+endif()
+
   # custom command for building the wrap file
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/helicsJava.c
     COMMAND
-      "${SWIG_EXECUTABLE}" "-java" "-package" "com.java.helics" -o "helicsJava.c"
+      "${SWIG_EXECUTABLE}" "-java" "-package" "com.java.helics" -o "helicsJava.c" "${SWIG_DOXYGEN_FLAG}"
       "-I${CMAKE_SOURCE_DIR}/src/helics/shared_api_library"
       ${CMAKE_CURRENT_SOURCE_DIR}/helicsJava.i
     DEPENDS

--- a/interfaces/python/pythonSwigGenerateOnly.cmake
+++ b/interfaces/python/pythonSwigGenerateOnly.cmake
@@ -11,11 +11,15 @@
 
 file(GLOB SHARED_LIB_HEADERS ${CMAKE_SOURCE_DIR}/src/helics/shared_api_library/*.h)
 
+if(SWIG_VERSION VERSION_GREATER "4.0.0")
+  set(SWIG_DOXYGEN_FLAG "-doxygen")
+endif()
+
   # custom command for building the wrap file
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/helicsPython.c
     COMMAND
-      "${SWIG_EXECUTABLE}" "-python" "-py3" -o "helicsPython.c"
+      "${SWIG_EXECUTABLE}" "-python" "-py3" -o "helicsPython.c" "${SWIG_DOXYGEN_FLAG}"
       "-I${CMAKE_SOURCE_DIR}/src/helics/shared_api_library"
       ${CMAKE_CURRENT_SOURCE_DIR}/helicsPython.i
     DEPENDS


### PR DESCRIPTION
### Summary
<!-- please finish the following statement -->
If merged this pull request will add a -doxygen flag for updating the generated Java and Python interfaces code.

### Proposed changes
- Add `-doxygen` flag when generating updated Python and Java interface files with SWIG
