### PR TITLE
Apps docstring fixes

### DIFF
--- a/docs/apps/Broker.md
+++ b/docs/apps/Broker.md
@@ -9,7 +9,7 @@ Command line arguments
 ----------
 ```
 helics_broker term <broker args...> will start a broker and open a terminal control window for the broker run help in a terminal for more commands
-helics_broker autorestart <broker args ...> will start a continually regenerating broker there is a 3 second countdown on broker completion to halt the program via ctrl-C
+helics_broker --autorestart <broker args ...> will start a continually regenerating broker there is a 3 second countdown on broker completion to halt the program via ctrl-C
 helics_broker <broker args ..> just starts a broker with the given args and waits for it to complete
 allowed options:
 

--- a/docs/apps/Recorder.md
+++ b/docs/apps/Recorder.md
@@ -56,7 +56,7 @@ configuration:
   --clone arg            existing endpoints to clone all packets to and from
   --capture arg          capture all the publications of a particular federate
                          capture="fed1;fed2"  supports multiple arguments or a
-                         comma separated list
+                         semicolon/comma separated list
   -o [ --output ] arg    the output file for recording the data
   --allow_iteration      allow iteration on values
   --verbose              print all value results to the screen

--- a/docs/apps/Tracer.md
+++ b/docs/apps/Tracer.md
@@ -30,7 +30,7 @@ configuration:
   --clone arg            existing endpoints to clone all packets to and from
   --capture arg          capture all the publications of a particular federate
                          capture="fed1;fed2"  supports multiple arguments or a
-                         comma separated list
+                         semicolon/comma separated list
   -o [ --output ] arg    the output file for recording the data
   --mapfile arg          write progress to a memory mapped file
 

--- a/src/helics/apps/Recorder.cpp
+++ b/src/helics/apps/Recorder.cpp
@@ -654,7 +654,7 @@ namespace apps {
             ->add_option(
                 "--capture",
                 "capture all the publications of a particular federate capture=\"fed1;fed2\"  "
-                "supports multiple arguments or a comma separated list")
+                "supports multiple arguments or a semicolon/comma separated list")
             ->each([this](const std::string& capt) {
                 auto captFeds = stringOps::splitlineQuotes(capt);
                 for (auto& captFed : captFeds) {

--- a/src/helics/apps/Tracer.cpp
+++ b/src/helics/apps/Tracer.cpp
@@ -502,7 +502,7 @@ namespace apps {
             ->add_option(
                 "--capture",
                 "capture all the publications of a particular federate capture=\"fed1;fed2\"  "
-                "supports multiple arguments or a comma separated list")
+                "supports multiple arguments or a semicolon/comma separated list")
             ->each([this](const std::string& capt) {
                 auto captFeds = stringOps::splitlineQuotes(capt);
                 for (auto& captFed : captFeds) {

--- a/src/helics/apps/helics-broker.cpp
+++ b/src/helics/apps/helics-broker.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
     cmdLine.add_flag(
         "--autorestart",
         autorestart,
-        "helics_broker autorestart <broker args ...> will start a continually regenerating broker "
+        "helics_broker --autorestart <broker args ...> will start a continually regenerating broker "
         "there is a 3 second countdown on broker completion to halt the program via ctrl-C\n");
     cmdLine.add_flag(
         "--http",


### PR DESCRIPTION
Found a note about fixing these doc/help string issues.

### Summary
If merged this pull request will fix the docs and help strings for using the `--autorestart` flag (not subcommand) and clarify that `--capture` can take a semicolon or comma separted list.

Trying to use `autorestart` without `--` gives an error.