### PR TITLE
Add STATUS mode to all cmake message() calls

### DIFF
--- a/config/cmake/GitUtils.cmake
+++ b/config/cmake/GitUtils.cmake
@@ -128,7 +128,7 @@ function(git_clone)
     endif()
 
     if(NOT PARGS_QUIET)
-        message("${git_output}")
+        message(STATUS "${git_output}")
     endif()
 
     # now checkout the right commit
@@ -152,6 +152,6 @@ function(git_clone)
     endif()
 
     if(NOT PARGS_QUIET)
-        message("${git_output}")
+        message(STATUS "${git_output}")
     endif()
 endfunction()

--- a/config/cmake/ucm.cmake
+++ b/config/cmake/ucm.cmake
@@ -240,6 +240,37 @@ macro(ucm_set_runtime)
     endif()
 endmacro()
 
+# ucm_set_embedded_debug on MSVC
+# Sets the runtime (static/dynamic) for msvc
+macro(ucm_set_embedded_debug)
+    cmake_parse_arguments(ARG "EMBEDDED;EXTERNAL" "" "" ${ARGN})
+
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+     
+	 if (MSVC)
+		ucm_gather_flags(0 flags_configs)
+    
+		# add/replace the flags
+		# note that if the user has messed with the flags directly this function might fail
+		# - for example if with MSVC and the user has removed the flags - here we just switch/replace them
+		if("${ARG_EMBEDDED}")
+			foreach(flags ${flags_configs})
+					if(${flags} MATCHES "/Zi")
+						string(REGEX REPLACE "/Zi" "/Z7" ${flags} "${${flags}}")
+					endif()
+			endforeach()
+		elseif("${ARG_EXTERNAL}")
+			foreach(flags ${flags_configs})
+					if(${flags} MATCHES "/Z7")
+						string(REGEX REPLACE "/Z7" "/Zi" ${flags} "${${flags}}")
+					endif()
+			endforeach()
+		endif()
+	endif()
+endmacro()
+
 # ucm_print_flags
 # Prints all compiler flags for all configurations
 macro(ucm_print_flags)

--- a/config/cmake/ucm.cmake
+++ b/config/cmake/ucm.cmake
@@ -21,12 +21,11 @@ endif()
 
 if(COMMAND cotire AND "1.7.9" VERSION_LESS "${COTIRE_CMAKE_MODULE_VERSION}")
     set(ucm_with_cotire 1)
+    option(UCM_UNITY_BUILD          "Enable unity build for targets registered with the ucm_add_target() macro"                     OFF)
+    option(UCM_NO_COTIRE_FOLDER     "Do not use a cotire folder in the solution explorer for all unity and cotire related targets"  ON)
 else()
     set(ucm_with_cotire 0)
 endif()
-
-option(UCM_UNITY_BUILD          "Enable unity build for targets registered with the ucm_add_target() macro"                     OFF)
-option(UCM_NO_COTIRE_FOLDER     "Do not use a cotire folder in the solution explorer for all unity and cotire related targets"  ON)
 
 # ucm_add_flags
 # Adds compiler flags to CMAKE_<LANG>_FLAGS or to a specific config

--- a/config/cmake/ucm.cmake
+++ b/config/cmake/ucm.cmake
@@ -1,28 +1,11 @@
 #
 # ucm.cmake - useful cmake macros
 #
-#The MIT License (MIT)
+# Copyright (c) 2016 Viktor Kirilov
 #
-#Copyright (c) 2016 Viktor Kirilov
-#
-#Permission is hereby granted, free of charge, to any person obtaining a copy
-#of this software and associated documentation files (the "Software"), to deal
-#in the Software without restriction, including without limitation the rights
-#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-#copies of the Software, and to permit persons to whom the Software is
-#furnished to do so, subject to the following conditions:
-#
-#The above copyright notice and this permission notice shall be included in all
-#copies or substantial portions of the Software.
-#
-#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-#SOFTWARE.
-#
+# Distributed under the MIT Software License
+# See accompanying file LICENSE.txt or copy at
+# https://opensource.org/licenses/MIT
 #
 # The documentation can be found at the library's page:
 # https://github.com/onqtam/ucm
@@ -32,18 +15,18 @@ cmake_minimum_required(VERSION 2.8.12)
 include(CMakeParseArguments)
 
 # optionally include cotire - the git submodule might not be inited (or the user might have already included it)
