### PR TITLE
Run Travis Code Coverage job if the branch name or commit message has "codecov"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -200,6 +200,7 @@ jobs:
         - BUILD_TYPE=RelWithDebInfo
     # Code coverage build
     - <<: *daily_linux
+      if: (type = cron) OR (branch =~ /(codecov)/) OR (commit_message =~ /(codecov)/)
       name: "GCC 6 Code Coverage"
       env:
         - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"


### PR DESCRIPTION

### Summary
If merged this pull request will run the code coverage Travis jobs on branch names containing "codecov" or commit messages with "codecov" in them.

### Proposed changes
- Update the condition for the Travis code coverage job to also run on branch names or commit messages containing "codecov"
