### PR TITLE
Fix void* to char* conversion error in Matlab interface

### DIFF
--- a/interfaces/matlab/matlab_maps.i
+++ b/interfaces/matlab/matlab_maps.i
@@ -257,7 +257,7 @@ static void throwHelicsMatlabError(helics_error *err) {
 }
 
 %typemap(argout) (void *data, int maxDatalen, int *actualSize) {
- if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3);
+ if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize((char*)$1,*$3);
 }
 
 // typemap for raw message data functions
@@ -276,5 +276,5 @@ static void throwHelicsMatlabError(helics_error *err) {
 }
 
 %typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
- if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3);
+ if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize((char*)$1,*$3);
 }


### PR DESCRIPTION
### Summary
If merged this pull request will fix the two `cannot convert argument of incomplete type 'void *' to 'const char *'` errors for #961.

### Proposed changes
- Cast void* to char* for the SWIG_FromCharPtrAndSize function call
