### PR TITLE
Set gitattributes hunk headers for common source file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,12 @@
 *.jpg -text
 *.png -text
 *.mat -text
+
+*.cpp  diff=cpp
+*.hpp  diff=cpp
+*.c    diff=cpp
+*.h    diff=cpp
+*.py   diff=python
+*.java diff=java
+*.m    diff=matlab
+*.cs   diff=csharp

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 * text=input
 
-*.jpg -text
-*.png -text
-*.mat -text
+*.jpg binary
+*.png binary
+*.mat binary
 
 *.cpp  diff=cpp
 *.hpp  diff=cpp


### PR DESCRIPTION
### Summary
If merged this pull request will set the hunk headers to use for several common source files types in the HELICS repository. These are the lines of text that show up when doing a `git diff` or using the `-p` (`--show-function`) or `-W` (`--function-context`) arguments to `git add`, `git grep`, and `git diff`.

Further details:
https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header
https://github.blog/2019-08-16-highlights-from-git-2-23/
https://github.blog/2020-01-13-highlights-from-git-2-25/

### Proposed changes
- Set git hunk header built-in patterns to use for common source file types
