### PR TITLE
Fix shellcheck issues on shell scripts

### DIFF
--- a/.github/actions/linux-release-builder/entrypoint.sh
+++ b/.github/actions/linux-release-builder/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-scl enable rh-git29 devtoolset-8 ${INPUT_SCRIPT}
+scl enable rh-git29 devtoolset-8 "${INPUT_SCRIPT}"

--- a/.github/workflows/interface_gen_script.sh
+++ b/.github/workflows/interface_gen_script.sh
@@ -1,16 +1,16 @@
-#!/usr/bin/sh
+#!/usr/bin/bash
 
 # Generate Matlab interface using swig matlab
 mkdir build_matlab
-pushd build_matlab
+pushd build_matlab || exit
 cmake -DBUILD_MATLAB_INTERFACE=ON -DHELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY=ON -DHELICS_OVERWRITE_INTERFACE_FILES=ON -DHELICS_BUILD_EXAMPLES=OFF -DENABLE_ZMQ_CORE=OFF -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_DISABLE_BOOST=ON -DHELICS_ENABLE_SWIG=ON -DSWIG_EXECUTABLE=/root/swig-matlab/bin/swig ..
 make -j2 mfile_overwrite
-popd
+popd || exit
 
 # Generate Python and Java interfaces
 mkdir build_interface
-pushd build_interface
+pushd build_interface || exit
 cmake -DBUILD_PYTHON_INTERFACE=ON -DBUILD_JAVA_INTERFACE=ON -DHELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY=ON -DHELICS_OVERWRITE_INTERFACE_FILES=ON -DHELICS_BUILD_EXAMPLES=OFF -DENABLE_ZMQ_CORE=OFF -DHELICS_BUILD_TESTS=OFF -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_DISABLE_BOOST=ON -DHELICS_ENABLE_SWIG=ON ..
 make -j2 pyfile_overwrite
 make -j2 javafile_overwrite
-popd
+popd || exit

--- a/.github/workflows/release-build/installer-Windows.sh
+++ b/.github/workflows/release-build/installer-Windows.sh
@@ -5,11 +5,11 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-mkdir build && cd build
+mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_JAVA_INTERFACE=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(which cmake)"
+cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
-cd ../artifact
+cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/workflows/release-build/installer-macOS.sh
+++ b/.github/workflows/release-build/installer-macOS.sh
@@ -3,11 +3,11 @@
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 brew install swig boost
-mkdir build && cd build
+mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_JAVA_INTERFACE=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(which cmake)"
+cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
-cd ../artifact
+cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/workflows/release-build/msvc-Windows.sh
+++ b/.github/workflows/release-build/msvc-Windows.sh
@@ -6,26 +6,26 @@
 
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-cpack_dir="$(which cmake)"
+cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
-mkdir build && cd build
+mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Debug -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=ON -DHELICS_DISABLE_C_SHARED_LIB=ON ..
 cmake --build . --config Debug
 echo "Packing Debug"
 "${cpack_dir}/cpack" -G "ZIP" -C Debug -B "$(pwd)/../tmp_dir"
 
-pushd ../tmp_dir
+pushd ../tmp_dir || exit
 rm -rf _CPack_Packages
 ZIP_FILE="$(ls Helics-*.zip)"
 7z x "$ZIP_FILE" -y
 rm "$ZIP_FILE"
-popd
+popd || exit
 
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=ON -DHELICS_DISABLE_C_SHARED_LIB=ON ..
 cmake --build . --config Release
 echo "Packing Release"
 "${cpack_dir}/cpack" -G "ZIP" -C Release -B "$(pwd)/../tmp_dir"
-cd ../tmp_dir
+cd ../tmp_dir || exit
 rm -rf _CPack_Packages
 ZIP_FILE="$(ls Helics-*.zip)"
 7z x "$ZIP_FILE" -y

--- a/.github/workflows/release-build/shared-library-Linux.sh
+++ b/.github/workflows/release-build/shared-library-Linux.sh
@@ -6,13 +6,13 @@
 #sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
 #rm cmake-install.sh
 
-mkdir build && cd build
+mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(which cmake)"
+cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
-cd ../artifact
+cd ../artifact || exit
 rm -rf _CPack_Packages
 ARCHIVE_FILE="$(ls Helics-*)"
 mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"

--- a/.github/workflows/release-build/shared-library-Windows.sh
+++ b/.github/workflows/release-build/shared-library-Windows.sh
@@ -5,13 +5,13 @@
 
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-mkdir build && cd build
+mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(which cmake)"
+cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
-cd ../artifact
+cd ../artifact || exit
 rm -rf _CPack_Packages
 ARCHIVE_FILE="$(ls Helics-*)"
 mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"

