### PR TITLE
Update Azure Windows CI builds to use Python 3.5

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.4'
+      versionSpec: '3.5'
       architecture: $(langArch)
     condition: ne( variables['imageName'], 'vs2015-win2012r2' )
     


### PR DESCRIPTION

### Summary
If merged this pull request will update the Azure Windows CI builds to use Python 3.5, since a colorama update broke Python 3.4 builds and the 5.x versions of pytest require Python 3.5 as a minimum.

### Proposed changes
- Update to use Python 3.5 on Azure Windows CI builds
