### PR TITLE
Remove dependency on Python for generating the swig interface

### DIFF
--- a/docs/installation/language.md
+++ b/docs/installation/language.md
@@ -28,8 +28,10 @@ In [1]: import helics
 
 In [2]: helics.helicsGetVersion()
 Out[2]: 'x.x.x (XXXX-XX-XX)'
-
 ```
+
+Note: If you already have a HELICS installation with the C shared library, it is possible to build the Python3 interface
+using the `interfaces/python` folder as a standalone CMake project. This can be much faster than rebuilding HELICS.
 
 ## HELICS with Python2
 

--- a/docs/installation/language.md
+++ b/docs/installation/language.md
@@ -31,7 +31,7 @@ Out[2]: 'x.x.x (XXXX-XX-XX)'
 ```
 
 Note: If you already have a HELICS installation with the C shared library, it is possible to build the Python3 interface
-using the `interfaces/python` folder as a standalone CMake project. This can be much faster than rebuilding HELICS.
+using the `interfaces/python` folder as a standalone CMake project ("e.g. `cmake <path to interfaces/python folder>`"). This can be much faster than rebuilding HELICS.
 
 ## HELICS with Python2
 

--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -102,6 +102,15 @@ else()
 endif()
 
 ###############################
+# Run SWIG only (no build)
+###############################
+# Swig doesn't need Python to generate the wrapper files
+if(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY AND SWIG_EXECUTABLE)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/pythonSwigGenerateOnly.cmake)
+    return()
+endif()
+
+###############################
 # Find Python libraries
 ###############################
 if(HELICS_USE_NEW_PYTHON_FIND)
@@ -128,14 +137,6 @@ else()
     set(HELICS_Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
     set(HELICS_Python3_INCLUDE_DIRS "${PYTHON_INCLUDE_DIRS}")
     set(HELICS_Python3_LIBRARIES "${PYTHON_LIBRARIES}")
-endif()
-
-###############################
-# Run SWIG only (no build)
-###############################
-if(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY AND SWIG_EXECUTABLE)
-    include(${CMAKE_CURRENT_SOURCE_DIR}/pythonSwigGenerateOnly.cmake)
-    return()
 endif()
 
 ###############################

--- a/interfaces/python/pythonSwigGenerateOnly.cmake
+++ b/interfaces/python/pythonSwigGenerateOnly.cmake
@@ -15,12 +15,15 @@ if(SWIG_VERSION VERSION_GREATER "4.0.0")
   set(SWIG_DOXYGEN_FLAG "-doxygen")
 endif()
 
+  get_filename_component(helics.i_INCLUDE_DIR "${HELICS_SWIG_helics.i_FILE}" DIRECTORY)
+
   # custom command for building the wrap file
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/helicsPython.c
     COMMAND
       "${SWIG_EXECUTABLE}" "-python" "-py3" -o "helicsPython.c" "${SWIG_DOXYGEN_FLAG}"
       "-I${CMAKE_SOURCE_DIR}/src/helics/shared_api_library"
+      "-I${helics.i_INCLUDE_DIR}"
       ${CMAKE_CURRENT_SOURCE_DIR}/helicsPython.i
     DEPENDS
       ${HELICS_SWIG_helics.i_FILE}
@@ -37,7 +40,7 @@ endif()
         ${CMAKE_CURRENT_SOURCE_DIR}/overwritePythonFiles.cmake
       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/helicsPython.c
     )
-	set_target_properties( pyfile_overwrite PROPERTIES FOLDER interfaces)
+	set_target_properties(pyfile_overwrite PROPERTIES FOLDER interfaces)
   else(HELICS_OVERWRITE_INTERFACE_FILES)
   #extra target for generation only and no overwrite
    add_custom_target(
@@ -45,5 +48,5 @@ endif()
       COMMAND
       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/helicsPython.c
     )
-	set_target_properties( python_create PROPERTIES FOLDER interfaces)
+	set_target_properties(python_create PROPERTIES FOLDER interfaces)
 endif(HELICS_OVERWRITE_INTERFACE_FILES)


### PR DESCRIPTION
### Summary
If merged this pull request will remove the dependency on Python when only generating updated interface files with swig.

### Proposed changes
- Handle the swig generate only option before finding Python (removes dependency on Python)
- Include the directory helics.i is in for swig generate only builds so that it can work standalone
- Add a note to the docs mentioning support for building the Python3 interface using an existing HELICS install