--- a/.github/workflows/release-build/shared-library-macOS.sh
+++ b/.github/workflows/release-build/shared-library-macOS.sh
@@ -3,13 +3,13 @@
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 brew install swig boost
-mkdir build && cd build
+mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(which cmake)"
+cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
-cd ../artifact
+cd ../artifact || exit
 rm -rf _CPack_Packages
 ARCHIVE_FILE="$(ls Helics-*)"
 mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"

--- a/.github/workflows/upload-release-asset.sh
+++ b/.github/workflows/upload-release-asset.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
-pushd $(dirname $1)
-FILE=$(basename $1)
-CONTENT_TYPE="$(file -b --mime-type $FILE)"
+pushd "$(dirname "$1")" || exit
+FILE=$(basename "$1")
+CONTENT_TYPE="$(file -b --mime-type "$FILE")"
 CONTENT_LENGTH="$(stat -c%s "$FILE")"
 curl \
   -sSL \
@@ -12,4 +12,4 @@ curl \
   -H "Content-Type: ${CONTENT_TYPE}" \
   --upload-file "${FILE}" \
   "${UPLOAD_URL%\{*}?name=${FILE}"
-popd
+popd || exit

--- a/scripts/_git-all-archive-python.sh
+++ b/scripts/_git-all-archive-python.sh
@@ -59,7 +59,7 @@ pip install pygithub
 echo "> creating root archive"
 export ROOT_ARCHIVE_DIR="$(pwd)"
 
-git checkout $tag
+git checkout "$tag"
 git submodule update --init
 export OUTPUT_FILE="HELICS-${tag}.tar.gz"
 # create root archive
@@ -85,7 +85,7 @@ echo "> gzipping final tar"
 gzip --force --verbose repo-output.tar
 
 echo "> moving output file to $OUTPUT_FILE"
-mv repo-output.tar.gz $OUTPUT_FILE
+mv repo-output.tar.gz "$OUTPUT_FILE"
 
 cmd="python git-all-archive.py --repo $repo --release $release --version $tag"
 if [ "${GITHUB_TOKEN}a" != "a" ]; then

--- a/scripts/_git-all-archive.sh
+++ b/scripts/_git-all-archive.sh
@@ -47,7 +47,7 @@ shift $((OPTIND - 1))
 echo "> creating root archive"
 export ROOT_ARCHIVE_DIR="$(pwd)"
 
-git checkout $tag
+git checkout "$tag"
 git submodule update --init
 OUTPUT_BASENAME="Helics-${release}-source"
 export OUTPUT_FILE="${OUTPUT_BASENAME}.tar.gz"
@@ -64,7 +64,7 @@ if (( $(ls repo-output-sub*.tar | wc -l) != 0  )); then
   echo
   echo "> combining all tars"
   for archivetar in $(ls repo-output-sub*.tar); do
-    echo $archivetar
+    echo "$archivetar"
     tar --concatenate --file="${OUTPUT_BASENAME}.tar" "$archivetar"
   done
 

--- a/scripts/cleanup-cmake.sh
+++ b/scripts/cleanup-cmake.sh
@@ -4,17 +4,17 @@ cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
 
 # Get rid of unneeded files that just take up extra space
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    rm -rf ${cmake_install_path}/doc
-    rm -rf ${cmake_install_path}/man
-    rm -f ${cmake_install_path}/bin/ccmake
-    rm -f ${cmake_install_path}/bin/cmake-gui
+    rm -rf "${cmake_install_path}/doc"
+    rm -rf "${cmake_install_path}/man"
+    rm -f "${cmake_install_path}/bin/ccmake"
+    rm -f "${cmake_install_path}/bin/cmake-gui"
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    rm -rf ${cmake_install_path}/CMake.app/Contents/Frameworks
-    rm -rf ${cmake_install_path}/CMake.app/Contents/MacOS
-    rm -rf ${cmake_install_path}/CMake.app/Contents/Resources
-    rm -rf ${cmake_install_path}/CMake.app/Contents/doc
-    rm -rf ${cmake_install_path}/CMake.app/Contents/man
-    rm -f ${cmake_install_path}/CMake.app/Contents/bin/ccmake
-    rm -f ${cmake_install_path}/CMake.app/Contents/bin/cmake-gui
+    rm -rf "${cmake_install_path}/CMake.app/Contents/Frameworks"
+    rm -rf "${cmake_install_path}/CMake.app/Contents/MacOS"
+    rm -rf "${cmake_install_path}/CMake.app/Contents/Resources"
+    rm -rf "${cmake_install_path}/CMake.app/Contents/doc"
+    rm -rf "${cmake_install_path}/CMake.app/Contents/man"
+    rm -f "${cmake_install_path}/CMake.app/Contents/bin/ccmake"
+    rm -f "${cmake_install_path}/CMake.app/Contents/bin/cmake-gui"
 fi
 

