### PR TITLE
Fix issue where git --local flag would cause fatal error

### DIFF
--- a/config/cmake/addGitHooks.cmake
+++ b/config/cmake/addGitHooks.cmake
@@ -4,6 +4,7 @@ set(CLANG_FORMAT_MIN_VERSION "7.0")
 function(set_git_hooks_enabled)
     execute_process(
             COMMAND ${GIT_EXECUTABLE} config --local core.hooksPath .githooks
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
     message(STATUS "Git hooks enabled")
 endfunction()
@@ -11,6 +12,7 @@ endfunction()
 function(set_git_hooks_disabled)
     execute_process(
             COMMAND ${GIT_EXECUTABLE} config --local --unset core.hooksPath
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
     message(STATUS "Git hooks disabled")
 endfunction()

--- a/config/cmake/addGitHooks.cmake
+++ b/config/cmake/addGitHooks.cmake
@@ -56,7 +56,12 @@ else ()
     set(GIT_REPO_FOUND OFF)
 endif ()
 
-cmake_dependent_advanced_option(HELICS_ENABLE_GIT_HOOKS "Activate git hooks to run clang-format on committed files." ON "GIT_REPO_FOUND;CLANG_FORMAT;CLANG_FORMAT_VERSION_OK" OFF)
+if (WIN32)
+    #there are a lot of potential issues doing this on windows, but the option should be available if desired
+    cmake_dependent_advanced_option(HELICS_ENABLE_GIT_HOOKS "Activate git hooks to run clang-format on committed files." OFF "GIT_REPO_FOUND;CLANG_FORMAT;CLANG_FORMAT_VERSION_OK" OFF)
+else()
+    cmake_dependent_advanced_option(HELICS_ENABLE_GIT_HOOKS "Activate git hooks to run clang-format on committed files." ON "GIT_REPO_FOUND;CLANG_FORMAT;CLANG_FORMAT_VERSION_OK" OFF)
+endif()
 
 find_package(Git)
 


### PR DESCRIPTION
When building in an external directory, the git repository would
be detected, but git would be unable to run in-folder. This fix
simply ensures that git is run from within the project directory
and not the build directory.

A new branch has been created, to avoid the "error" trigger word from the previous version of this issue. 

Resolves #996 
