### PR TITLE
Add macOS installers and Linux shared library to release build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -285,7 +285,7 @@ jobs:
       run: |
         brew install swig
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
+        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
         cmake --build . --config Release
         cpack_dir="$(which cmake)"
         cpack_dir="${cpack_dir%/cmake}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -283,7 +283,7 @@ jobs:
       # 1. replacing x86 with Win32 (setting the Python version uses x86)
       # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
       run: |
-        brew install swig
+        brew install swig boost
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
         cmake --build . --config Release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -272,6 +272,11 @@ jobs:
         ref: develop
       if: github.event_name == 'schedule'
         
+    # Build with Python 3.6 interface
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+        
     # Compile HELICS and create the installer
     - name: Build installer
       shell: bash

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -385,6 +385,7 @@ jobs:
       # This uses bash variable substitution in a few places
       # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
       run: |
+        sudo apt-get install -y libboost-dev
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
         cmake --build . --config Release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -254,11 +254,68 @@ jobs:
         path: artifact
         
 ################################
+# Build macOS shared library
+################################
+  build-macos-sharedlib:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+    steps:
+    - name: Checkout event ref
+      uses: actions/checkout@v1
+      if: github.event.action == 'published'
+    
+    - name: Checkout develop branch
+      uses: actions/checkout@v1
+      with:
+        ref: develop
+      if: github.event_name == 'schedule'
+        
+    # Compile HELICS and create the installer
+    - name: Build installer
+      env:
+        BUILD_ARCH: ${{ matrix.arch }}
+        BUILD_GEN: ${{ matrix.cmake_gen }}
+        MSVC_VER: ${{ matrix.msvc_ver }}
+      shell: bash
+      # This uses bash variable substitution in a few places
+      # 1. replacing x86 with Win32 (setting the Python version uses x86)
+      # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+      run: |
+        brew install -y swig
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
+        cmake --build . --config Release
+        cpack_dir="$(which cmake)"
+        cpack_dir="${cpack_dir%/cmake}"
+        "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
+        cd ../artifact
+        rm -rf _CPack_Packages
+        ARCHIVE_FILE="$(ls Helics-*)"
+        mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"
+        
+    - name: Upload installer to release
+      if: github.event.action == 'published'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOAD_URL: ${{ github.event.release.upload_url }}
+      shell: bash
+      run: ./.github/workflows/upload-release-asset.sh "$(ls artifact/Helics-*)"
+      
+    # GitHub Actions combines artifacts uploaded with the same name
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: macos-installers
+        path: artifact
+      
+################################
 # Generate SHA-256 file
 ################################
   generate-sha256:
     name: Calculate SHA256 for release assets
-    needs: [create-all-submodule-archive, build-windows-installer, build-windows-msvc, build-windows-sharedlib]
+    needs: [create-all-submodule-archive, build-windows-installer, build-windows-msvc, build-windows-sharedlib, build-macos-sharedlib]
     runs-on: ubuntu-latest
     if: github.event.action == 'published'
     steps:
@@ -274,6 +331,12 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: windows-installers
+        path: artifacts
+        
+    - name: Get macOS installers
+      uses: actions/download-artifact@v1
+      with:
+        name: macos-installers
         path: artifacts
         
     - name: Create SHA-256 file

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -252,7 +252,57 @@ jobs:
       with:
         name: windows-installers
         path: artifact
+      
+################################
+# Build macOS installer
+################################
+  build-macos-installer:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+    steps:
+    - name: Checkout event ref
+      uses: actions/checkout@v1
+      if: github.event.action == 'published'
+    
+    - name: Checkout develop branch
+      uses: actions/checkout@v1
+      with:
+        ref: develop
+      if: github.event_name == 'schedule'
         
