### PR TITLE
Add a clang-format actions workflow

### DIFF
--- a/.github/actions/create-file-update-pr/action.yml
+++ b/.github/actions/create-file-update-pr/action.yml
@@ -1,5 +1,12 @@
 name: 'Create File Update PR'
 description: 'Pushes a new branch with changed files and opens a PR for updating the changed files in the base branch'
+inputs:
+  no-hash: # turn off inclusion of the hash in the created branch name
+    description: 'Do not include the changed file hash in the PR branch name'
+    default: false
+  replace-branch: # if a PR branch already exists, replaces it with updated contents
+    description: 'Replace the contents of an existing PR branch of the same name'
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/.github/actions/create-file-update-pr/entrypoint.sh
+++ b/.github/actions/create-file-update-pr/entrypoint.sh
@@ -11,7 +11,12 @@ files_changed=$(git diff --staged --name-only)
 if [[ "$files_changed" != "" ]];
 then
   hash=$(sha256sum "${files_changed}" | sha256sum | cut -c 1-12 -)
-  current_branch="${GITHUB_REF#refs/heads/}"
+  if [[ "${GITHUB_REF}" == "refs/pull/"* ]];
+  then
+    current_branch="${GITHUB_HEAD_REF}"
+  else
+    current_branch="${GITHUB_REF#refs/heads/}"
+  fi
 
   # Set the git origin url for committing using a GITHUB_TOKEN
   git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"

--- a/.github/actions/create-file-update-pr/entrypoint.sh
+++ b/.github/actions/create-file-update-pr/entrypoint.sh
@@ -10,32 +10,53 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 files_changed=$(git diff --staged --name-only)
 if [[ "$files_changed" != "" ]];
 then
