### PR TITLE
Disable asio option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 A note on future revisions.  
   Everything within a major version number should be code compatible (with the exception of experimental interfaces).  The most notable example of an experimental interface is the support for multiple source inputs.  The APIs to deal with this will change in future minor releases.  Everything within a single minor release should be network compatible with other federates on the same minor release number.  Compatibility across minor release numbers may be possible in some situations but we are not going to guarantee this as those components are subject to performance improvements and may need to be modified at some point.  Patch releases will be limited to bug fixes and other improvements not impacting the public API or network compatibility.  Check the [Public API](./docs/Public_API.md) for details on what is included and excluded from the public API and version stability.
 
+## \[2.3.1\] ~ In Development
+Bug Fixes and some code refactoring
+### Changed
+
+### Fixed 
+-   Some documentation links in the docs
+
+### Added
+-   CMake option for `HELICS_DISABLE_ASIO` to completely remove the use the ASIO library, turns off the UDP, and TCP core types, all realtime capabilities, and timeout and heartbeat detection for cores and brokers.  ASIO doesn't support all version of cygwin.  
+   
+
+### Deprecated 
+
+### Removed
+-  The option for `ENABLE_INPROC_CORE` will not show in the cmake-gui if `HELICS_BUILD_BENCHMARKS` is enabled. 
+-  The Option for `ENABLE_TEST_CORE` will not show in the cmake-gui if `HELICS_BUILD_TESTS` is enabled.
+
 ## \[2.3.0\] ~ 2019-11-12
 Minor release with lots of CMake updates and build changes and a few fixes and additions.  The biggest change is in the C++ shared library and complete removal of boost\:\:test.
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,15 @@ if(MSYS
     set(UNIX_LIKE TRUE)
 endif()
 
-# allow BOOST library inclusion to be turned off completely to be turned off completely
+# allow BOOST library inclusion to be turned off completely
+# this will disable the IPC core
 option(HELICS_DISABLE_BOOST OFF "disable all references to the Boost C++ libraries")
 mark_as_advanced(HELICS_DISABLE_BOOST)
+
+# allow ASIO library inclusion to be turned off completely 
+# this will disable the UDP and TCP core as well as the timeout detection and real-time features of HELICS
+option(HELICS_DISABLE_ASIO OFF "disable all references to the ASIO C++ libraries")
+mark_as_advanced(HELICS_DISABLE_ASIO)
 
 # we want to acknowledge this flag since it is standard C++ but it can cause issues in
 # submodules so we need to set other variables
@@ -330,8 +336,10 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/ThirdParty/fmtlib/CMakeLists.txt")
     submod_update(ThirdParty/fmtlib)
 endif()
 
-if(NOT EXISTS "${PROJECT_SOURCE_DIR}/ThirdParty/asio/asio/include/asio.hpp")
-    submod_update(ThirdParty/asio)
+if (NOT HELICS_DISABLE_ASIO)
+    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/ThirdParty/asio/asio/include/asio.hpp")
+        submod_update(ThirdParty/asio)
+    endif()
 endif()
 
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/ThirdParty/jsoncpp/CMakeLists.txt")
@@ -370,8 +378,8 @@ endif()
 
 option(ENABLE_MPI_CORE "Enable MPI networking library" OFF)
 option(ENABLE_ZMQ_CORE "Enable ZeroMQ networking library" ON)
-option(ENABLE_TCP_CORE "Enable TCP core types" ON)
-option(ENABLE_UDP_CORE "Enable UDP core types" ON)
+cmake_dependent_advanced_option(ENABLE_TCP_CORE "Enable TCP core types" ON "NOT HELICS_DISABLE_ASIO" OFF)
+cmake_dependent_advanced_option(ENABLE_UDP_CORE "Enable UDP core types" ON "NOT HELICS_DISABLE_ASIO" OFF)
 cmake_dependent_advanced_option(
     ENABLE_IPC_CORE "Enable Interprocess communication types" ON
     "NOT HELICS_DISABLE_BOOST" OFF
@@ -381,7 +389,7 @@ option(ENABLE_INPROC_CORE "Enable inprocess core type" ON)
 option(ENABLE_ZMQ_CORE "Enable ZeroMQ networking library" ON)
 
 mark_as_advanced(
-    ENABLE_MPI_CORE ENABLE_ZMQ_CORE ENABLE_TCP_CORE ENABLE_UDP_CORE ENABLE_TEST_CORE
+    ENABLE_MPI_CORE ENABLE_ZMQ_CORE ENABLE_TEST_CORE
     ENABLE_ZMQ_CORE
 )
 
@@ -445,18 +453,18 @@ endif()
 if(ENABLE_ZMQ_CORE)
     include(addZeroMQ)
 
-    if(ZeroMQ_FOUND)
-        if(HELICS_USE_ZMQ_STATIC_LIBRARY)
-            set(ZeroMQ_DEPENDENCY libzmq-static)
-            target_compile_definitions(helics_base INTERFACE -DZMQ_STATIC)
-        else()
-            set(ZeroMQ_DEPENDENCY libzmq)
-        endif()
-        # message(STATUS "zmq dep ${ZeroMQ_DEPENDENCY}")
-        target_link_libraries(helics_base INTERFACE ${ZeroMQ_DEPENDENCY})
-    else(ZeroMQ_FOUND)
-        message(FATAL_ERROR "ZeroMQ not found")
-    endif(ZeroMQ_FOUND)
+    if(NOT ZeroMQ_FOUND)
+	    message(FATAL_ERROR "ZeroMQ not found needed for to enable the ZMQ Core")
+	endif()
+	
+    if(HELICS_USE_ZMQ_STATIC_LIBRARY)
+        set(ZeroMQ_DEPENDENCY libzmq-static)
+        target_compile_definitions(helics_base INTERFACE -DZMQ_STATIC)
+    else()
+        set(ZeroMQ_DEPENDENCY libzmq)
+    endif()
+    # message(STATUS "zmq dep ${ZeroMQ_DEPENDENCY}")
+    target_link_libraries(helics_base INTERFACE ${ZeroMQ_DEPENDENCY})
 endif()
 
 # -----------------------------------------------------------------------------
@@ -503,12 +511,13 @@ endif()
 # -------------------------------------------------------------
 # Asio include directories
 # -------------------------------------------------------------
-target_compile_definitions(helics_base INTERFACE "-DASIO_STANDALONE")
-target_include_directories(
-    helics_base SYSTEM
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/asio/asio/include>
-)
-
+if (NOT HELICS_DISABLE_ASIO)
+    target_compile_definitions(helics_base INTERFACE "-DASIO_STANDALONE")
+    target_include_directories(
+        helics_base SYSTEM
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ThirdParty/asio/asio/include>
+    )
+endif()
 # -------------------------------------------------------------
 # setting the RPATH
 # -------------------------------------------------------------
@@ -768,8 +777,6 @@ endif(NOT HELICS_BINARY_ONLY_INSTALL)
 # combine 3rd party license files for install package
 include(combineLicenses)
 set(LICENSE_LIST
-    "asio"
-    "${PROJECT_SOURCE_DIR}/ThirdParty/asio/asio/LICENSE_1_0.txt"
     "cereal"
     "${PROJECT_SOURCE_DIR}/ThirdParty/helics/external/cereal/LICENSE"
     "GMLC Concurrency"
@@ -806,7 +813,7 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.11)
         )
     endif()
 
-    if(EXISTS ${PROJECT_BINARY_DIR}/_deps/libzmq-src)
+    if(EXISTS ${PROJECT_BINARY_DIR}/_deps/libzmq-src AND ENABLE_ZMQ_CORE)
         list(APPEND LICENSE_LIST "ZeroMQ"
                     "${PROJECT_BINARY_DIR}/_deps/libzmq-src/COPYING"
         )
@@ -825,9 +832,14 @@ else()
         )
     endif()
 