--- a/scripts/git-archive.sh
+++ b/scripts/git-archive.sh
@@ -37,10 +37,10 @@ while getopts p:d:n: options; do
    esac
 done
 shift $((OPTIND - 1))
-cd ${DIRECTORY}
-ROOT_DIRECTORY=`pwd`
+cd "${DIRECTORY}"
+ROOT_DIRECTORY=$(pwd)
 echo "> checkout tag ${NAME}"
-git checkout ${NAME}
+git checkout "${NAME}"
 echo "> archiving main repository"
 git archive --verbose --prefix "repo/" --format "tar" --output "./${PREFIX}-output.tar" "master"
 echo "> checking out all submodules"

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -129,11 +129,7 @@ if [[ "$os_name" == "Linux" ]]; then
     # Install Boost
     if [[ ! -d "${boost_install_path}" ]]; then
         echo "*** build boost"
-        boost_sanitizer=""
-        if [[ "$RUN_SANITIZER" == "tsan" ]]; then
-            boost_sanitizer="BOOST_SANITIZER=thread"
-        fi
-        "${boost_sanitizer}" ${WAIT_COMMAND} ./scripts/install-dependency.sh boost ${boost_version} "${boost_install_path}"
+        ${WAIT_COMMAND} ./scripts/install-dependency.sh boost ${boost_version} "${boost_install_path}"
         echo "*** built boost successfully"
     fi
 
