### PR TITLE
Send helics-version-update event to helics-packaging after new releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,9 +7,9 @@ on:
     types: published
 
 jobs:
-################################
+#####################################
 # Create all submodules archive
-################################
+#####################################
   create-all-submodule-archive:
     name: Create all submodule archive
     runs-on: ubuntu-latest
@@ -33,9 +33,9 @@ jobs:
         name: all-submodules-archive
         path: artifact
         
-################################
+#####################################
 # Build MSVC archives
-################################
+#####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -90,9 +90,9 @@ jobs:
         name: ${{ runner.os }}-installers
         path: artifact
         
-################################
+#####################################
 # Build installers
-################################
+#####################################
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
@@ -172,9 +172,9 @@ jobs:
         name: ${{ runner.os }}-installers
         path: artifact
       
-################################
+#####################################
 # Build shared libraries
-################################
+#####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
@@ -248,9 +248,9 @@ jobs:
         name: ${{ runner.os }}-installers
         path: artifact
         
-################################
+#####################################
 # Generate SHA-256 file
-################################
+#####################################
   generate-sha256:
     name: Calculate SHA256 for release assets
     needs: [create-all-submodule-archive, build-installers, build-sharedlibs, build-windows-msvc]
@@ -291,3 +291,24 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UPLOAD_URL: ${{ github.event.release.upload_url }}
       run: ./.github/workflows/upload-release-asset.sh "artifacts/Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}")-SHA-256.txt"
+
+#####################################
+# Send helics-version-update event(s)
+#####################################
+  send-version-update-event:
+    name: Send helics-version-update event(s)
+    needs: [generate-sha256]
+    runs-on: ubuntu-latest
+    if: github.event.action == 'published'
+    steps:
+      - name: Send helics-packaging a helics-version-update-event
+        run: |
+          HELICS_REPO="${{ github.repository }}"
+          HELICS_VERSION="${{ github.event.release.tag_name }}"
+          curl -X POST --header 'authorization: Bearer ${{ secrets.HELICS_BOT_TOKEN }}' \
+               --url https://api.github.com/repos/GMLC-TDC/helics-packaging/dispatches \
+               --header 'content-type: application/json' \
+               --data '{"event_type":"helics-version-update", \
+                      "client_payload":{"repository":"${HELICS_REPO}", \
+                      "tag_name":"${HELICS_VERSION}", \
+                      "version":"${HELICS_VERSION#v}" }}'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -308,7 +308,4 @@ jobs:
           curl -X POST --header 'authorization: Bearer ${{ secrets.HELICS_BOT_TOKEN }}' \
                --url https://api.github.com/repos/GMLC-TDC/helics-packaging/dispatches \
                --header 'content-type: application/json' \
-               --data '{"event_type":"helics-version-update", \
-                      "client_payload":{"repository":"${HELICS_REPO}", \
-                      "tag_name":"${HELICS_VERSION}", \
-                      "version":"${HELICS_VERSION#v}" }}'
+               --data "{\"event_type\":\"helics-version-update\",\"client_payload\":{\"repository\":\"${HELICS_REPO}\",\"tag_name\":\"${HELICS_VERSION}\",\"version\":\"${HELICS_VERSION#v}\"}}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'published'
     steps:
-      - name: Send helics-packaging a helics-version-update-event
+      - name: Send event to helics-packaging
         run: |
           HELICS_REPO="${{ github.repository }}"
           HELICS_VERSION="${{ github.event.release.tag_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Increased code coverage and additional bug fixes.
 -   helics can be installed on [MSYS2](https://helics.readthedocs.io/en/latest/installation/windows.html#msys2) using pacman.
 -   Standalone benchmark federates for use in multinode benchmark runs
 -   A FreeBSD 12.1 CI build using Cirrus CI
--   An event to trigger creating additional HELICS packages when a new release is made
+-   An event to GitHub Actions release builds to trigger updating additional HELICS packages when a new release is made
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Increased code coverage and additional bug fixes.
 -   helics can be installed on [MSYS2](https://helics.readthedocs.io/en/latest/installation/windows.html#msys2) using pacman.
 -   Standalone benchmark federates for use in multinode benchmark runs
 -   A FreeBSD 12.1 CI build using Cirrus CI
--   An event to GitHub Actions release builds to trigger updating additional HELICS packages when a new release is made
+-   Sending an event from GitHub Actions release builds to trigger updating additional HELICS packages when a new release is made
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Increased code coverage and additional bug fixes.
 -   helics can be installed on [MSYS2](https://helics.readthedocs.io/en/latest/installation/windows.html#msys2) using pacman.
 -   Standalone benchmark federates for use in multinode benchmark runs
 -   A FreeBSD 12.1 CI build using Cirrus CI
+-   An event to trigger creating additional HELICS packages when a new release is made
 
 ### Deprecated
 


### PR DESCRIPTION
### Summary
If merged this pull request will send an event after all HELICS release binaries are built to helics-packaging telling it that a new version has been released.

The action that handles the event in `helics-packaging` updates the version file, but doesn't open a PR yet -- it shows a [git diff](https://github.com/GMLC-TDC/helics-packaging/runs/483558701?check_suite_focus=true#step:4:10) of the change that would be in a PR.

### Proposed changes
- Send a `helics-version-update` event to `helics-packaging` after the the release build is finished