-  hash=$(sha256sum ${files_changed} | sha256sum | cut -c 1-12 -)
-  current_branch=${GITHUB_REF#refs/heads/}
-  
+  hash=$(sha256sum "${files_changed}" | sha256sum | cut -c 1-12 -)
+  current_branch="${GITHUB_REF#refs/heads/}"
+
   # Set the git origin url for committing using a GITHUB_TOKEN
   git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
   git config user.name "${INPUT_GIT_NAME}"
   git config user.email "${INPUT_GIT_EMAIL}"
-  
-  # Make sure a branch with the same name (hash + base branch) doesn't already exist
-  pr_branch="${INPUT_BRANCH_PREFIX}update-${current_branch}-${hash}"
+
+  # Construct the branch name with the changes for a PR
+  pr_branch="${INPUT_BRANCH_PREFIX}update-${current_branch}"
+  if [[ "${INPUT_NO_HASH}" != "true" ]];
+  then
+    pr_branch="${pr_branch}-${hash}"
+  fi
+
+  # Make sure a branch with the same name doesn't already exist, unless INPUT_REPLACE_BRANCH is true
   git ls-remote --exit-code . "origin/${pr_branch}"
   rv=$?
-  if [[ "$rv" != "0" ]];
+  if [[ "$rv" == "0" ]];
   then
-    # Commit the changed files and push the branch to GitHub
-    git checkout -b "${pr_branch}"
-    git commit -m "${INPUT_COMMIT_MSG}"
-    git push -u origin "${pr_branch}"
-  
+    if [[ "${INPUT_REPLACE_BRANCH}" != "true" ]];
+    then
+      exit 0
+    fi
+    pr_branch_exists="true"
+  fi
+
+  if [[ "${pr_branch_exists}" == "true" ]];
+  then
+      # delete any existing local branch with the same name
+      git branch -D "${pr_branch}" >/dev/null 2>&1
+  fi
+
+  # Commit the changed files and push the branch to GitHub
+  git checkout -b "${pr_branch}"
+  git commit -m "${INPUT_COMMIT_MSG}"
+  git push -f -u origin "${pr_branch}"
+
+  if [[ "$pr_branch_exists" != "true" ]];
+  then
     # Format string values for GitHub API JSON payload
     PR_TITLE="$(echo -n "${INPUT_PR_TITLE}" | jq --raw-input --slurp ".")"
     PR_BODY="$(echo -n "${INPUT_PR_BODY}" | jq --raw-input --slurp ".")"
     PR_BASE="$(echo -n "${current_branch}" | jq --raw-input --slurp ".")"
     PR_HEAD="$(echo -n "${pr_branch}" | jq --raw-input --slurp ".")"
     pr_api_data="{\"title\":${PR_TITLE}, \"body\":${PR_BODY}, \"base\":${PR_BASE}, \"head\":${PR_HEAD}, \"draft\":false}"
-  
+
     # Open up the GitHub PR
     curl -XPOST -fsSL \
          -H "${AUTH_HEADER}" \

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,8 +1,8 @@
 name: Format source code
 
 on:
-  issue_comment:
-    types: [created]
+#  issue_comment:
+#    types: [created]
   push:
     paths:
       - '.github/workflows/clang-format.yml'
@@ -17,18 +17,18 @@ on:
 
 jobs:
   build:
-    if: github.event_name != 'issue_comment' || contains(github.event.comment.body, '/format')
+#    if: github.event_name != 'issue_comment' || contains(github.event.comment.body, '/format')
     runs-on: ubuntu-latest
     container:
       image: helics/buildenv:clang-format
     
     steps:
-    - uses: actions/github-script@0.3.0
-      if: github.event_name == 'issue_comment'
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.issues.createComment({...context.issue, body: 'Okay, commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} is being formatted. A PR with the changes will be open soon! :sunglasses:'})
+#    - uses: actions/github-script@0.3.0
+#      if: github.event_name == 'issue_comment'
+#      with:
+#        github-token: ${{secrets.GITHUB_TOKEN}}
+#        script: |
+#          github.issues.createComment({...context.issue, body: 'Okay, commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} is being formatted. A PR with the changes will be open soon! :sunglasses:'})
     - uses: actions/checkout@v1
     - name: Run clang-format
       run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,9 +11,9 @@ on:
       - '**.[ch]'
       - '!ThirdParty/**'
       - '!interfaces/**'
-#    branches: 
-#      - master
-#      - develop
+    branches: 
+      - master
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,14 +1,22 @@
 name: Format source code
 
 on:
+  issue_comment:
+    types: [created]
   push:
+    paths:
+      - '.github/workflows/clang-format.yml'
+      - '.clang-format'
+      - '**.[ch]pp'
+      - '**.[ch]'
+      - '!ThirdParty/**'
 #    branches: 
 #      - master
 #      - develop
 
 jobs:
   build:
-
+    if: github.event_name != 'issue_comment' || contains(github.event.comment.body, '/format')
     runs-on: ubuntu-latest
     container:
       image: helics/buildenv:clang-format

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,6 +23,12 @@ jobs:
       image: helics/buildenv:clang-format
     
     steps:
+    - uses: actions/github-script@0.3.0
+      if: github.event_name == 'issue_comment'
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({...context.issue, body: 'Okay, commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} is being formatted. A PR with the changes will be open soon! :sunglasses:'})
     - uses: actions/checkout@v1
     - name: Run clang-format
       run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Run clang-format
       run: |
         clang-format --version
-        find * | grep -v "^ThirdParty" | grep -E ".*\.[ch](p{2})?$"
         find * | grep -v "^ThirdParty" | grep -E ".*\.[ch](p{2})?$" | xargs clang-format -i -style=file
         
     - name: Stage changed source files
@@ -34,9 +33,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting update to source files"
-        PR_TITLE: "Automated formatting update to source files"
-        PR_BODY: "Automated formatting update to source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }}."
+        COMMIT_MSG: "Automated formatting of source files"
+        PR_TITLE: "Automated formatting of source files"
+        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"
         BRANCH_PREFIX: "clang-format/"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,6 +10,7 @@ on:
       - '**.[ch]pp'
       - '**.[ch]'
       - '!ThirdParty/**'
+      - '!interfaces/**'
 #    branches: 
 #      - master
 #      - develop
@@ -26,7 +27,7 @@ jobs:
     - name: Run clang-format
       run: |
         clang-format --version
-        find * | grep -v "^ThirdParty" | grep -E ".*\.[ch](p{2})?$" | xargs clang-format -i -style=file
+        find * | grep -v -e "^ThirdParty" -e "^interfaces" | grep -E ".*\.[ch](p{2})?$" | xargs clang-format -i -style=file
         
     - name: Stage changed source files
       shell: bash --noprofile --norc {0}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,42 @@
+name: Format source code
+
+on:
+  push:
+#    branches: 
+#      - master
+#      - develop
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container:
+      image: helics/buildenv:clang-format
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run clang-format
+      run: |
+        clang-format --version
+        find * | grep -v "^ThirdParty" | grep -E ".*\.[ch](p{2})?$"
+        find * | grep -v "^ThirdParty" | grep -E ".*\.[ch](p{2})?$" | xargs clang-format -i -style=file
+        
+    - name: Stage changed source files
+      shell: bash --noprofile --norc {0}
+      run: |
+        git diff --name-only | grep -E ".*\.[h|c](p{2})?$"
+        if [[ "$?" == "0" ]];
+        then
+          git add *.cpp *.hpp *.c *.h
+        fi
+        exit 0
+    - uses: ./.github/actions/create-file-update-pr
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        COMMIT_MSG: "Automated formatting update to source files"
+        PR_TITLE: "Automated formatting update to source files"
+        PR_BODY: "Automated formatting update to source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }}."
+        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
+        GIT_NAME: "HELICS-bot"
+        BRANCH_PREFIX: "clang-format/"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,6 +3,8 @@ name: Format source code
 on:
 #  issue_comment:
 #    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     paths:
       - '.github/workflows/clang-format.yml'
@@ -17,6 +19,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.draft != true
 #    if: github.event_name != 'issue_comment' || contains(github.event.comment.body, '/format')
     runs-on: ubuntu-latest
     container:
@@ -29,7 +32,14 @@ jobs:
 #        github-token: ${{secrets.GITHUB_TOKEN}}
 #        script: |
 #          github.issues.createComment({...context.issue, body: 'Okay, commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} is being formatted. A PR with the changes will be open soon! :sunglasses:'})
-    - uses: actions/checkout@v1
+    - name: Checkout event Ref
+      uses: actions/checkout@v1
+      if: github.event_name != 'pull_request'
+    - name: Checkout PR Head Ref
+      uses: actions/checkout@v1
+      if: github.event_name == 'pull_request'
+      with:
+        ref: ${{ github.head_ref }}
     - name: Run clang-format
       run: |
         clang-format --version
@@ -44,7 +54,10 @@ jobs:
           git add *.cpp *.hpp *.c *.h
         fi
         exit 0
-    - uses: ./.github/actions/create-file-update-pr
+        
+    - name: Create a file update PR with hash
+      uses: ./.github/actions/create-file-update-pr
+      if: github.event_name == 'push'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -54,3 +67,18 @@ jobs:
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"
         BRANCH_PREFIX: "clang-format/"
+        
+    - name: Create/update a file update PR with no hash
+      uses: ./.github/actions/create-file-update-pr
+      if: github.event_name == 'pull_request'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        COMMIT_MSG: "Automated formatting of source files"
+        PR_TITLE: "Automated formatting of source files"
+        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }}."
+        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
+        GIT_NAME: "HELICS-bot"
+        BRANCH_PREFIX: "clang-format/"
+        NO_HASH: "true"
+        REPLACE_BRANCH: "true"


### PR DESCRIPTION
### Summary
If merged this pull request will open automated clang-format PRs for commits to develop and master that don't match the format given in the `.clang-format`. Updates to code in the ThirdParty folder or automated swig generated source files in the interfaces folder will not trigger a formatting run.

~A manual run can be triggered by commenting on a PR with `/format`. A PR with the formatting changes will be opened that can be merged into the PR (or the base branch could be changed to develop for merging later).~

The `format-trigger-testing` branch shows the results of some tests of the path/file triggers from some commits that did not result in any open PRs (or workflow runs) and two that did (#927 and #928).

Update on comment triggers: the Git SHA in the comment trigger is for the latest commit in the default branch, which could be entirely unrelated to the source and target branches involved in a PR. It looks like there might not be the required information in the event context to add support in an easy/straightforward way.

### Proposed changes
- Add a clang-format GitHub Actions workflow that automatically runs clang-format and opens a PR with formatting changes when HELICS (not swig generated or third party) code or formatting related files are updated.
- ~Add a `/format` comment as a trigger for the automatic formatting workflow to format a branch~
