### PR TITLE
Build macOS release assets with the macOS 10.10 SDK

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -116,6 +116,7 @@ jobs:
             os: macos-latest
             arch: x64
             cpack_gen: TGZ
+            macos_target_ver: '10.10'
 
     steps:
     - name: Checkout event ref
@@ -133,6 +134,11 @@ jobs:
       with:
         python-version: '3.6'
         architecture: ${{ matrix.arch }}
+ 
+    # Setup a copy of the macOS 10.10 SDK
+    - name: Setup macOS 10.10 SDK
+      if: runner.os == 'macOS'
+      run: ./.github/workflows/setup-macos-10.10-sdk.sh
         
     # Compile HELICS and create the installer
     - name: Build installer
@@ -140,6 +146,7 @@ jobs:
         BUILD_ARCH: ${{ matrix.arch }}
         BUILD_GEN: ${{ matrix.cmake_gen }}
         MSVC_VER: ${{ matrix.msvc_ver }}
+        MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_target_ver }}
         CPACK_GEN: ${{ matrix.cpack_gen }}
       shell: bash
       run: ./.github/workflows/release-build/installer-${{ runner.os }}.sh
@@ -182,6 +189,7 @@ jobs:
           - id: macos-x64
             os: macos-latest
             arch: x64
+            macos_target_ver: '10.10'
           - id: ubuntu-x64
             os: ubuntu-latest
             arch: x64
@@ -196,7 +204,12 @@ jobs:
       with:
         ref: develop
       if: github.event_name == 'schedule'
-        
+     
+    # Setup a copy of the macOS 10.10 SDK
+    - name: Setup macOS 10.10 SDK
+      if: runner.os == 'macOS'
+      run: ./.github/workflows/setup-macos-10.10-sdk.sh
+   
     # Compile HELICS and create the installer
     - name: Build shared library
       if: runner.os != 'Linux'
@@ -204,6 +217,7 @@ jobs:
         BUILD_ARCH: ${{ matrix.arch }}
         BUILD_GEN: ${{ matrix.cmake_gen }}
         MSVC_VER: ${{ matrix.msvc_ver }}
+        MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_target_ver }}
       shell: bash
       run: ./.github/workflows/release-build/shared-library-${{ runner.os }}.sh
     

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -98,7 +98,7 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
     strategy:
       matrix:
-        id: [windows-x64-nsis, windows-x64-zip, macos-x64-tgz]
+        id: [windows-x64-nsis, windows-x64-zip, macos-x64-zip]
         include:
           - id: windows-x64-nsis
             os: windows-latest
@@ -112,10 +112,10 @@ jobs:
             cpack_gen: ZIP
             cmake_gen: 'Visual Studio 16 2019'
             msvc_ver: 'msvc2019'
-          - id: macos-x64-tgz
+          - id: macos-x64-zip
             os: macos-latest
             arch: x64
-            cpack_gen: TGZ
+            cpack_gen: ZIP
             macos_target_ver: '10.10'
 
     steps:

--- a/.github/workflows/release-build/installer-macOS.sh
+++ b/.github/workflows/release-build/installer-macOS.sh
@@ -8,6 +8,6 @@ cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACK
 cmake --build . --config Release
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
-"${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
+"${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/workflows/setup-macos-10.10-sdk.sh
+++ b/.github/workflows/setup-macos-10.10-sdk.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+XCODE_MACOS_PLATFORM_PATH="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform"
+XCODE_MACOS_SDK_PATH="${XCODE_MACOS_PLATFORM_PATH}/Developer/SDKs"
+
+# Download macOS 10.10 SDK
+wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.10.sdk.tar.xz
+
+# Extract macOS 10.10 SDK to the XCode macOS SDKs folder
+tar -xf MacOSX10.10.sdk.tar.xz -C "${XCODE_MACOS_SDK_PATH}"
+
+# Set the MinimumSDKVersion for XCode to 10.10
+/usr/libexec/PlistBuddy -c "Set :MinimumSDKVersion 10.10" "${XCODE_MACOS_PLATFORM_PATH}/Info.plist"
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ add_library(HELICS::compile_flags_target ALIAS compile_flags_target)
 add_library(HELICS::build_flags_target ALIAS build_flags_target)
 
 get_target_property(EXTRA_BUILD_FLAGS build_flags_target INTERFACE_COMPILE_OPTIONS)
-set(HELICS_BUILD_FLAGS_OUTPUT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_STATIC_LINKER_FLAGS} ${EXTRA_BUILD_FLAGS} ") 
+set(HELICS_BUILD_FLAGS_OUTPUT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_STATIC_LINKER_FLAGS} ${EXTRA_BUILD_FLAGS} ")
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(NOT USE_LIBCXX)
@@ -958,14 +958,16 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
             endif()
         endif()
     endif()
+    # cmake-format: off
     set(CPACK_PACKAGE_NAME "Helics")
     set(CPACK_PACKAGE_VENDOR "GMLC")
-    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "HELICS")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)")
     set(CPACK_PACKAGE_VERSION "${HELICS_VERSION}")
     set(CPACK_PACKAGE_VERSION_MAJOR ${HELICS_VERSION_MAJOR})
     set(CPACK_PACKAGE_VERSION_MINOR ${HELICS_VERSION_MINOR})
     set(CPACK_PACKAGE_VERSION_PATCH ${HELICS_VERSION_PATCH})
     set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "HELICS")
+    # cmake-format: on
 
     set(CPACK_COMPONENTS_ALL
         applications
@@ -982,8 +984,10 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     )
     if(WIN32)
         set(CPACK_RESOURCE_FILE_LICENSE "${HELICS_SOURCE_DIR}\\\\LICENSE")
+        set(CPACK_RESOURCE_FILE_README "${HELICS_SOURCE_DIR}\\\\README.md")
     else(WIN32)
         set(CPACK_RESOURCE_FILE_LICENSE "${HELICS_SOURCE_DIR}/LICENSE")
+        set(CPACK_RESOURCE_FILE_README "${HELICS_SOURCE_DIR}/README.md")
     endif(WIN32)
 
     set(CPACK_COMPONENT_APPLICATIONS_DISPLAY_NAME "Application")
@@ -1061,13 +1065,9 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     endif(WIN32)
 
     if(APPLE)
-        set(CPACK_BUNDLE_NAME "libhelics")
-        configure_file(
-            "${HELICS_SOURCE_DIR}/config/Info.plist.in"
-            "${CMAKE_CURRENT_BINARY_DIR}/Info.plist" @ONLY
-        )
-        set(CPACK_BUNDLE_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist")
-        set(CPACK_BUNDLE_ICON "${HELICS_SOURCE_DIR}/docs/img/HELICS.ico")
+        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-macOS")
+        set(CPACK_DMG_DISABLE_APPLICATIONS_SYMLINK ON)
+        set(CPACK_PACKAGE_ICON "${HELICS_SOURCE_DIR}/docs/img/HELICS.ico")
     endif(APPLE)
 
     set(CPACK_SOURCE_IGNORE_FILES "/Build*/;/build*/;/.git/")


### PR DESCRIPTION
### Summary
If merged this pull request will build the macOS installer and shared library release assets using a macOS 10.10 SDK to support older versions of macOS.

### Proposed changes
- Setup a copy of the macOS 10.10 SDK and use it to build macOS release assets
- Cleanup some of the macOS release package settings
- Switch macOS installer CPack generator from TGZ to ZIP