-    if(EXISTS ${PROJECT_BINARY_DIR}/_deps/libzmq)
+    if(EXISTS ${PROJECT_BINARY_DIR}/_deps/libzmq AND ENABLE_ZMQ_CORE)
         list(APPEND LICENSE_LIST "ZeroMQ" "${PROJECT_BINARY_DIR}/_deps/libzmq/COPYING")
     endif()
+endif()
+
+if (NOT HELICS_DISABLE_ASIO)
+	list(APPEND LICENSE_LIST "asio"
+    "${PROJECT_SOURCE_DIR}/ThirdParty/asio/asio/LICENSE_1_0.txt")
 endif()
 
 combinelicenses(${PROJECT_BINARY_DIR}/THIRDPARTY_LICENSES ${LICENSE_LIST})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,7 +454,7 @@ if(ENABLE_ZMQ_CORE)
     include(addZeroMQ)
 
     if(NOT ZeroMQ_FOUND)
-	    message(FATAL_ERROR "ZeroMQ not found needed for to enable the ZMQ Core")
+	    message(FATAL_ERROR "ZeroMQ not found, needed to enable the ZMQ Core")
 	endif()
 	
     if(HELICS_USE_ZMQ_STATIC_LIBRARY)

--- a/config/helics-config.h.in
+++ b/config/helics-config.h.in
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #cmakedefine HELICS_ENABLE_TRACE_LOGGING
 #cmakedefine HELICS_ENABLE_DEBUG_LOGGING
 
+#cmakedefine HELICS_DISABLE_ASIO
 
 #cmakedefine HELICS_USE_PICOSECOND_TIME
 

--- a/docs/installation/helics_cmake_options.md
+++ b/docs/installation/helics_cmake_options.md
@@ -34,8 +34,8 @@ These options effect the configuration of HELICS itself and how/what gets built 
 -   `ENABLE_TCP_CORE` : \[Default=ON\] enable the HELICS TCPIP related core types
 -   `ENABLE_UDP_CORE` : \[Default=ON\] enable the HELICS UDP core type
 -   `ENABLE_IPC_CORE` : \[Default=ON\] enable the HELICS interprocess shared memory related core types
