### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Gitter
+    url: https://gitter.im/GMLC-TDC/HELICS
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/support-or-design-question.md
+++ b/.github/ISSUE_TEMPLATE/support-or-design-question.md
@@ -1,6 +1,9 @@
 ---
 name: Support or design question
 about: Ask a detailed question or start a design discussion
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,6 +1,7 @@
 # Support resources
 
-We have an active [Gitter]((https://gitter.im/GMLC-TDC/HELICS) channel
-Our GitHub pages provides a rich set of [documentation](https://helics.readthedocs.io/en/latest/) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/), complete doxygen-auto-produced [API documentation](https://helics.readthedocs.io/en/latest/doxygen/), There is a [WIKI](https://github.com/GMLC-TDC/HELICS/wiki) with some additional information, and [USER GUIDE]() to help you get started. 
+We have an active [Gitter](https://gitter.im/GMLC-TDC/HELICS) channel.
+
+Our [ReadTheDocs](https://helics.readthedocs.io/en/latest/) pages provides a rich set of [documentation](https://helics.readthedocs.io/en/latest/) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/), and complete doxygen-auto-produced [API documentation](https://helics.readthedocs.io/en/latest/doxygen/). There is a [WIKI](https://github.com/GMLC-TDC/HELICS/wiki) with some additional information, and a [USER GUIDE](https://helics.readthedocs.io/en/latest/user-guide/) to help you get started. 
 
 We've created a series of roughly 10-minute mini-tutorial videos that discuss various design topics, concepts, and interfaces, including how to use the tool. They can be found on our [YouTube channel](https://www.youtube.com/channel/UCPa81c4BVXEYXt2EShTzbcg).   


### PR DESCRIPTION

### Summary
If merged this pull request will update the new bug report issue template to automatically add a bug label, and add a link to open the HELICS Gitter to the list of options when creating a new issue.

### Proposed changes
- Add Gitter link to the new issue creation page
- Add default metadata to the bug report issue template to automatically add a `bug` label
