### PR TITLE
Adds a CMake function to Git Submodules logic to check if all submodules are current

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,8 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/ThirdParty/toml11/toml/value.hpp")
     submod_update(ThirdParty/toml11)
 endif()
 
+check_submodule_status()
+
 include(GNUInstallDirs)
 
 # -------------------------------------------------------------
@@ -400,7 +402,7 @@ endif()
 # -------------------------------------------------------------
 
 set(toml11_BUILD_TEST OFF CACHE INTERNAL "")
-add_subdirectory(ThirdParty/toml11 EXCLUDE_FROM_ALL) 
+add_subdirectory(ThirdParty/toml11 EXCLUDE_FROM_ALL)
 
 # -------------------------------------------------------------
 # options for enabling specific core communication types

--- a/config/cmake/updateGitSubmodules.cmake
+++ b/config/cmake/updateGitSubmodules.cmake
@@ -12,15 +12,15 @@
 find_package(Git QUIET)
 if(GIT_FOUND AND (GIT_VERSION_STRING VERSION_GREATER "1.5.2"))
     if(EXISTS "${PROJECT_SOURCE_DIR}/.git")
-        option(ENABLE_SUBMODULE_UPDATE "Checkout and update git submodules" ON)
-		mark_as_advanced(ENABLE_SUBMODULE_UPDATE)
+        option(${PROJECT_NAME}_ENABLE_SUBMODULE_UPDATE "Checkout and update git submodules" ON)
+		mark_as_advanced(${PROJECT_NAME}_ENABLE_SUBMODULE_UPDATE)
     else()
         message(STATUS "${PROJECT_SOURCE_DIR} is not a Git repository. Clone ${PROJECT_NAME} with Git or ensure you get copies of all the Git submodules code.")
     endif()
 endif()
 
 macro(submod_update_all)
-  if (ENABLE_SUBMODULE_UPDATE)
+  if (${PROJECT_NAME}_ENABLE_SUBMODULE_UPDATE)
     message(STATUS "Git Submodule Update")
             execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -35,7 +35,7 @@ macro(submod_update_all)
 endmacro()
 
 macro(submod_update target)
-  if (ENABLE_SUBMODULE_UPDATE)
+  if (${PROJECT_NAME}_ENABLE_SUBMODULE_UPDATE)
      message(STATUS "Git Submodule Update ${target}")
      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init -- ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -50,7 +50,7 @@ macro(submod_update target)
 endmacro()
 
 function(check_submodule_status)
-    if (ENABLE_SUBMODULE_UPDATE)
+    if (${PROJECT_NAME}_ENABLE_SUBMODULE_UPDATE)
         execute_process(COMMAND ${GIT_EXECUTABLE} submodule status
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 RESULT_VARIABLE GIT_RESULT

--- a/config/cmake/updateGitSubmodules.cmake
+++ b/config/cmake/updateGitSubmodules.cmake
@@ -51,13 +51,13 @@ endmacro()
 
 function(check_submodule_status)
     if (ENABLE_SUBMODULE_UPDATE)
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule status --recursive
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule status
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 RESULT_VARIABLE GIT_RESULT
                 OUTPUT_VARIABLE GIT_OUTPUT)
 
         if (GIT_RESULT)
-            message(WARNING "Automatic submodule verification with `git submodule status --recursive` failed with error ${GIT_RESULT} and output ${GIT_OUTPUT}. Verify submodules before building.")
+            message(WARNING "Automatic submodule verification with `git submodule status` failed with error ${GIT_RESULT} and output ${GIT_OUTPUT}. Verify submodules before building.")
         endif ()
 
         if (WIN32 AND NOT (MSYS OR CYGWIN))
@@ -70,7 +70,8 @@ function(check_submodule_status)
                     )
         endif ()
         if (NOT "${SUBMODULE_STATUS}" STREQUAL "")
-            message(WARNING "Submodules are not up to date. Update submodules by running `git submodule update --init --recursive` before building HELICS.")
+            message(WARNING "Submodules are not up to date. Update submodules by running `git submodule update --init` before building HELICS."
+            "\nOut of date submodules:\n ${SUBMODULE_STATUS}")
         endif ()
     endif ()
 endfunction()

--- a/docs/installation/helics_cmake_options.md
+++ b/docs/installation/helics_cmake_options.md
@@ -46,7 +46,7 @@ These options effect the configuration of HELICS itself and how/what gets built 
 Options effect the connection of libraries used in HELICS and how they are linked.
 -   `HELICS_DISABLE_BOOST` : \[Default=OFF\] Completely turn off searching and inclusion of boost libraries.  This will disable the IPC core and few other features, possibly more in the future.  
 -   `HELICS_DISABLE_ASIO` : \[Default=OFF\] Completely turn off  inclusion of ASIO libraries.  This will disable all TCP and UDP cores, disable real time mode for HELICS, and disable all timeout features for the Library so **use with caution**.  
--   `ENABLE_SUBMODULE_UPDATE` : \[Default=ON\] Enable CMake to automatically download the submodules and update them if Unnecessary
+-   `HELICS_ENABLE_SUBMODULE_UPDATE` : \[Default=ON\] Enable CMake to automatically download the submodules and update them if necessary
 -   `HELICS_ENABLE_ERROR_ON_WARNING` :\[Default=OFF\] Turns on Werror or equivalent,  probably not useful for normal activity,  There isn't many warnings but left in to allow the possibility
 -   `HELICS_ENABLE_EXTRA_COMPILER_WARNINGS` : \[Default=ON\] Turn on higher levels of warnings in the compilers,  can be turned off if you didn't need or want the warning checks.
 -   `STATIC_STANDARD_LIB`:   \[Default=""\] link the standard library as a static library for no additional C++ system dependencies (recognized values are `default`, `static`, and `dynamic`, anything else is treated the same as `default`)


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will add a non-blocking CMake function to Git Submodules logic to check if all submodules are current.

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
Uses the `git submodule status --recursive` command to verify all submodules are
up to date with the parent repository, and displays a non-blocking warning if any
module is out of date, as well as the command to update submodules.
Output from git is piped through grep on *nix style machines, and powershell Select-String on Win32 machines to verify all submodules and their dependencies are clean. 
If submodules are out of date, the user is notified with a CMake warning, and the command to update the submodules is displayed. 