+    # Compile HELICS and create the installer
+    - name: Build installer
+      shell: bash
+      # This uses bash variable substitution in a few places
+      # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+      run: |
+        brew install swig boost
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_JAVA_INTERFACE=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DBUILD_TESTING=OFF .. || true
+        cmake --build . --config Release
+        cpack_dir="$(which cmake)"
+        cpack_dir="${cpack_dir%/cmake}"
+        "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
+        cd ../artifact
+        rm -rf _CPack_Packages
+        
+    - name: Upload installer to release
+      if: github.event.action == 'published'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOAD_URL: ${{ github.event.release.upload_url }}
+      shell: bash
+      run: ./.github/workflows/upload-release-asset.sh "$(ls artifact/Helics-*)"
+      
+    # GitHub Actions combines artifacts uploaded with the same name
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: macos-installers
+        path: artifact
+      
 ################################
 # Build macOS shared library
 ################################
@@ -274,18 +324,13 @@ jobs:
         
     # Compile HELICS and create the installer
     - name: Build installer
-      env:
-        BUILD_ARCH: ${{ matrix.arch }}
-        BUILD_GEN: ${{ matrix.cmake_gen }}
-        MSVC_VER: ${{ matrix.msvc_ver }}
       shell: bash
       # This uses bash variable substitution in a few places
-      # 1. replacing x86 with Win32 (setting the Python version uses x86)
-      # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+      # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
       run: |
         brew install swig boost
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
+        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
         cmake --build . --config Release
         cpack_dir="$(which cmake)"
         cpack_dir="${cpack_dir%/cmake}"
@@ -309,13 +354,64 @@ jobs:
       with:
         name: macos-installers
         path: artifact
+        
+################################
+# Build Linux shared library
+################################
+  build-linux-sharedlib:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - name: Checkout event ref
+      uses: actions/checkout@v1
+      if: github.event.action == 'published'
+    
+    - name: Checkout develop branch
+      uses: actions/checkout@v1
+      with:
+        ref: develop
+      if: github.event_name == 'schedule'
+        
+    # Compile HELICS and create the installer
+    - name: Build installer
+      shell: bash
+      # This uses bash variable substitution in a few places
+      # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
+        cmake --build . --config Release
+        cpack_dir="$(which cmake)"
+        cpack_dir="${cpack_dir%/cmake}"
+        "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
+        cd ../artifact
+        rm -rf _CPack_Packages
+        ARCHIVE_FILE="$(ls Helics-*)"
+        mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"
+        
+    - name: Upload installer to release
+      if: github.event.action == 'published'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOAD_URL: ${{ github.event.release.upload_url }}
+      shell: bash
+      run: ./.github/workflows/upload-release-asset.sh "$(ls artifact/Helics-*)"
+      
+    # GitHub Actions combines artifacts uploaded with the same name
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: linux-installers
+        path: artifact
       
 ################################
 # Generate SHA-256 file
 ################################
   generate-sha256:
     name: Calculate SHA256 for release assets
-    needs: [create-all-submodule-archive, build-windows-installer, build-windows-msvc, build-windows-sharedlib, build-macos-sharedlib]
+    needs: [create-all-submodule-archive, build-windows-installer, build-windows-msvc, build-windows-sharedlib, build-macos-installer, build-macos-sharedlib, build-linux-sharedlib]
     runs-on: ubuntu-latest
     if: github.event.action == 'published'
     steps:
@@ -337,6 +433,12 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: macos-installers
+        path: artifacts
+        
+    - name: Get Linux installers
+      uses: actions/download-artifact@v1
+      with:
+        name: linux-installers
         path: artifacts
         
     - name: Create SHA-256 file

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -283,7 +283,7 @@ jobs:
       # 1. replacing x86 with Win32 (setting the Python version uses x86)
       # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
       run: |
-        brew install -y swig
+        brew install swig
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF .. || true
         cmake --build . --config Release


### PR DESCRIPTION

### Summary
<!-- please finish the following statement -->
If merged this pull request will add builds for a macOS and Linux shared library, and a macOS archive that includes some extras like the compiled apps to the releases workflow.

Latest test run at https://github.com/nightlark/HELICS/releases/tag/vMac.7 (MSVC archive builds failed due to swig archive not downloading, probably sourceforge issues -- rerun is at https://github.com/nightlark/HELICS/releases/tag/vMac.8)

### Proposed changes
- Add a macOS and Linux shared libraries (+ headers and swig *.i files) to the release build workflow
- Add a macOS archive that includes pre-compiled apps and some interfaces to the release build workflow
