### PR TITLE
Fix Windows Python module extension for builds without swig

### DIFF
--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -252,6 +252,12 @@ else()
                 helicsPYTHON
                 PROPERTIES PREFIX "_" OUTPUT_NAME "helics"
             )
+            
+            # Set the output library extension to .pyd on Windows
+            if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+                set_property(TARGET helicsPYTHON PROPERTY SUFFIX ".pyd")
+            endif()
+
             target_link_libraries(helicsPYTHON PUBLIC helicsSharedLib)
 
             install(


### PR DESCRIPTION
### Summary
If merged this pull request will change the extension when building the Python interface on Windows without Swig to `pyd`. Fixes #979.

### Proposed changes
- Set the Python module extension on Windows builds to `pyd` when not using swig
