### PR TITLE
Add FreeBSD CI build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+freebsd_instance:
+  image_family: freebsd-12-1
+
+task:
+  install_script: |
+    pkg install -y cmake libzmq4 boost-libs ninja
+  build_script: |
+    mkdir build && cd build
+    cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
+    cmake --build .
+  test_script: |
+    cd build
+    ctest --output-on-failure --timeout 480 -C Release -L "SystemCI"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
     pkg install -y cmake libzmq4 ninja git
   build_script: |
     mkdir build && cd build
-    cmake -GNinja -DENABLE_IPC_CORE=OFF -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
+    cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
     cmake --build .
   test_script: |
     cd build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,8 @@ task:
   install_script: |
     pkg install -y cmake libzmq4 boost-libs ninja
   build_script: |
+    git --version
+    git submodule update --init
     mkdir build && cd build
     cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
     cmake --build .

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,8 @@ freebsd_instance:
 
 task:
   install_script: |
-    pkg install -y cmake libzmq4 boost-libs ninja
+    pkg install -y cmake libzmq4 boost-libs ninja git
   build_script: |
-    git --version
-    git submodule update --init
     mkdir build && cd build
     cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
     cmake --build .

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
     pkg install -y cmake libzmq4 ninja git
   build_script: |
     mkdir build && cd build
-    cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
+    cmake -GNinja -DENABLE_IPC_CORE=OFF -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
     cmake --build .
   test_script: |
     cd build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
 
 task:
   install_script: |
-    pkg install -y cmake libzmq4 boost-libs ninja git
+    pkg install -y cmake libzmq4 ninja git
   build_script: |
     mkdir build && cd build
     cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Increased code coverage and additional bug fixes.
 -   Docker image for a helics builder which includes build tools and the helics installation
 -   helics can be installed on [MSYS2](https://helics.readthedocs.io/en/latest/installation/windows.html#msys2) using pacman.
 -   Standalone benchmark federates for use in multinode benchmark runs
+-   A FreeBSD 12.1 CI build using Cirrus CI
 
 ### Deprecated
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,9 +413,13 @@ cmake_dependent_advanced_option(
 cmake_dependent_advanced_option(
     ENABLE_UDP_CORE "Enable UDP core types" ON "NOT HELICS_DISABLE_ASIO" OFF
 )
+if("${CMAKE_SYSTEM_NAME}" MATCHES ".*BSD")
+    set(SYSTEM_IS_BSD ON)
+endif()
+
 cmake_dependent_advanced_option(
     ENABLE_IPC_CORE "Enable Interprocess communication types" ON
-    "NOT HELICS_DISABLE_BOOST" OFF
+    "NOT HELICS_DISABLE_BOOST;NOT SYSTEM_IS_BSD" OFF
 )
 cmake_dependent_advanced_option(
     ENABLE_TEST_CORE "Enable test inprocess core type" OFF "NOT HELICS_BUILD_TESTS" ON

--- a/docs/developer-guide/continuous-integration.md
+++ b/docs/developer-guide/continuous-integration.md
@@ -55,6 +55,9 @@ All PR's and branches trigger a set of builds using Docker images on Circle-CI.
 ## Drone
 -  64 bit and 32 bit builds on ARM processors
 
+## Cirrus CI
+-  FreeBSD 12.1 build
+
 ## Read the docs
 -  Build the docs for the website and test on every commit
 


### PR DESCRIPTION

### Summary
If merged this pull request will add a FreeBSD 12.1 CI build running on Cirrus CI. Resolves #840.

It compiles and runs with the IPC core enabled, however there were 5 system CI tests that consistently failed with the IPC, so it is disabled. In all those cases, the error is:
```
unknown file: Failure
C++ exception with description "core is unable to register and has timed out, federate cannot be registered" thrown in the test body.
forcing disconnect
```

The test summary for a failed build with the IPC core enabled is:
```
[==========] 134 tests from 14 test suites ran. (250625 ms total)
[  PASSED  ] 129 tests.
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] query_tests/query_type_tests.publication_queries/2, where GetParam() = "ipc_2"
[  FAILED  ] query_tests/query_type_tests.broker_queries/2, where GetParam() = "ipc_2"
[  FAILED  ] query_tests/query_type_tests.publication_fed_queries/2, where GetParam() = "ipc_2"
[  FAILED  ] flag_tests/flag_type_tests.optional_pub/2, where GetParam() = "ipc"
[  FAILED  ] flag_tests/flag_type_tests.optional_sub/2, where GetParam() = "ipc"
 5 FAILED TESTS
error in connecting to process lock
error in connecting to process lock
error in connecting to process lock
error in connecting to process lock
error in connecting to process lock
0% tests passed, 1 tests failed out of 1
Label Time Summary:
Continuous    = 254.04 sec*proc (1 test)
SystemCI      = 254.04 sec*proc (1 test)
Valgrind      = 254.04 sec*proc (1 test)
Total Test time (real) = 254.28 sec
The following tests FAILED:
	 12 - system-ci-tests (Failed)
```


### Proposed changes
- Adds a FreeBSD 12.1 CI build on Cirrus CI.