-#if(NOT COMMAND cotire)
-#    include(${CMAKE_CURRENT_LIST_DIR}/../cotire/CMake/cotire.cmake OPTIONAL)
-#endif()
-#
-#if(COMMAND cotire AND "1.7.9" VERSION_LESS "${COTIRE_CMAKE_MODULE_VERSION}")
-#    set(ucm_with_cotire 1)
-#else()
-#    set(ucm_with_cotire 0)
-#endif()
-#
-#option(UCM_UNITY_BUILD          "Enable unity build for targets registered with the ucm_add_target() macro"                     OFF)
-#option(UCM_NO_COTIRE_FOLDER     "Do not use a cotire folder in the solution explorer for all unity and cotire related targets"  ON)
+if(NOT COMMAND cotire)
+    include(${CMAKE_CURRENT_LIST_DIR}/../cotire/CMake/cotire.cmake OPTIONAL)
+endif()
+
+if(COMMAND cotire AND "1.7.9" VERSION_LESS "${COTIRE_CMAKE_MODULE_VERSION}")
+    set(ucm_with_cotire 1)
+else()
+    set(ucm_with_cotire 0)
+endif()
+
+option(UCM_UNITY_BUILD          "Enable unity build for targets registered with the ucm_add_target() macro"                     OFF)
+option(UCM_NO_COTIRE_FOLDER     "Do not use a cotire folder in the solution explorer for all unity and cotire related targets"  ON)
 
 # ucm_add_flags
 # Adds compiler flags to CMAKE_<LANG>_FLAGS or to a specific config
@@ -257,47 +240,44 @@ macro(ucm_set_runtime)
     endif()
 endmacro()
 
-
-# ucm_set_embedded_debug on MSVC
-# Sets the runtime (static/dynamic) for msvc
-macro(ucm_set_embedded_debug)
-    cmake_parse_arguments(ARG "EMBEDDED;EXTERNAL" "" "" ${ARGN})
-
-    if(ARG_UNPARSED_ARGUMENTS)
-        message(FATAL_ERROR "unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
-    endif()
-     
-	 if (MSVC)
-		ucm_gather_flags(0 flags_configs)
-    
-		# add/replace the flags
-		# note that if the user has messed with the flags directly this function might fail
-		# - for example if with MSVC and the user has removed the flags - here we just switch/replace them
-		if("${ARG_EMBEDDED}")
-			foreach(flags ${flags_configs})
-					if(${flags} MATCHES "/Zi")
-						string(REGEX REPLACE "/Zi" "/Z7" ${flags} "${${flags}}")
-					endif()
-			endforeach()
-		elseif("${ARG_EXTERNAL}")
-			foreach(flags ${flags_configs})
-					if(${flags} MATCHES "/Z7")
-						string(REGEX REPLACE "/Z7" "/Zi" ${flags} "${${flags}}")
-					endif()
-			endforeach()
-		endif()
-	endif()
-endmacro()
-
 # ucm_print_flags
 # Prints all compiler flags for all configurations
 macro(ucm_print_flags)
     ucm_gather_flags(1 flags_configs)
-    message("")
+    message(STATUS "")
     foreach(flags ${flags_configs})
-        message("${flags}: ${${flags}}")
+        message(STATUS "${flags}: ${${flags}}")
     endforeach()
-    message("")
+    message(STATUS "")
+endmacro()
+
+# ucm_set_xcode_attrib
+# Set xcode attributes - name value CONFIG config1 conifg2..
+macro(ucm_set_xcode_attrib)
+    cmake_parse_arguments(ARG "" "CLEAR" "CONFIG" ${ARGN})
+
+    if(NOT ARG_CONFIG)
+        set(ARG_CONFIG " ")
+    endif()
+
+    foreach(CONFIG ${ARG_CONFIG})
+        # determine to which attributes to add
+        if(${CONFIG} STREQUAL " ")
+            if(${ARG_CLEAR})
+                # clear the old flags
+                unset(CMAKE_XCODE_ATTRIBUTE_${ARGV0})
+            else()
+                set(CMAKE_XCODE_ATTRIBUTE_${ARGV0} ${ARGV1})
+            endif()
+        else()
+            if(${ARG_CLEAR})
+                # clear the old flags
+                unset(CMAKE_XCODE_ATTRIBUTE_${ARGV0}[variant=${CONFIG}])
+            else()
+                set(CMAKE_XCODE_ATTRIBUTE_${ARGV0}[variant=${CONFIG}] ${ARGV1})
+            endif()
+        endif()
+    endforeach()
 endmacro()
 
 # ucm_count_sources

--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -216,7 +216,7 @@ if(HELICS_ENABLE_SWIG AND SWIG_EXECUTABLE)
 
     set(HELICS_PYTHON_TARGET_NAME _helics)
 else()
-    message("Building without swig cmake ${CMAKE_VERSION}")
+    message(STATUS "Building without swig")
 
     if(HELICS_USE_NEW_PYTHON_FIND)
         python3_add_library(helicsPYTHON MODULE helicsPython.c)


### PR DESCRIPTION
### Summary
If merged this pull request will ensure all cmake message() calls have a mode set to STATUS instead of no mode. ucm and cmake_clone_git modules are updated to the latest versions.

### Proposed changes
- Update cmake_clone_git
- Update ucm
- Add STATUS mode to a message() call in the python interface CMakeLists.txt
