### PR TITLE
fix missing return value in psuedo header for the CPP shared library …

### DIFF
--- a/src/helics/cxx_shared_library/BrokerFactory.hpp
+++ b/src/helics/cxx_shared_library/BrokerFactory.hpp
@@ -100,7 +100,7 @@ registered or when the clean up function is called this prevents some odd thread
 @param delay the number of milliseconds to wait to ensure stuff is cleaned up
 @return the number of brokers still operating
 */
-HELICS_SHARED_DEPRECATED size_t cleanUpBrokers (std::chrono::milliseconds delay){};
+HELICS_SHARED_DEPRECATED size_t cleanUpBrokers (std::chrono::milliseconds delay) { return 0; };
 
 /** make a copy of the broker pointer to allow access to the new name
 @return true if successful


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will fix a missing return value in the brokerFactory header used in the C++ shared library

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add a return value in a function that was missing one in the brokerFactory header used in the C++ shared library
