### PR TITLE
Fix pre-commit hook to no longer block

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+command -v clang-format >/dev/null 2>&1 || { echo >&2 "Githooks require clang-format but it's not available in this environment. Bypassing githook."; exit 0; }
+
 files=()
 for file in `git diff --cached --name-only --diff-filter=ACMRT ':!interfaces' ':!ThirdParty' | grep -E "\.(cpp|hpp|c|h)$"`; do
   if ! cmp -s <(git show :${file}) <(git show :${file}|clang-format); then
@@ -11,7 +13,7 @@ if [[ -n "${files}" ]]; then
     echo "Clang-format found issues with the following files:"
     printf "%s\n" "${files[@]}"
     echo "Run clang-format -i <filename> to resolve the issue before committing, or commit with --no-verify"
-    exit 1
+#    exit 1
 else
     echo "Clang-format check passed successfully."
 fi


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
Resolves #987 

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
Makes git-hook no longer blocking, and verify availability of clang-format before attempting to execute. 
