### PR TITLE
Always use no-hash branches for clang-format PRs

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -55,28 +55,14 @@ jobs:
         fi
         exit 0
         
-    - name: Create a file update PR with hash
-      uses: ./.github/actions/create-file-update-pr
-      if: github.event_name == 'push'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        COMMIT_MSG: "Automated formatting of source files"
-        PR_TITLE: "Automated formatting of source files"
-        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }}."
-        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
-        GIT_NAME: "HELICS-bot"
-        BRANCH_PREFIX: "clang-format/"
-        
     - name: Create/update a file update PR with no hash
       uses: ./.github/actions/create-file-update-pr
-      if: github.event_name == 'pull_request'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         COMMIT_MSG: "Automated formatting of source files"
         PR_TITLE: "Automated formatting of source files"
-        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }}."
+        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} from ref ${{ github.ref }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"
         BRANCH_PREFIX: "clang-format/"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         COMMIT_MSG: "Automated formatting of source files"
         PR_TITLE: "Automated formatting of source files"
-        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} from ref ${{ github.ref }}."
+        PR_BODY: "Automated formatting of source files in commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"
         BRANCH_PREFIX: "clang-format/"


### PR DESCRIPTION

### Summary
If merged this pull request will remove the changed file hash from the branch names used in PRs opened by the clang-format action. This avoids the filename length error from a formatting change that affects a large number of errors.

### Proposed changes
- Remove the hash from the clang-format action PR branch names
- Add the GitHub ref to the body of the PR message