@@ -186,7 +182,8 @@ else
         last_pyversion=${last_pyversion/#\*/}
         # Remove a trailing set of parenthesis saying where the version was set
         last_pyversion=${last_pyversion%(*)}
-
+        # Remove whitespace
+        last_pyversion="$(echo -e "$last_pyversion" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         pyenv global "${last_pyversion}"
     fi
 

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -11,7 +11,7 @@ if [[ "$TRAVIS" == "true" ]]; then
     WAIT_COMMAND=travis_wait
 
     # Convert commit message to lower case
-    commit_msg=$(tr '[:upper:]' '[:lower:]' <<< ${TRAVIS_COMMIT_MESSAGE})
+    commit_msg=$(tr '[:upper:]' '[:lower:]' <<< "${TRAVIS_COMMIT_MESSAGE}")
 
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         os_name="Linux"
@@ -68,39 +68,39 @@ zmq_install_path=${CI_DEPENDENCY_DIR}/zmq
 if [[ $commit_msg == *'[update_cache]'* ]]; then
     individual="false"
     if [[ $commit_msg == *'boost'* ]]; then
-        rm -rf ${boost_install_path};
+        rm -rf "${boost_install_path}";
         individual="true"
     fi
     if [[ $commit_msg == *'zmq'* ]]; then
-        rm -rf ${zmq_install_path};
+        rm -rf "${zmq_install_path}";
         individual="true"
     fi
     if [[ $commit_msg == *'swig'* ]]; then
-        rm -rf ${swig_install_path};
+        rm -rf "${swig_install_path}";
         individual="true"
     fi
     if [[ "$USE_MPI" ]]; then
-        if [[$commit_msg == *'mpi'* ]]; then
-            rm -rf ${mpi_install_path};
+        if [[ $commit_msg == *'mpi'* ]]; then
+            rm -rf "${mpi_install_path}";
             individual="true"
         fi
     fi
 
     # If no dependency named in commit message, update entire cache
     if [[ "$individual" != 'true' ]]; then
-        rm -rf ${CI_DEPENDENCY_DIR};
+        rm -rf "${CI_DEPENDENCY_DIR}";
     fi
 fi
 
 if [[ ! -d "${CI_DEPENDENCY_DIR}" ]]; then
-    mkdir -p ${CI_DEPENDENCY_DIR};
+    mkdir -p "${CI_DEPENDENCY_DIR}";
 fi
 
 # Only compile these dependencies on Linux, to install them on macOS use the Brewfile .ci/Brewfile.travis
 if [[ "$os_name" == "Linux" ]]; then
     # Install CMake
     if [[ ! -d "${cmake_install_path}" ]]; then
-        ./scripts/install-dependency.sh cmake ${cmake_version} ${cmake_install_path}
+        ./scripts/install-dependency.sh cmake ${cmake_version} "${cmake_install_path}"
     fi
 
     # Set path to CMake executable depending on OS
@@ -114,7 +114,7 @@ if [[ "$os_name" == "Linux" ]]; then
 
     # Install SWIG
     if [[ ! -d "${swig_install_path}" ]]; then
-        ./scripts/install-dependency.sh swig ${swig_version} ${swig_install_path}
+        ./scripts/install-dependency.sh swig ${swig_version} "${swig_install_path}"
     fi
     export PATH="${swig_install_path}/bin:${PATH}"
     echo "*** built swig successfully {$PATH}"
@@ -122,18 +122,18 @@ if [[ "$os_name" == "Linux" ]]; then
     # Install ZeroMQ
     if [[ "$TRAVIS" != "true" && ! -d "${zmq_install_path}" ]]; then
         echo "*** build libzmq"
-        ./scripts/install-dependency.sh zmq ${zmq_version} ${zmq_install_path}
+        ./scripts/install-dependency.sh zmq ${zmq_version} "${zmq_install_path}"
         echo "*** built zmq successfully"
     fi
 
     # Install Boost
     if [[ ! -d "${boost_install_path}" ]]; then
         echo "*** build boost"
-        local boost_sanitizer=""
+        boost_sanitizer=""
         if [[ "$RUN_SANITIZER" == "tsan" ]]; then
             boost_sanitizer="BOOST_SANITIZER=thread"
         fi
-        ${BOOST_SANITIZER} ${WAIT_COMMAND} ./scripts/install-dependency.sh boost ${boost_version} ${boost_install_path}
+        "${boost_sanitizer}" ${WAIT_COMMAND} ./scripts/install-dependency.sh boost ${boost_version} "${boost_install_path}"
         echo "*** built boost successfully"
     fi
 
@@ -153,8 +153,8 @@ fi
 if [[ "$USE_MPI" ]]; then
     if [[ ! -d "${mpi_install_path}" ]]; then
         # if mpi_implementation isn't set, then the mpi implementation requested wasn't recognized
-        if [[ ! -z "${mpi_implementation}" ]]; then
-            ${WAIT_COMMAND} ./scripts/install-dependency.sh ${mpi_implementation} ${mpi_version} ${mpi_install_path}
+        if [[ -n "${mpi_implementation}" ]]; then
+            ${WAIT_COMMAND} ./scripts/install-dependency.sh ${mpi_implementation} ${mpi_version} "${mpi_install_path}"
         fi
     fi
 fi
@@ -168,7 +168,7 @@ fi
 
 if [[ "$os_name" == "Darwin" && -x "$(command -v brew)" ]]; then
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-    bash miniconda.sh -b -p $HOME/miniconda
+    bash miniconda.sh -b -p "$HOME/miniconda"
     export PATH="$HOME/miniconda/bin:$PATH"
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
@@ -187,7 +187,7 @@ else
         # Remove a trailing set of parenthesis saying where the version was set
         last_pyversion=${last_pyversion%(*)}
 
-        pyenv global ${last_pyversion}
+        pyenv global "${last_pyversion}"
     fi
 
     python3 -m pip install --user --upgrade pip wheel
@@ -198,7 +198,7 @@ pyver=$(python3 -c 'import sys; ver=sys.version_info[:2]; print(".".join(map(str
 
 export PYTHON_LIB_PATH=$(python3-config --prefix)/lib/libpython${pyver}m.${shared_lib_ext}
 export PYTHON_INCLUDE_PATH=$(python3-config --prefix)/include/python${pyver}m/
-export PYTHON_EXECUTABLE=$(which python3)
+export PYTHON_EXECUTABLE=$(command -v python3)
 
 # Tell macOS users to use Homebrew to install additional dependencies
 if [[ "$TRAVIS" != "true" && "$os_name" == Darwin ]]; then

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -144,11 +144,11 @@ install_boost () {
     fi
 
     if [[ "${cxxflags_arr[*]}" ]]; then
-        cxxflags_var="cxxflags=${cxxflags_arr[@]}"
+        cxxflags_var="cxxflags=${cxxflags_arr[*]}"
     fi
 
     if [[ "${linkflags_arr[*]}" ]]; then
-        linkflags_var="linkflags=${linkflags_arr[@]}"
+        linkflags_var="linkflags=${linkflags_arr[*]}"
     fi
 
     echo Boost link type: $b2_link_type

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -7,10 +7,10 @@ fi
 # Compares two semantic version numbers (major.minor.revision)
 check_minimum_version () {
     local -a ver
-    IFS='. ' read -r -a ver <<< $1
+    IFS='. ' read -r -a ver <<< "$1"
 
     local -a ver_min
-    IFS='. ' read -r -a ver_min <<< $2
+    IFS='. ' read -r -a ver_min <<< "$2"
 
     if [[ ${ver[0]} -lt ${ver_min[0]} ]] || [[ ${ver[0]} -eq ${ver_min[0]} && ${ver[1]} -lt ${ver_min[1]} ]] || [[ ${ver[0]} -eq ${ver_min[0]} && ${ver[1]} -eq ${ver_min[1]} && ${ver[2]} -lt ${ver_min[2]} ]]; then
         return 1
@@ -23,8 +23,8 @@ check_minimum_version () {
 fetch_and_untar () {
     local output_name=$1
     local url=$2
-    wget --no-check-certificate -O ${output_name} ${url}
-    tar -zxf ${output_name}
+    wget --no-check-certificate -O "${output_name}" "${url}"
+    tar -zxf "${output_name}"
 }
 
 install_swig () {
@@ -32,10 +32,10 @@ install_swig () {
     local swig_version=$1
     local swig_version_str=swig-${swig_version}
     local install_path=$2
-    fetch_and_untar ${swig_version_str}.tar.gz \
-        https://sourceforge.net/projects/swig/files/swig/${swig_version_str}/${swig_version_str}.tar.gz/download
-    cd ${swig_version_str};
-    ./configure --prefix ${install_path};
+    fetch_and_untar "${swig_version_str}.tar.gz" \
+        "https://sourceforge.net/projects/swig/files/swig/${swig_version_str}/${swig_version_str}.tar.gz/download"
+    cd "${swig_version_str}" || return;
+    ./configure --prefix "${install_path}";
     make;
     make install;
 }
@@ -47,11 +47,11 @@ install_zmq () {
     if [[ "${zmq_version}" == "HEAD" ]]; then
         git clone git://github.com/zeromq/libzmq.git;
     else
-        git clone --branch v${zmq_version} git://github.com/zeromq/libzmq.git;
+        git clone --branch "v${zmq_version}" git://github.com/zeromq/libzmq.git;
     fi
-    cd libzmq;
+    cd libzmq || return;
     ./autogen.sh;
-    mkdir -p build && cd build;
+    mkdir -p build && cd build || return;
     cmake .. -DENABLE_CURVE=OFF -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${install_path}"
     make;
     make install;
@@ -60,16 +60,16 @@ install_zmq () {
 install_mpich () {
     # MPICH version number splitting
     local -a ver
-    IFS='. ' read -r -a ver <<< $1
+    IFS='. ' read -r -a ver <<< "$1"
 
     # Download and install MPICH (only works with v3+, version number scheme is different for v2)
     local mpich_version=$1
     local mpich_version_str=mpich-${mpich_version}
     local install_path=$2
-    fetch_and_untar ${mpich_version_str}.tar.gz \
-        http://www.mpich.org/static/downloads/${mpich_version}/${mpich_version_str}.tar.gz
-    cd ${mpich_version_str}/;
-    ./configure --prefix=${install_path} \
+    fetch_and_untar "${mpich_version_str}.tar.gz" \
+        "http://www.mpich.org/static/downloads/${mpich_version}/${mpich_version_str}.tar.gz"
+    cd "${mpich_version_str}/" || return;
+    ./configure --prefix="${install_path}" \
         --disable-dependency-tracking \
         --enable-fast=yes \
         --enable-g=none \
@@ -87,17 +87,17 @@ install_mpich () {
 install_openmpi () {
     # Open MPI version number splitting
     local -a ver
-    IFS='. ' read -r -a ver <<< $1
+    IFS='. ' read -r -a ver <<< "$1"
 
     # Download and install Open MPI
     local openmpi_version=$1
     local openmpi_short_ver=v${ver[0]}.${ver[1]}
     local openmpi_version_str=openmpi-${openmpi_version}
     local install_path=$2
-    fetch_and_untar ${openmpi_version_str}.tar.gz \
-        https://www.open-mpi.org/software/ompi/${openmpi_short_ver}/downloads/${openmpi_version_str}.tar.gz
-    cd ${openmpi_version_str}/;
-    ./configure --prefix=${install_path} \
+    fetch_and_untar "${openmpi_version_str}.tar.gz" \
+        "https://www.open-mpi.org/software/ompi/${openmpi_short_ver}/downloads/${openmpi_version_str}.tar.gz"
+    cd "${openmpi_version_str}/" || return;
+    ./configure --prefix="${install_path}" \
         --disable-dependency-tracking \
         --enable-coverage=no \
         --enable-shared=yes \
@@ -111,7 +111,7 @@ install_openmpi () {
 install_boost () {
     # Split argument 1 into 'ver' array, using '.' as delimiter
     local -a ver
-    IFS='. ' read -r -a ver <<< $1
+    IFS='. ' read -r -a ver <<< "$1"
 
     # Download and install Boost
     local boost_version=$1
@@ -122,8 +122,8 @@ install_boost () {
     local b2_extra_options=""
     local cxxflags_var=""
     local cxxflags_arr=()
-    if [[ "${BOOST_CXXFLAGS}" ]]; then
-        cxxflags_arr+=("${BOOST_CXXFLAGS}")
+    if [[ "${BOOST_CXX_FLAGS}" ]]; then
+        cxxflags_arr+=("${BOOST_CXX_FLAGS}")
     fi
 
     local linkflags_var=""
@@ -143,11 +143,11 @@ install_boost () {
         linkflags_arr+=("-fsanitize=${BOOST_SANITIZER}")
     fi
 
-    if [[ "${cxxflags_arr[@]}" ]]; then
+    if [[ "${cxxflags_arr[*]}" ]]; then
         cxxflags_var="cxxflags=${cxxflags_arr[@]}"
     fi
 
-    if [[ "${linkflags_arr[@]}" ]]; then
+    if [[ "${linkflags_arr[*]}" ]]; then
         linkflags_var="linkflags=${linkflags_arr[@]}"
     fi
 
@@ -155,15 +155,15 @@ install_boost () {
 
     echo Boost b2 extra options ${b2_extra_options}
 
-    fetch_and_untar ${boost_version_str}.tar.gz \
-        http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download
-    cd ${boost_version_str}/;
-    ./bootstrap.sh --with-libraries=test --with-toolset=${boost_toolset};
-    ./b2 install -j2 --prefix=${install_path} \
+    fetch_and_untar "${boost_version_str}.tar.gz" \
+        "http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download"
+    cd "${boost_version_str}/" || return;
+    ./bootstrap.sh --with-libraries=test --with-toolset="${boost_toolset}";
+    ./b2 install -j2 --prefix="${install_path}" \
         variant=release \
         link=${b2_link_type} \
         threading=multi \
-        toolset=${boost_toolset} \
+        toolset="${boost_toolset}" \
         "${cxxflags_var}" \
         "${linkflags_var}" \
         ${b2_extra_options} >/dev/null;
@@ -172,19 +172,20 @@ install_boost () {
 install_cmake () {
     # Split CMake version
     local -a ver
-    IFS='. ' read -r -a ver <<< $1
+    IFS='. ' read -r -a ver <<< "$1"
 
     # Download cmake
     # uname for Linux/Darwin
-    local os_name="$(uname -s)"
+    local os_name
+    os_name="$(uname -s)"
     local cmake_version=$1
     local cmake_version_str=cmake-${cmake_version}-${os_name}-x86_64
     local install_path=$2
-    fetch_and_untar ${cmake_version_str}.tar.gz \
-        http://cmake.org/files/v${ver[0]}.${ver[1]}/${cmake_version_str}.tar.gz
+    fetch_and_untar "${cmake_version_str}.tar.gz" \
+        "http://cmake.org/files/v${ver[0]}.${ver[1]}/${cmake_version_str}.tar.gz"
 
     # Move cmake to "install" location
-    mv ${cmake_version_str} ${install_path};
+    mv "${cmake_version_str}" "${install_path}";
 }
 
 
@@ -226,15 +227,15 @@ fi
 if [[ ${FORCE_TOOLSET+x} ]]; then
     case "${compiler_toolset}" in
         gcc*)
-            ln -s $(which ${CC}) gcc
-            ln -s $(which ${CXX}) g++
+            ln -s "$(command -v "${CC}")" gcc
+            ln -s "$(command -v "${CXX}")" g++
             ;;
         clang*)
-            ln -s $(which ${CC}) clang
-            ln -s $(which ${CXX}) clang++
+            ln -s "$(command -v "${CC}")" clang
+            ln -s "$(command -v "${CXX}")" clang++
             ;;
         intel*)
-            ln -s $(which ${CXX}) icc
+            ln -s "$(command -v "${CXX}")" icc
             ;;
         *)
             echo "Unrecognized compiler toolset"
@@ -245,30 +246,30 @@ fi
 # Create and use a temp directory for downloading/building dependencies
 # First command may fail on older versions of macOS
 dependency_temp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'deptmpdir')
-pushd ${dependency_temp_dir}
+pushd "${dependency_temp_dir}" || exit
 
 case "$1" in
     boost)
-        install_boost ${install_version} ${install_path} ${compiler_toolset}
+        install_boost "${install_version}" "${install_path}" "${compiler_toolset}"
         ;;
     cmake)
-        install_cmake ${install_version} ${install_path}
+        install_cmake "${install_version}" "${install_path}"
         ;;
     mpich)
-        install_mpich ${install_version} ${install_path}
+        install_mpich "${install_version}" "${install_path}"
         ;;
     openmpi)
-        install_openmpi ${install_version} ${install_path}
+        install_openmpi "${install_version}" "${install_path}"
         ;;
     swig)
-        install_swig ${install_version} ${install_path}
+        install_swig "${install_version}" "${install_path}"
         ;;
     zmq)
         if [[ -z ${install_path:+x} ]]; then
             install_version="HEAD"
             install_path=$2
         fi
-        install_zmq ${install_version} ${install_path}
+        install_zmq "${install_version}" "${install_path}"
         ;;
     *)
         echo "Usage:"
@@ -278,8 +279,8 @@ case "$1" in
 esac
 
 # Return to the original directory and get rid of the temp directory
-popd
-rm -rf ${dependency_temp_dir}
+popd || exit
+rm -rf "${dependency_temp_dir}"
 
 if [[ ${DEBUG_INSTALL_DEPENDENCY+x} ]]; then
     set +x

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -158,7 +158,7 @@ install_boost () {
     fetch_and_untar "${boost_version_str}.tar.gz" \
         "http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download"
     cd "${boost_version_str}/" || return;
-    ./bootstrap.sh --with-libraries=test --with-toolset="${boost_toolset}";
+    ./bootstrap.sh --with-libraries="" --with-toolset="${boost_toolset}";
     ./b2 install -j2 --prefix="${install_path}" \
         variant=release \
         link=${b2_link_type} \

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -158,15 +158,21 @@ install_boost () {
     fetch_and_untar "${boost_version_str}.tar.gz" \
         "http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download"
     cd "${boost_version_str}/" || return;
-    ./bootstrap.sh --with-libraries="" --with-toolset="${boost_toolset}";
-    ./b2 install -j2 --prefix="${install_path}" \
-        variant=release \
-        link=${b2_link_type} \
-        threading=multi \
-        toolset="${boost_toolset}" \
-        "${cxxflags_var}" \
-        "${linkflags_var}" \
-        ${b2_extra_options} >/dev/null;
+
+    if [[ "${BOOST_BUILD_LIBS}" ]]; then
+        ./bootstrap.sh --with-libraries="${BOOST_BUILD_LIBS}" --with-toolset="${boost_toolset}";
+        ./b2 install -j2 --prefix="${install_path}" \
+            variant=release \
+            link=${b2_link_type} \
+            threading=multi \
+            toolset="${boost_toolset}" \
+            "${cxxflags_var}" \
+            "${linkflags_var}" \
+            ${b2_extra_options} >/dev/null;
+    else
+        mkdir -p "${install_path}/include" || exit
+        cp -r boost "${install_path}/include"
+    fi
 }
 
 install_cmake () {

--- a/scripts/lcov-helper.sh
+++ b/scripts/lcov-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "$1" ]]; then
-    subcmd=$(tr '[:upper:]' '[:lower:]' <<< $1)
+    subcmd=$(tr '[:upper:]' '[:lower:]' <<< "$1")
     case "${subcmd}" in
         setup-counters)
             lcov --directory . --zerocounters > /dev/null
@@ -35,7 +35,7 @@ if [[ "$1" ]]; then
 
             if [[ "$SUBMIT_CODECOV" != "true" || "$SUBMIT_COVERALLS" == "true" ]]; then
                 # Get the coverage info from the test runs into a file
-                lcov --gcov-tool $GCOV_TOOL --no-external --directory . --capture --output-file coverage.info &> /dev/null
+                lcov --gcov-tool "$GCOV_TOOL" --no-external --directory . --capture --output-file coverage.info &> /dev/null
                 # Combine the base coverage info with info from running programs
                 lcov -a coverage.base -a coverage.info --output-file coverage.total > /dev/null
                 # Clean-up the coverage info
@@ -44,14 +44,14 @@ if [[ "$1" ]]; then
 
             # Submit coverage info to dashboard
             if [[ "$SUBMIT_COVERALLS" == "true" ]]; then
-                coveralls --gcov ${GCOV_TOOL} --lcov-file coverage.info.cleaned > /dev/null
+                coveralls --gcov "${GCOV_TOOL}" --lcov-file coverage.info.cleaned > /dev/null
             fi
             if [[ "$SUBMIT_CODECOV" == "true" ]]; then
-                bash <(curl -s https://codecov.io/bash) -x ${GCOV_TOOL} > /dev/null
+                bash <(curl -s https://codecov.io/bash) -x "${GCOV_TOOL}" > /dev/null
             fi
             ;;
         *)
-            echo "Usage: $@ setup-counters|gather-coverage-info"
+            echo "Usage: $0 setup-counters|gather-coverage-info"
             ;;
     esac
 else

--- a/scripts/mktempdir.sh
+++ b/scripts/mktempdir.sh
@@ -1,1 +1,0 @@
-mytmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -66,7 +66,7 @@ else
     export CTEST_OUTPUT_ON_FAILURE=true
 
     if [[ "$TEST_CONFIG_GIVEN" == "true" ]]; then
-        test_label=$(tr '[:upper:]' '[:lower:]' <<< $TEST_CONFIG)
+        test_label=$(tr '[:upper:]' '[:lower:]' <<< "$TEST_CONFIG")
         case "${test_label}" in
 	    # Recognize aliases/case-insensitive versions of some values for TEST_CONFIG
             *daily*)
@@ -113,10 +113,10 @@ else
     if [[ "$DISABLE_UNIT_TESTS" != "true" ]]; then
 	if [[ -n "${TEST_CONFIG}" ]]; then
         	echo "Running ${TEST_CONFIG} tests"
-        	ctest -L ${TEST_CONFIG} ${CTEST_OPTIONS}
+        	ctest -L ${TEST_CONFIG} "${CTEST_OPTIONS}"
 	else
 		echo "Running all tests"
-		ctest ${CTEST_OPTIONS}
+		ctest "${CTEST_OPTIONS}"
 	fi
     fi
 fi

--- a/scripts/trigger-dependent-ci-builds.sh
+++ b/scripts/trigger-dependent-ci-builds.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUILD_MESSAGE="Test ${TRAVIS_REPO_SLUG} ${TRAVIS_COMMIT_RANGE}"
+#BUILD_MESSAGE="Test ${TRAVIS_REPO_SLUG} ${TRAVIS_COMMIT_RANGE}"
 
 # Trigger HELICS-FMI build
 #body='{
@@ -33,14 +33,14 @@ trigger_azure_build () {
     "reason": "individualCI",
     "sourceBranch": "refs/heads/'${TRAVIS_BRANCH}'"
     }'
-    
+
     curl -s -X POST \
          -H "Content-Type: application/json" \
          -H "Accept: application/json" \
          -H "Authorization: Basic ${HELICSBOT_AZURE_TOKEN}" \
          -d "$body" \
-         https://dev.azure.com/${azure_slug}/_apis/build/builds?api-version=4.1
-    
+         "https://dev.azure.com/${azure_slug}/_apis/build/builds?api-version=4.1"
+
     echo "===Triggering Azure build==="
     echo "Slug: $azure_slug"
     echo "Definition ID: $def_id"

--- a/scripts/upload-ci-artifact.sh
+++ b/scripts/upload-ci-artifact.sh
@@ -4,4 +4,4 @@ CI_DIR=${TRAVIS_BUILD_DIR}
 
 # Upload artifact to Bintray
 BT_URL="https://api.bintray.com/content/helics/develop/snapshot/${TRAVIS_BRANCH}/${TRAVIS_BRANCH}/helics-install-$(uname -s).sh?publish=1&override=1"
-curl -T $(ls ${CI_DIR}/build/cpack-output/Helics*.sh) -u${BT_USER}:${BT_APIKEY} ${BT_URL}
+curl -T "$(ls "${CI_DIR}"/build/cpack-output/Helics*.sh)" -u"${BT_USER}:${BT_APIKEY}" "${BT_URL}"


### PR DESCRIPTION

### Summary
If merged this pull request will fix various shellcheck warnings and errors. Mostly quoting variables to make sure spaces in the value work correctly, replacing `which` with the more standard `command -v` to get program paths, and adding `|| exit/return` for failed directory changes.

### Proposed changes
- Fix shellcheck warnings, including some bugs
- Remove no longer used Boost sanitizer and compilation step; copy the Boost headers instead (160 seconds -> 50 seconds for installing dependencies without a cache on Travis)
