### PR TITLE
Filter CI tests run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ jobs:
       env:
         - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=102"
         - HOMEBREW_NO_AUTO_UPDATE=1
+        - CI_TEST_EXCLUDE="application-api-ci-tests|system-ci-tests"
       osx_image: xcode10.2
 
     # XCode 9.4, OS X 10.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,8 +168,7 @@ jobs:
       if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request)) OR (branch =~ /(mingw)/) OR (commit_message =~ /(mingw)/)
       env:
         - DISABLE_INTERFACES="Python,Java"
-        - SKIP_TEST_RUN=true
-        - CORE_CI_TEST=true
+        - CI_TEST_MATCH="core-ci-tests"
         - ZMQ_SUBPROJECT=true
         - ZMQ_FORCE_SUBPROJECT=true
         - DISABLE_EXAMPLES=true
@@ -187,8 +186,7 @@ jobs:
       if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request)) OR (branch =~ /(msys)/) OR (commit_message =~ /(msys)/)
       env:
         - DISABLE_INTERFACES="Python,Java"
-        - SKIP_TEST_RUN=true
-        - CORE_CI_TEST=true
+        - CI_TEST_MATCH="core-ci-tests"
         - DISABLE_EXAMPLES=true
         - CMAKE_GENERATOR="MSYS Makefiles"
         - SET_MSYS_PATH=true
@@ -281,10 +279,6 @@ script:
     if [[ "$SKIP_TEST_RUN" != "true" ]]; then
       echo "travis_wait ../scripts/run-ci-tests.sh ${CI_TEST_FLAGS}"
       travis_wait $SHELL_CMD ../scripts/run-ci-tests.sh ${CI_TEST_FLAGS}
-    else
-      if [[ "$CORE_CI_TEST" == "true" ]]; then
-      travis_wait $SHELL_CMD ../scripts/run-core-ci-tests.sh
-      fi
     fi
 
   # Gather coverage results

--- a/scripts/run-core-ci-tests.sh
+++ b/scripts/run-core-ci-tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-if [[ "$SET_MSYS_PATH" == "true" ]]; then
-    export PATH="/c/tools/msys64/mingw64/bin:$PATH"
-    echo "$PATH"
-fi
-
-ctest -R core-ci-tests --timeout 120 --output-on-failure

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -89,6 +89,12 @@ TEST_FLAGS_ARR=("$TEST_TYPE")
 if [[ "$CI_TEST_CONFIG" ]]; then
     TEST_FLAGS_ARR+=("$CI_TEST_CONFIG")
 fi
+if [[ "$CI_TEST_MATCH" ]]; then
+    TEST_FLAGS_ARR+=("--match-tests" "$CI_TEST_MATCH")
+fi
+if [[ "$CI_TEST_EXCLUDE" ]]; then
+    TEST_FLAGS_ARR+=("--exclude-tests" "$CI_TEST_EXCLUDE")
+fi
 
 # Valgrind options
 if [[ "$RUN_VALGRIND" ]]; then


### PR DESCRIPTION
### Summary
If merged this pull request will add options to the CI test running script to filter the tests run using a matching and/or excluding regex. The mingw and msys tests on Travis are updated to use the new filter to only run the core ci tests, and the macOS XCode 10.2 build is updated to exclude the (very slow) application api and system tests.

### Proposed changes
- Add match and exclude regex options to the CI test running bash script
- Remove the core ci test running bash script
- Use the test matching option to run only the core ci tests on the mingw and msys builds
- Use the test excluding option to disable running the application api and system tests on the macOS XCode 10.2 build