### PR TITLE
Handle edge cases with git archive creation script tag arguments

### DIFF
--- a/scripts/_git-all-archive.sh
+++ b/scripts/_git-all-archive.sh
@@ -1,4 +1,5 @@
-#
+#!/bin/bash
+
 # Copyright (c) 2017-2019,
 # Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
 # the top-level NOTICE for additional details. All rights reserved.
@@ -47,10 +48,23 @@ shift $((OPTIND - 1))
 echo "> creating root archive"
 export ROOT_ARCHIVE_DIR="$(pwd)"
 
-git checkout "$tag"
+# Checkout a tag if provided
+if [[ -n "$tag" ]];
+then
+  git checkout "$tag"
+fi
+
+# Get git submodule source code
 git submodule update --init
-OUTPUT_BASENAME="Helics-${release}-source"
+
+# Set the output name based on if a release name was provided
+OUTPUT_BASENAME="Helics-source"
+if [[ -n "$release" ]];
+then
+  OUTPUT_BASENAME="Helics-${release}-source"
+fi
 export OUTPUT_FILE="${OUTPUT_BASENAME}.tar.gz"
+
 # create root archive
 git archive --verbose --format "tar" --output "${ROOT_ARCHIVE_DIR}/${OUTPUT_BASENAME}.tar" "$(git rev-parse --abbrev-ref HEAD)"
 


### PR DESCRIPTION

### Summary
If merged this pull request will add better handling for the edge cases where the checkout tag and release tag arguments aren't provided for creating a git archive with all submodules.

### Proposed changes
- Handle the case of no checkout tag argument provided
- Set a nicer output file name when no release tag is given
