### PR TITLE
Add a Linux installer to the release builds

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -98,7 +98,7 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
     strategy:
       matrix:
-        id: [windows-x64, macos-x64-zip]
+        id: [windows-x64, macos-x64-zip, linux-x64]
         include:
           - id: windows-x64
             os: windows-latest
@@ -111,6 +111,10 @@ jobs:
             arch: x64
             cpack_gen: ZIP
             macos_target_ver: '10.10'
+          - id: linux-x64
+            os: ubuntu-latest
+            arch: x64
+            cpack_gen: TGZ
 
     steps:
     - name: Checkout event ref
@@ -125,6 +129,7 @@ jobs:
       
     # Build with Python 3.6 interface
     - uses: actions/setup-python@v1
+      if: runner.os != 'Linux'
       with:
         python-version: '3.6'
         architecture: ${{ matrix.arch }}
@@ -136,6 +141,7 @@ jobs:
         
     # Compile HELICS and create the installer
     - name: Build installer
+      if: runner.os != 'Linux'
       env:
         BUILD_ARCH: ${{ matrix.arch }}
         BUILD_GEN: ${{ matrix.cmake_gen }}
@@ -144,7 +150,13 @@ jobs:
         CPACK_GEN: ${{ matrix.cpack_gen }}
       shell: bash
       run: ./.github/workflows/release-build/installer-${{ runner.os }}.sh
-        
+ 
+    - name: Build installer (container)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/linux-release-builder
+      with:
+        script: ./.github/workflows/release-build/installer-${{ runner.os }}.sh
+       
     - name: Upload installer to release
       if: github.event.action == 'published'
       env:

--- a/.github/workflows/release-build/installer-Linux.sh
+++ b/.github/workflows/release-build/installer-Linux.sh
@@ -14,5 +14,3 @@ cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages
-ARCHIVE_FILE="$(ls Helics-*)"
-mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"

--- a/.github/workflows/release-build/installer-Linux.sh
+++ b/.github/workflows/release-build/installer-Linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This uses bash variable substitution in a few places
+# 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+
+#wget --quiet -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && chmod +x cmake-install.sh
+#sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
+#rm cmake-install.sh
+
+mkdir build && cd build || exit
+cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
+cmake --build . --config Release
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+"${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
+cd ../artifact || exit
+rm -rf _CPack_Packages
+ARCHIVE_FILE="$(ls Helics-*)"
+mv "$ARCHIVE_FILE" "${ARCHIVE_FILE/Helics-/Helics-shared-}"


### PR DESCRIPTION
### Summary
If merged this pull request will add a Linux installer release archive (manylinux2010 compliant, CentOS 6+). The main difference from the shared library archive is that it includes HELICS app binaries that have been static linked to the system stdlibc++ and libgcc for portability. It does not include pre-built Python/Java interfaces (likely requires compiling Java from source and installing a copy of Python; pip install is easier than picking a single Python version to include).

### Proposed changes
- Add a Linux installer with the HELICS apps and shared library to the release builds
