### PR TITLE
Set macOS rpaths to make installs movable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,8 +578,10 @@ if(NOT APPLE)
                 "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
     )
 else()
-    list(APPEND CMAKE_INSTALL_RPATH "@loader_path/.")
-    list(APPEND CMAKE_INSTALL_RPATH "@executable_path/.")
+    list(APPEND CMAKE_INSTALL_RPATH "@loader_path")
+    list(APPEND CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+    list(APPEND CMAKE_INSTALL_RPATH "@executable_path")
+    list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,17 +559,15 @@ endif()
 # -------------------------------------------------------------
 # setting the RPATH
 # -------------------------------------------------------------
-# use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-
-# when building, don't use the install RPATH already (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-set(CMAKE_MACOSX_RPATH ON)
+if(NOT DEFINED CMAKE_MACOSX_RPATH)
+    set(CMAKE_MACOSX_RPATH ON)
+endif()
 
 # add the automatically determined parts of the RPATH which point to directories outside
 # the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+if(NOT DEFINED CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
 
 # Add the local directory to the rpath
 if(NOT APPLE)

--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -25,10 +25,12 @@ if(NOT hasParent)
     include(GNUInstallDirs)
 
     # Setup rpath
-    set(CMAKE_SKIP_BUILD_RPATH FALSE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-    set(CMAKE_MACOSX_RPATH ON)
-    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    if(NOT DEFINED CMAKE_MACOSX_RPATH)
+        set(CMAKE_MACOSX_RPATH ON)
+    endif()
+    if(NOT DEFINED CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+        set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    endif()
 
     # Add the local directory to the rpath
     if(NOT APPLE)

--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -37,8 +37,10 @@ if(NOT hasParent)
                     "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         )
     else()
-        list(APPEND CMAKE_INSTALL_RPATH "@loader_path/.")
-        list(APPEND CMAKE_INSTALL_RPATH "@executable_path/.")
+        list(APPEND CMAKE_INSTALL_RPATH "@loader_path")
+        list(APPEND CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+        list(APPEND CMAKE_INSTALL_RPATH "@executable_path")
+        list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
     endif()
 endif()
 


### PR DESCRIPTION
### Summary
If merged this pull request will set the rpaths on macOS so that installs can be moved around (useful for tar.gz release download for language interfaces). Some CMake rpath settings will also no longer be forced to their default values, or override a user that configures a different setting; this is aimed at making packaging for different systems more flexible.

### Proposed changes
- Add relative path to lib folder to macOS rpath
- Don't override user set CMake rpath settings or force the default values