--   `ENABLE_TEST_CORE` : \[Default=OFF\] enable the HELICS in process core type with some additional features for tests, Required and enabled if the `HELICS_BUILD_TESTS` option is enabled,
--   `ENABLE_INPROC_CORE` : \[Default=ON\] enable the HELICS in process core type,  Required if `HELICS_BUILD_BENCHMARKS` is on. 
+-   `ENABLE_TEST_CORE` : \[Default=OFF\] enable the HELICS in process core type with some additional features for tests, required and enabled if the `HELICS_BUILD_TESTS` option is enabled
+-   `ENABLE_INPROC_CORE` : \[Default=ON\] enable the HELICS in process core type,  required if `HELICS_BUILD_BENCHMARKS` is on
 -   `ENABLE_MPI_CORE` : \[Default=OFF\] enable the HELICS Message Passing interface(MPI) related core types, most commonly used for High performance computing application (HPC)
 
 #### HELICS logging Options
@@ -52,7 +52,7 @@ Options effect the connection of libraries used in HELICS and how they are linke
 -   `STATIC_STANDARD_LIB`:   \[Default=OFF\] link the standard library as a static library for no additional C++ system dependencies
 -   `HELICS_ENABLE_SWIG`:    \[Default=OFF\] conditional option if `BUILD_MATLAB_INTERACE` or `BUILD_PYTHON_INTERFACE` or `BUILD_JAVA_INTERACE` is selected and no other option that requires swig is used.  This enables swig usage in cases where it would not otherwise be necessary.
 -   `HELICS_USE_NEW_PYTHON_FIND`:  \[Default=OFF\] if python is required, this option can be set to use newer FindPython routines from CMake, if CMake version in use is >=3.12,  This does change the variables that need to be set to link to a specific python, but can be helpful in some situations with newer python versions.   
--   `Boost_NO_BOOST_CMAKE`: \[Default=OFF\] This is an option related to the Boost find module, but is occasionally needed if a specific version of boost is desired and there is a system copy of BoostConfig.cmake.  So if an incorrect version of boost is being found even `BOOST_ROOT` is being specified this option might need to be set to `ON`.  
+-   `Boost_NO_BOOST_CMAKE`: \[Default=OFF\] This is an option related to the Boost find module, but is occasionally needed if a specific version of boost is desired and there is a system copy of BoostConfig.cmake.  So if an incorrect version of boost is being found even when `BOOST_ROOT` is being specified this option might need to be set to `ON`.  
 
 #### ZeroMQ related Options
 -   `HELICS_USE_SYSTEM_ZEROMQ_ONLY`:  \[Default=OFF\] Only find Zeromq through the system libraries, never attempt a local build.

--- a/docs/installation/helics_cmake_options.md
+++ b/docs/installation/helics_cmake_options.md
@@ -6,7 +6,7 @@
 -   `HELICS_BUILD_APP_LIBRARY` :  \[Default=ON\] tell HELICS to build the [app]() Library
 -   `HELICS_BUILD_APP_EXECUTABLES` : \[Default=ON\]build some executables associated with the apps
 -   `HELICS_BUILD_BENCHMARKS` :  \[Default=OFF\]Build some timing benchmarks associated with HELICS
