### PR TITLE
clean up some of the core options 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,8 +376,12 @@ if(NOT HELICS_DISABLE_BOOST)
     include(addBoost)
 endif()
 
+# -------------------------------------------------------------
+# options for enabling specific core communication types
+# -------------------------------------------------------------
+
+
 option(ENABLE_MPI_CORE "Enable MPI networking library" OFF)
-option(ENABLE_ZMQ_CORE "Enable ZeroMQ networking library" ON)
 cmake_dependent_advanced_option(ENABLE_TCP_CORE "Enable TCP core types" ON "NOT HELICS_DISABLE_ASIO" OFF)
 cmake_dependent_advanced_option(ENABLE_UDP_CORE "Enable UDP core types" ON "NOT HELICS_DISABLE_ASIO" OFF)
 cmake_dependent_advanced_option(
@@ -390,7 +394,6 @@ option(ENABLE_ZMQ_CORE "Enable ZeroMQ networking library" ON)
 
 mark_as_advanced(
     ENABLE_MPI_CORE ENABLE_ZMQ_CORE
-    ENABLE_ZMQ_CORE
 )
 
 # -------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,12 +384,12 @@ cmake_dependent_advanced_option(
     ENABLE_IPC_CORE "Enable Interprocess communication types" ON
     "NOT HELICS_DISABLE_BOOST" OFF
 )
-option(ENABLE_TEST_CORE "Enable test inprocess core type" ON)
-option(ENABLE_INPROC_CORE "Enable inprocess core type" ON)
+cmake_dependent_advanced_option(ENABLE_TEST_CORE "Enable test inprocess core type" OFF "NOT HELICS_BUILD_TESTS" ON)
+cmake_dependent_advanced_option(ENABLE_INPROC_CORE "Enable inprocess core type" ON "NOT HELICS_BUILD_BENCHMARKS" ON )
 option(ENABLE_ZMQ_CORE "Enable ZeroMQ networking library" ON)
 
 mark_as_advanced(
-    ENABLE_MPI_CORE ENABLE_ZMQ_CORE ENABLE_TEST_CORE
+    ENABLE_MPI_CORE ENABLE_ZMQ_CORE
     ENABLE_ZMQ_CORE
 )
 
@@ -646,13 +646,18 @@ add_subdirectory(src)
 
 if(HELICS_BUILD_TESTS
    AND BUILD_TESTING
-   AND ENABLE_TEST_CORE
 )
+    if (NOT ENABLE_TEST_CORE)
+		message(FATAL_ERROR "TEST CORE must be enabled to build the HELICS tests")
+	endif()
     mark_as_advanced(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
 if(HELICS_BUILD_BENCHMARKS)
+    if (NOT ENABLE_INPROC_CORE)
+		message(FATAL_ERROR "INPROC CORE must be enabled to build the HELICS Benchmarks")
+	endif()
     add_subdirectory(benchmarks)
 endif()
 

--- a/benchmarks/helics/CMakeLists.txt
+++ b/benchmarks/helics/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
     messageLookupBenchmarks
     conversionBenchmarks
 	echoMessageBenchmarks
+	messageSendBenchmarks
     pholdBenchmarks
 )
 

--- a/src/helics/common/CMakeLists.txt
+++ b/src/helics/common/CMakeLists.txt
@@ -62,7 +62,7 @@ set_target_properties(helics_common PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(helics_common PUBLIC helics_base build_flags_target PRIVATE compile_flags_target)
 target_link_libraries(helics_common PUBLIC HELICS::jsoncpp_lib HELICS::utilities HELICS::units) 
 
-if(TARGET Boost::boost)
+if(TARGET Boost::boost AND NOT HELICS_DISABLE_BOOST)
    target_link_libraries(helics_common PRIVATE Boost::boost)
 endif()
 

--- a/src/helics/core/CMakeLists.txt
+++ b/src/helics/core/CMakeLists.txt
@@ -215,7 +215,7 @@ add_library(helics_core STATIC ${SRC_FILES} ${INCLUDE_FILES} ${PUBLIC_INCLUDE_FI
 
 target_link_libraries(helics_core PUBLIC helics_common PRIVATE fmt::fmt compile_flags_target)
 
-if(TARGET Boost::boost)
+if(TARGET Boost::boost AND NOT HELICS_DISABLE_BOOST)
 	target_compile_definitions(helics_core PRIVATE BOOST_DATE_TIME_NO_LIB)
 	target_link_libraries(helics_core PRIVATE Boost::boost)
 endif()

--- a/tests/helics/coreTypeLists.hpp
+++ b/tests/helics/coreTypeLists.hpp
@@ -72,11 +72,11 @@ SPDX-License-Identifier: BSD-3-Clause
 #define INPROCTEST2 "inproc_2",
 #define INPROCTEST3 "inproc_3",
 #define INPROCTEST4 "inproc_4",
-#else
-#define INPROCTEST
-#define INPROCTEST2
-#define INPROCTEST3
-#define INPROCTEST4
+#else //if the INPROC core is turned off then just use the test core since it is required to be available for tests
+#define INPROCTEST "test"
+#define INPROCTEST2 "test_2"
+#define INPROCTEST3 "test_3"
+#define INPROCTEST4 "test_4"
 #endif
 
 #ifdef ENABLE_ZMQ_CORE


### PR DESCRIPTION
and require the inproc core for benchmarks and the test core for the tests


### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add checks to fail the build if the inproc core is not enabled for the benchmarks and the test core is not built for the tests.  
Remove some options from the cmake-gui if they are required.  
