### PR TITLE
Update some CMake option names to use their new HELICS_ name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ if(ENABLE_ZMQ_CORE)
     include(addZeroMQ)
 
     if(ZeroMQ_FOUND)
-        if(ZMQ_USE_STATIC_LIBRARY)
+        if(HELICS_USE_ZMQ_STATIC_LIBRARY)
             set(ZeroMQ_DEPENDENCY libzmq-static)
             target_compile_definitions(helics_base INTERFACE -DZMQ_STATIC)
         else()
@@ -555,7 +555,7 @@ else()
 endif()
 
 if(NOT WIN32)
-    if(ENABLE_ZMQ_CORE AND NOT ZMQ_USE_STATIC_LIBRARY)
+    if(ENABLE_ZMQ_CORE AND NOT HELICS_USE_ZMQ_STATIC_LIBRARY)
         get_target_property(zmqlibfile libzmq IMPORTED_LOCATION)
         if(NOT zmqlibfile)
             get_target_property(zmqlibfile libzmq IMPORTED_LOCATION_RELEASE)
@@ -851,7 +851,7 @@ cmake_dependent_option(
 if(HELICS_ENABLE_PACKAGE_BUILD)
 
     if(CMAKE_VERSION VERSION_LESS 3.13)
-        if(ZMQ_SUBPROJECT OR ZMQ_FORCE_SUBPROJECT)
+        if(HELICS_ZMQ_SUBPROJECT OR HELICS_ZMQ_FORCE_SUBPROJECT)
             if(ENABLE_ZMQ_CORE)
                 message(
                     FATAL_ERROR

--- a/config/Docker/Dockerfile-HELICS
+++ b/config/Docker/Dockerfile-HELICS
@@ -30,7 +30,7 @@ RUN if [ "${ENABLE_GITHUB-}" = "true" ]; then rm -rf HELICS && git clone --depth
 
 # Generates the makefiles for building HELICS without tests, examples, C shared library, or the IPC core
 # Build type is set to release for the optimized binaries (and smaller size)
-RUN mkdir build && cd build && cmake -DBUILD_HELICS_TESTS=OFF -DDISABLE_BOOST=ON -DBUILD_HELICS_EXAMPLES=OFF -DDISABLE_C_SHARED_LIB=ON \
+RUN mkdir build && cd build && cmake -DHELICS_BUILD_TESTS=OFF -DHELICS_DISABLE_BOOST=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_DISABLE_C_SHARED_LIB=ON \
   -DCMAKE_BUILD_TYPE=Release -DHELICS_BINARY_ONLY_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/root/develop/helics-install /root/HELICS
 
 # Compile and install HELICS to a temporary prefix (for easy copying to the final image)


### PR DESCRIPTION
### Summary
If merged this pull request will rename some instances of CMake options that have been renamed to have a HELICS_ prefix.

### Proposed changes
- Update ZMQ option names using old names to new HELICS_ name
- Update option names used in Dockerfile-HELICS