--   `HELICS_BUILD_CXX_SHARED_LIB` :  \[Default=OFF\]Build a C++ shared library with the underlying C++ interface to HELICS
+-   `HELICS_BUILD_CXX_SHARED_LIB` :  \[Default=OFF\]Build C++ shared libraries of the Application API C++ interface to HELICS and if `HELICS_BUILD_APP_LIBRARY` is also enabled another C++ shared library with the APP library
 -   `HELICS_BUILD_EXAMPLES` :  \[Default=OFF\]Build a few select examples using HELICS,  this is mostly for testing purposes.  The main examples repo is [here](https://github.com/GMLC-TDC/HELICS-Examples)
 -   `HELICS_BUILD_TESTS` :  \[Default=OFF\]Build the HELICS unit and system test executables.
 -   `HELICS_ENABLE_LOGGING` :  \[Default=ON\] Enable debug and higher levels of logging,  if this is turned off that capability is completely removed from HELICS
@@ -34,7 +34,8 @@ These options effect the configuration of HELICS itself and how/what gets built 
 -   `ENABLE_TCP_CORE` : \[Default=ON\] enable the HELICS TCPIP related core types
 -   `ENABLE_UDP_CORE` : \[Default=ON\] enable the HELICS UDP core type
 -   `ENABLE_IPC_CORE` : \[Default=ON\] enable the HELICS interprocess shared memory related core types
--   `ENABLE_TEST_CORE` : \[Default=ON\] enable the HELICS in process core type,
+-   `ENABLE_TEST_CORE` : \[Default=OFF\] enable the HELICS in process core type with some additional features for tests, Required and enabled if the `HELICS_BUILD_TESTS` option is enabled,
+-   `ENABLE_INPROC_CORE` : \[Default=ON\] enable the HELICS in process core type,  Required if `HELICS_BUILD_BENCHMARKS` is on. 
 -   `ENABLE_MPI_CORE` : \[Default=OFF\] enable the HELICS Message Passing interface(MPI) related core types, most commonly used for High performance computing application (HPC)
 
 #### HELICS logging Options
@@ -44,12 +45,14 @@ These options effect the configuration of HELICS itself and how/what gets built 
 ### Build configuration Options
 Options effect the connection of libraries used in HELICS and how they are linked.
 -   `HELICS_DISABLE_BOOST` : \[Default=OFF\] Completely turn off searching and inclusion of boost libraries.  This will disable the IPC core and few other features, possibly more in the future.  
+-   `HELICS_DISABLE_ASIO` : \[Default=OFF\] Completely turn off  inclusion of ASIO libraries.  This will disable all TCP and UDP cores, disable real time mode for HELICS, and disable all timeout features for the Library so **use with caution**.  
 -   `ENABLE_SUBMODULE_UPDATE` : \[Default=ON\] enable CMake to automatically download the submodules and update them if Unnecessary
 -   `HELICS_ENABLE_ERROR_ON_WARNING` :\[Default=OFF\] turns on Werror or equivalent,  probably not useful for normal activity,  There isn't many warnings but left in to allow the possibility
 -   `HELICS_ENABLE_EXTRA_COMPILER_WARNINGS` : \[Default=ON\] turn on higher levels of warnings in the compilers,  can be turned off if you didn't need or want the warning checks.
 -   `STATIC_STANDARD_LIB`:   \[Default=OFF\] link the standard library as a static library for no additional C++ system dependencies
 -   `HELICS_ENABLE_SWIG`:    \[Default=OFF\] conditional option if `BUILD_MATLAB_INTERACE` or `BUILD_PYTHON_INTERFACE` or `BUILD_JAVA_INTERACE` is selected and no other option that requires swig is used.  This enables swig usage in cases where it would not otherwise be necessary.
 -   `HELICS_USE_NEW_PYTHON_FIND`:  \[Default=OFF\] if python is required, this option can be set to use newer FindPython routines from CMake, if CMake version in use is >=3.12,  This does change the variables that need to be set to link to a specific python, but can be helpful in some situations with newer python versions.   
+-   `Boost_NO_BOOST_CMAKE`: \[Default=OFF\] This is an option related to the Boost find module, but is occasionally needed if a specific version of boost is desired and there is a system copy of BoostConfig.cmake.  So if an incorrect version of boost is being found even `BOOST_ROOT` is being specified this option might need to be set to `ON`.  
 
 #### ZeroMQ related Options
 -   `HELICS_USE_SYSTEM_ZEROMQ_ONLY`:  \[Default=OFF\] Only find Zeromq through the system libraries, never attempt a local build.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -57,7 +57,7 @@ Alternatively, you can install from source. See the next section for more inform
     linux
     docker
     language
-	linking
+    linking
     helics_cmake_options
 ```
 
@@ -98,4 +98,4 @@ This means you can pass it configurations settings as a key value pair by adding
 For example, to build the Python extension all you need to do is pass in `-DBUILD_PYTHON_INTERFACE=ON`.
 You can also run `ccmake .` in the build folder, to get a command line interactive prompt to change configuration settings.
 On Windows, you can use the cmake GUI to do the same.
-Again, there are more instructions in the individual installation pages but a useful trick to know if something isn't documented or a slightly more advanced feature is required.  Available CMake options for HELICS are documented [here](helics_cmake_option.md).
+Again, there are more instructions in the individual installation pages but a useful trick to know if something isn't documented or a slightly more advanced feature is required.  Available CMake options for HELICS are documented [here](https://helics.readthedocs.io/en/latest/installation/helics_cmake_options.html).

--- a/src/helics/application_api/FederateInfo.cpp
+++ b/src/helics/application_api/FederateInfo.cpp
@@ -276,19 +276,20 @@ std::unique_ptr<helicsCLI11App> FederateInfo::makeCLIApp ()
         "--timedelta", [this] (Time val) { setProperty (helics_property_time_delta, val); },
         "The minimum time between time grants for a Federate (default in ms)")
       ->ignore_underscore ();
-    app
+	auto rtgroup = app->add_option_group("realtime");
+    rtgroup
       ->add_option_function<Time> (
         "--rtlag", [this] (Time val) { setProperty (helics_property_time_rt_lag, val); },
         "the amount of the time the federate is allowed to lag realtime before "
         "corrective action is taken (default in ms)")
       ->ignore_underscore ();
-    app
+    rtgroup
       ->add_option_function<Time> (
         "--rtlead", [this] (Time val) { setProperty (helics_property_time_rt_lead, val); },
         "the amount of the time the federate is allowed to lead realtime before "
         "corrective action is taken (default in ms)")
       ->ignore_underscore ();
-    app
+    rtgroup
       ->add_option_function<Time> (
         "--rttolerance", [this] (Time val) { setProperty (helics_property_time_rt_tolerance, val); },
         "the time tolerance of the real time mode (default in ms)")
@@ -321,9 +322,9 @@ std::unique_ptr<helicsCLI11App> FederateInfo::makeCLIApp ()
       ->add_option (
         "--separator",
         [this] (CLI::results_t res) {
-            separator = res[0][0];
             if (res[0].size () != 1)
                 return false;
+			separator = res[0][0];
             return true;
         },
         "separator character for local federates")
@@ -335,6 +336,9 @@ std::unique_ptr<helicsCLI11App> FederateInfo::makeCLIApp ()
       ->delimiter (',')
       ->each ([this] (const std::string &flag) { loadFlags (*this, flag); });
     app->allow_extras ();
+#ifdef HELICS_DISABLE_ASIO
+	rtgroup->disabled();
+#endif
     return app;
 }
 

--- a/src/helics/common/CMakeLists.txt
+++ b/src/helics/common/CMakeLists.txt
@@ -12,7 +12,6 @@ set(
     JsonProcessingFunctions.hpp
     JsonBuilder.hpp
     TomlProcessingFunctions.hpp
-    AsioContextManager.h
     logger.h
     loggerCore.hpp
     GuardedTypes.hpp
@@ -23,7 +22,6 @@ set(
 
 set(
     common_sources
-    AsioContextManager.cpp
     JsonProcessingFunctions.cpp
     JsonBuilder.cpp
     TomlProcessingFunctions.cpp
@@ -52,6 +50,11 @@ if(ENABLE_ZMQ_CORE)
     list(APPEND common_headers ${zmq_headers})
     list(APPEND common_sources ${zmq_sources})
 endif(ENABLE_ZMQ_CORE)
+
+if (NOT HELICS_DISABLE_ASIO)
+    list(APPEND common_headers AsioContextManager.h)
+    list(APPEND common_sources AsioContextManager.cpp)
+endif()
 
 add_library(helics_common STATIC ${common_sources} ${common_headers})
 set_target_properties(helics_common PROPERTIES LINKER_LANGUAGE CXX)

--- a/src/helics/core/BrokerBase.cpp
+++ b/src/helics/core/BrokerBase.cpp
@@ -489,7 +489,7 @@ void BrokerBase::queueProcessingLoop ()
             }
             messagesSinceLastTick = 0;
             // reschedule the timer
-#ifndef HELICS_DISABLE_ASIO
+			#ifndef HELICS_DISABLE_ASIO
             ticktimer.expires_at (std::chrono::steady_clock::now () + tickTimer.to_ns ());
             active = std::make_pair (true, true);
             ticktimer.async_wait (timerCallback);

--- a/src/helics/core/BrokerBase.cpp
+++ b/src/helics/core/BrokerBase.cpp
@@ -7,7 +7,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "BrokerBase.hpp"
 
-#include "../common/AsioContextManager.h"
 #include "../common/logger.h"
 #include "helicsCLI11.hpp"
 
@@ -17,7 +16,16 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gmlc/libguarded/guarded.hpp"
 #include "gmlc/utilities/stringOps.h"
 #include "loggingHelper.hpp"
-#include <asio/steady_timer.hpp>
+#ifndef HELICS_DISABLE_ASIO
+#    include "../common/AsioContextManager.h"
+#    include <asio/steady_timer.hpp>
+#else
+#    ifdef _WIN32
+#        include <Processthreadsapi.h>
+#    else
+#    endif
+#endif
+
 #include <iostream>
 
 static inline std::string genId ()
@@ -65,9 +73,9 @@ BrokerBase::~BrokerBase ()
         }
     }
 }
-std::function<void (int, const std::string &, const std::string &)> BrokerBase::getLoggingCallback () const
+std::function<void(int, const std::string &, const std::string &)> BrokerBase::getLoggingCallback () const
 {
-    return [this] (int level, const std::string &name, const std::string &message) {
+    return [this](int level, const std::string &name, const std::string &message) {
         sendToLogger (global_id.load (), level, name, message);
     };
 }
@@ -124,7 +132,7 @@ std::shared_ptr<helicsCLI11App> BrokerBase::generateBaseCLI ()
     logging_group->add_option ("--logfile", logFile, "the file to log the messages to")->ignore_underscore ();
     logging_group
       ->add_option_function<int> (
-        "--loglevel,--log-level", [this] (int val) { setLogLevel (val); },
+        "--loglevel,--log-level", [this](int val) { setLogLevel (val); },
         "the level which to log the higher this is set to the more gets logs(-1) for no logging")
       ->transform (CLI::CheckedTransformer (&log_level_map, CLI::ignore_case, CLI::ignore_underscore));
 
@@ -210,7 +218,7 @@ void BrokerBase::configureBase ()
     }
 
     timeCoord = std::make_unique<ForwardingTimeCoordinator> ();
-    timeCoord->setMessageSender ([this] (const ActionMessage &msg) { addActionMessage (msg); });
+    timeCoord->setMessageSender ([this](const ActionMessage &msg) { addActionMessage (msg); });
 
     loggingObj = std::make_unique<Logger> ();
     if (!logFile.empty ())
@@ -279,8 +287,7 @@ void BrokerBase::setLoggingFile (const std::string &lfile)
     }
 }
 
-void BrokerBase::setLoggerFunction (
-  std::function<void (int, const std::string &, const std::string &)> logFunction)
+void BrokerBase::setLoggerFunction (std::function<void(int, const std::string &, const std::string &)> logFunction)
 {
     loggerFunction = std::move (logFunction);
     if (loggerFunction)
@@ -309,7 +316,7 @@ void BrokerBase::setLogLevels (int32_t consoleLevel, int32_t fileLevel)
 {
     consoleLogLevel = consoleLevel;
     fileLogLevel = fileLevel;
-    maxLogLevel = std::max (consoleLogLevel, fileLogLevel);
+    maxLogLevel = (std::max)(consoleLogLevel, fileLogLevel);
     if (loggingObj)
     {
         loggingObj->changeLevels (consoleLogLevel, fileLogLevel);
@@ -341,7 +348,7 @@ void BrokerBase::addActionMessage (ActionMessage &&m)
         actionQueue.emplace (std::move (m));
     }
 }
-
+#ifndef HELICS_DISABLE_ASIO
 using activeProtector = gmlc::libguarded::guarded<std::pair<bool, bool>>;
 
 static void haltTimer (activeProtector &active, asio::steady_timer &tickTimer)
@@ -393,6 +400,8 @@ static void timerTickHandler (BrokerBase *bbase, activeProtector &active, const 
     p->second = false;
 }
 
+#endif
+
 bool BrokerBase::tryReconnect () { return false; }
 
 //#define DISABLE_TICK
@@ -404,13 +413,13 @@ void BrokerBase::queueProcessingLoop ()
         return;
     }
     std::vector<ActionMessage> dumpMessages;
-
+	#ifndef HELICS_DISABLE_ASIO
     auto serv = AsioContextManager::getContextPointer ();
     auto contextLoop = serv->startContextLoop ();
     asio::steady_timer ticktimer (serv->getBaseContext ());
     activeProtector active (true, false);
 
-    auto timerCallback = [this, &active] (const std::error_code &ec) { timerTickHandler (this, active, ec); };
+    auto timerCallback = [this, &active](const std::error_code &ec) { timerTickHandler (this, active, ec); };
     if (tickTimer > timeZero)
     {
         if (tickTimer < Time (0.5))
@@ -421,9 +430,10 @@ void BrokerBase::queueProcessingLoop ()
         ticktimer.expires_at (std::chrono::steady_clock::now () + tickTimer.to_ns ());
         ticktimer.async_wait (timerCallback);
     }
+	#endif
     global_broker_id_local = global_id.load ();
     int messagesSinceLastTick = 0;
-    auto logDump = [&, this] () {
+    auto logDump = [&, this]() {
         if (dumplog)
         {
             for (auto &act : dumpMessages)
@@ -436,8 +446,10 @@ void BrokerBase::queueProcessingLoop ()
     };
     if (haltOperations)
     {
+		#ifndef HELICS_DISABLE_ASIO
         haltTimer (active, ticktimer);
         contextLoop = nullptr;
+		#endif
         mainLoopIsRunning.store (false);
         return;
     }
@@ -463,8 +475,10 @@ void BrokerBase::queueProcessingLoop ()
         case CMD_TICK:
             if (checkActionFlag (command, error_flag))
             {
+				#ifndef HELICS_DISABLE_ASIO
                 contextLoop = nullptr;
                 contextLoop = serv->startContextLoop ();
+				#endif
             }
             if (messagesSinceLastTick == 0 || forwardTick)
             {
@@ -475,9 +489,11 @@ void BrokerBase::queueProcessingLoop ()
             }
             messagesSinceLastTick = 0;
             // reschedule the timer
+#ifndef HELICS_DISABLE_ASIO
             ticktimer.expires_at (std::chrono::steady_clock::now () + tickTimer.to_ns ());
             active = std::make_pair (true, true);
             ticktimer.async_wait (timerCallback);
+			#endif
             break;
         case CMD_PING:
             // ping is processed normally but doesn't count as an actual message for timeout purposes unless it
@@ -492,8 +508,10 @@ void BrokerBase::queueProcessingLoop ()
         default:
             break;
         case CMD_TERMINATE_IMMEDIATELY:
+			#ifndef HELICS_DISABLE_ASIO
             haltTimer (active, ticktimer);
             contextLoop = nullptr;
+			#endif
             mainLoopIsRunning.store (false);
             logDump ();
             {
@@ -510,8 +528,10 @@ void BrokerBase::queueProcessingLoop ()
             }
             return;  // immediate return
         case CMD_STOP:
+			#ifndef HELICS_DISABLE_ASIO
             haltTimer (active, ticktimer);
             contextLoop = nullptr;
+			#endif
             if (!haltOperations)
             {
                 processCommand (std::move (command));

--- a/src/helics/core/BrokerBase.cpp
+++ b/src/helics/core/BrokerBase.cpp
@@ -21,7 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #    include <asio/steady_timer.hpp>
 #else
 #    ifdef _WIN32
-#        include <Processthreadsapi.h>
+#        include <windows.h>
 #    else
 #    endif
 #endif

--- a/src/helics/core/CMakeLists.txt
+++ b/src/helics/core/CMakeLists.txt
@@ -31,11 +31,11 @@ set(
     HandleManager.cpp
     FilterCoordinator.cpp
     UnknownHandleManager.cpp
-    MessageTimer.cpp
     federate_id.cpp
     TimeoutMonitor.cpp
 	coreTypeOperations.cpp
 )
+
 
 set(TESTCORE_SOURCE_FILES test/TestBroker.cpp test/TestCore.cpp test/TestComms.cpp)
 
@@ -124,7 +124,6 @@ set(
     HandleManager.hpp
     UnknownHandleManager.hpp
     queryHelpers.hpp
-    MessageTimer.hpp
     NetworkBroker.hpp
     NetworkCore.hpp
     NetworkBroker_impl.hpp
@@ -133,6 +132,12 @@ set(
     networkDefaults.hpp
     ../helics_enums.h
 )
+
+if (NOT HELICS_DISABLE_ASIO)
+    list(APPEND SRC_FILES MessageTimer.cpp)
+    list(APPEND INCLUDE_FILES MessageTimer.hpp)
+endif()
+
 
 set(TESTCORE_HEADER_FILES test/TestCore.h test/TestBroker.h test/TestComms.h)
 

--- a/src/helics/core/MessageTimer.hpp
+++ b/src/helics/core/MessageTimer.hpp
@@ -6,8 +6,9 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 #pragma once
 
-#include "../common/AsioContextManager.h"
+
 #include "ActionMessage.hpp"
+#include "../common/AsioContextManager.h"
 #include <asio/steady_timer.hpp>
 #include <memory>
 #include <mutex>

--- a/src/helics/core/NetworkBrokerData.cpp
+++ b/src/helics/core/NetworkBrokerData.cpp
@@ -10,9 +10,11 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gmlc/netif/NetIF.hpp"
 #include "helicsCLI11.hpp"
 
+#ifndef HELICS_DISABLE_ASIO
 #include "../common/AsioContextManager.h"
 #include <asio/ip/host_name.hpp>
 #include <asio/ip/tcp.hpp>
+#endif
 
 #include <algorithm>
 #include <iostream>
@@ -368,6 +370,7 @@ auto matchcount (InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last
 
 std::string getLocalExternalAddressV4 ()
 {
+	#ifndef HELICS_DISABLE_ASIO
     auto srv = AsioContextManager::getContextPointer ();
 
     asio::ip::tcp::resolver resolver (srv->getBaseContext ());
@@ -376,6 +379,9 @@ std::string getLocalExternalAddressV4 ()
     asio::ip::tcp::endpoint endpoint = *it;
 
     auto resolved_address = endpoint.address ().to_string ();
+	#else
+    std::string resolved_address;
+	#endif
     auto interface_addresses = gmlc::netif::getInterfaceAddressesV4 ();
 
     // Return the resolved address if no interface addresses were found
@@ -423,6 +429,7 @@ std::string getLocalExternalAddressV4 ()
 
 std::string getLocalExternalAddressV4 (const std::string &server)
 {
+	#ifndef HELICS_DISABLE_ASIO
     auto srv = AsioContextManager::getContextPointer ();
 
     asio::ip::tcp::resolver resolver (srv->getBaseContext ());
@@ -439,21 +446,25 @@ std::string getLocalExternalAddressV4 (const std::string &server)
     asio::ip::tcp::resolver::iterator end;
 
     auto sstring = (it_server == end) ? server : servep.address ().to_string ();
-
+	#else
+    std::string sstring = server;
+	#endif
+	
     auto interface_addresses = gmlc::netif::getInterfaceAddressesV4 ();
 
+	std::vector<std::string> resolved_addresses;
+	#ifndef HELICS_DISABLE_ASIO
     asio::ip::tcp::resolver::query query (asio::ip::tcp::v4 (), asio::ip::host_name (), "");
     asio::ip::tcp::resolver::iterator it = resolver.resolve (query);
     // asio::ip::tcp::endpoint endpoint = *it;
-
-    std::vector<std::string> resolved_addresses;
+    
     while (it != end)
     {
         asio::ip::tcp::endpoint ept = *it;
         resolved_addresses.push_back (ept.address ().to_string ());
         ++it;
     }
-
+	#endif
     auto candidate_addresses = prioritizeExternalAddresses (interface_addresses, resolved_addresses);
 
     int cnt = 0;
@@ -473,6 +484,7 @@ std::string getLocalExternalAddressV4 (const std::string &server)
 
 std::string getLocalExternalAddressV6 ()
 {
+	#ifndef HELICS_DISABLE_ASIO
     auto srv = AsioContextManager::getContextPointer ();
 
     asio::ip::tcp::resolver resolver (srv->getBaseContext ());
@@ -481,6 +493,9 @@ std::string getLocalExternalAddressV6 ()
     asio::ip::tcp::endpoint endpoint = *it;
 
     auto resolved_address = endpoint.address ().to_string ();
+	#else
+    std::string resolved_address;
+	#endif
     auto interface_addresses = gmlc::netif::getInterfaceAddressesV6 ();
 
     // Return the resolved address if no interface addresses were found
@@ -528,6 +543,7 @@ std::string getLocalExternalAddressV6 ()
 
 std::string getLocalExternalAddressV6 (const std::string &server)
 {
+	#ifndef HELICS_DISABLE_ASIO
     auto srv = AsioContextManager::getContextPointer ();
 
     asio::ip::tcp::resolver resolver (srv->getBaseContext ());
@@ -538,20 +554,23 @@ std::string getLocalExternalAddressV6 (const std::string &server)
     asio::ip::tcp::resolver::iterator end;
 
     auto sstring = (it_server == end) ? server : servep.address ().to_string ();
+	#else
+    std::string sstring = server;
+	#endif
     auto interface_addresses = gmlc::netif::getInterfaceAddressesV6 ();
-
+    std::vector<std::string> resolved_addresses;
+	#ifndef HELICS_DISABLE_ASIO
     asio::ip::tcp::resolver::query query (asio::ip::tcp::v6 (), asio::ip::host_name (), "");
     asio::ip::tcp::resolver::iterator it = resolver.resolve (query);
     // asio::ip::tcp::endpoint endpoint = *it;
-
-    std::vector<std::string> resolved_addresses;
+    
     while (it != end)
     {
         asio::ip::tcp::endpoint ept = *it;
         resolved_addresses.push_back (ept.address ().to_string ());
         ++it;
     }
-
+	#endif
     auto candidate_addresses = prioritizeExternalAddresses (interface_addresses, resolved_addresses);
 
     int cnt = 0;

--- a/tests/helics/core/CMakeLists.txt
+++ b/tests/helics/core/CMakeLists.txt
@@ -17,7 +17,6 @@ set(
     ActionMessage-tests.cpp
     BrokerClassTests.cpp
     CoreFactory-tests.cpp
-    MessageTimerTests.cpp
     data-block-tests.cpp
     ForwardingTimeCoordinatorTests.cpp
     TimeCoordinatorTests.cpp
@@ -47,6 +46,10 @@ endif()
 
 if(ENABLE_MPI_CORE)
     list(APPEND core_test_sources MpiCore-tests.cpp)
+endif()
+
+if (NOT HELICS_DISABLE_ASIO)
+    list(APPEND core_test_sources MessageTimerTests.cpp)
 endif()
 
 add_executable(core-tests ${core_test_sources} ${core_test_headers})

--- a/tests/helics/system_tests/CMakeLists.txt
+++ b/tests/helics/system_tests/CMakeLists.txt
@@ -13,17 +13,19 @@ set(
     TimingTests.cpp
     iterationTests.cpp
     ErrorTests.cpp
-    federateRealTimeTests.cpp
     TimingTests2.cpp
     QueryTests.cpp
     heat-transfer-tests.cpp
     flagTests.cpp
     updateTests.cpp
     networkTests.cpp
-    brokerTimeoutTests.cpp
     ../application_api/testFixtures.cpp
     ../application_api/testFixtures.hpp
 )
+
+if (NOT HELICS_DISABLE_ASIO)
+	list(APPEND system_test_sources federateRealTimeTests.cpp brokerTimeoutTests.cpp)
+endif()
 
 add_executable(system-tests ${system_test_sources} ${system_test_headers})
 target_link_libraries(system-tests helics_application_api helics_test_base)

--- a/tests/helics/system_tests/ErrorTests.cpp
+++ b/tests/helics/system_tests/ErrorTests.cpp
@@ -370,7 +370,7 @@ TEST_P (error_tests_type, test_duplicate_broker_name)
 
 INSTANTIATE_TEST_SUITE_P (error_tests, error_tests_type, ::testing::ValuesIn (core_types_simple));
 
-constexpr const char *networkCores[] = {"zmq", "udp"};
+constexpr const char *networkCores[] = {ZMQTEST UDPTEST};
 
 class network_error_tests : public ::testing::TestWithParam<const char *>, public FederateTestFixture
 {

--- a/tests/helics/system_tests/TimingTests.cpp
+++ b/tests/helics/system_tests/TimingTests.cpp
@@ -15,6 +15,8 @@ the top-level NOTICE for additional details. All rights reserved. SPDX-License-I
 #include "../application_api/testFixtures.hpp"
 #include "helics/helics.hpp"
 
+#include "helics/helics-config.h"
+
 struct timing_tests : public FederateTestFixture, public ::testing::Test
 {
 };

--- a/tests/helics/system_tests/networkTests.cpp
+++ b/tests/helics/system_tests/networkTests.cpp
@@ -7,6 +7,7 @@ the top-level NOTICE for additional details. All rights reserved. SPDX-License-I
 #include "../application_api/testFixtures.hpp"
 #include "gtest/gtest.h"
 #include "helics/ValueFederates.hpp"
+#include "helics/helics-config.h"
 
 /** tests for some network options*/
 
@@ -14,6 +15,7 @@ struct network_tests : public FederateTestFixture, public ::testing::Test
 {
 };
 
+#ifdef ENABLE_TCP_CORE
 /** test simple creation and destruction*/
 TEST_F (network_tests, test_external_tcp)
 {
@@ -80,6 +82,9 @@ TEST_F (network_tests, test_external_tcpss_ipv4)
     vFed1->finalize ();
 }
 
+#endif
+
+#ifdef ENABLE_UDP_CORE
 /** test simple creation and destruction*/
 TEST_F (network_tests, test_external_udp)
 {
@@ -112,3 +117,5 @@ TEST_F (network_tests, test_external_udp_ipv4)
     vFed1->enterExecutingMode ();
     vFed1->finalize ();
 }
+
+#endif


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will add a cmake option to disable linking with ASIO.  This can be useful in some environments where ASIO isn't supported.  Such as cygwin 64 bits.  It turns off the TCP and UDP cores as well as any timeout capabilities, and real time capabilities of HELICS.  Some of options related to real time operation have been disabled and will result in an error if used.  Others are left in place since there wasn't a good way to disable them.  Some potential options in the future may be available in later version of CLI11.  But the use cases for this are expected to be rare.  

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- Add cmake (advanced option) to disable ASIO
- disable code and tests that make use of ASIO
- disable some options and configurations based on ASIO

will resolve Issue #877