### PR TITLE
Get Python extension suffix and fix several minor issues

### DIFF
--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -134,7 +134,7 @@ endif()
 # Swig doesn't need Python to generate the wrapper files
 if(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY AND SWIG_EXECUTABLE)
     if(NOT hasParent)
-        message(FATAL_ERROR "SWIG generate interface files only must be run using the root HELICS CMakeLists.txt file")
+        message(FATAL_ERROR "`HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY`  can only be used when building from the root HELICS CMakeLists.txt file")
     endif()
     include(${CMAKE_CURRENT_SOURCE_DIR}/pythonSwigGenerateOnly.cmake)
     return()

--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -15,6 +15,11 @@ get_directory_property(hasParent PARENT_DIRECTORY)
 if(NOT hasParent)
     message(STATUS "Standalone Python interface build")
 
+    # find_package(<PackageName>) searches prefixes given in <PackageName>_ROOT CMake variable
+    if(POLICY CMP0074)
+        cmake_policy(SET CMP0074 NEW)
+    endif()
+
     # Setup options
     option(HELICS_ENABLE_SWIG "Use SWIG to generate the Python interface files" ON)
     option(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY "Only generate the SWIG interface files" OFF)

--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT hasParent)
 
     # Setup options
     option(HELICS_ENABLE_SWIG "Use SWIG to generate the Python interface files" ON)
-    option(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY "Only generate the SWIG interface files" OFF)
+    #option(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY "Only generate the SWIG interface files" OFF)
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.12)
         option(HELICS_USE_NEW_PYTHON_FIND "Use the FindPython module added in CMake 3.12" OFF)
     endif()
@@ -133,6 +133,9 @@ endif()
 ###############################
 # Swig doesn't need Python to generate the wrapper files
 if(HELICS_SWIG_GENERATE_INTERFACE_FILES_ONLY AND SWIG_EXECUTABLE)
+    if(NOT hasParent)
+        message(FATAL_ERROR "SWIG generate interface files only must be run using the root HELICS CMakeLists.txt file")
+    endif()
     include(${CMAKE_CURRENT_SOURCE_DIR}/pythonSwigGenerateOnly.cmake)
     return()
 endif()

--- a/interfaces/python/pythonSwigGenerateOnly.cmake
+++ b/interfaces/python/pythonSwigGenerateOnly.cmake
@@ -24,12 +24,12 @@ endif()
       "${SWIG_EXECUTABLE}" "-python" "-py3" -o "helicsPython.c" "${SWIG_DOXYGEN_FLAG}"
       "-I${CMAKE_SOURCE_DIR}/src/helics/shared_api_library"
       "-I${helics.i_INCLUDE_DIR}"
-      ${CMAKE_CURRENT_SOURCE_DIR}/helicsPython.i
+      ${CMAKE_CURRENT_SOURCE_DIR}/helicsPython3.i
     DEPENDS
       ${HELICS_SWIG_helics.i_FILE}
-      ${CMAKE_CURRENT_SOURCE_DIR}/helicsPython.i
+      ${CMAKE_CURRENT_SOURCE_DIR}/helicsPython3.i
       ${SHARED_LIB_HEADERS}
-      ${CMAKE_CURRENT_SOURCE_DIR}/python_maps.i
+      ${CMAKE_CURRENT_SOURCE_DIR}/python_maps3.i
   )
 
   if(HELICS_OVERWRITE_INTERFACE_FILES)


### PR DESCRIPTION
### Summary
If merged this pull request will get the right shared library platform tag from Python (e.g. `.cpython-37m-x86_64-linux-gnu.so`) in a way that matches the behavior of using the `python-config --extension-suffix` (without needing to find the right python-config or python3-config executable). Also several small fixes for generating new interface files, and setting the CMP0074 policy so that `HELICS_ROOT` can be used to set the path to a HELICS install.

If an error happens getting the extension suffix from Python, it leaves the default shared library extension on *nix and `.pyd` on Windows.

### Proposed changes
- Get the right Python extension suffix for the platform in a portable way
- Set policy CMP0074 so that `HELICS_ROOT` can set the location of a HELICS install
- Update python swig generate only code to use the renamed swig type map files for Python
- Add an error message if trying to regenerate the Python interface files in a standalone build
