### PR TITLE
Add win32 release zip archive

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -98,7 +98,7 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
     strategy:
       matrix:
-        id: [windows-x64, macos-x64-zip, linux-x64]
+        id: [windows-x64, windows-x86, macos-x64, linux-x64]
         include:
           - id: windows-x64
             os: windows-latest
@@ -106,7 +106,13 @@ jobs:
             cpack_gen: NSIS;ZIP
             cmake_gen: 'Visual Studio 16 2019'
             msvc_ver: 'msvc2019'
-          - id: macos-x64-zip
+          - id: windows-x86
+            os: windows-latest
+            arch: x86
+            cpack_gen: ZIP
+            cmake_gen: 'Visual Studio 16 2019'
+            msvc_ver: 'msvc2019'
+          - id: macos-x64
             os: macos-latest
             arch: x64
             cpack_gen: ZIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Increased code coverage and additional bug fixes.
 -   Standalone benchmark federates for use in multinode benchmark runs
 -   A FreeBSD 12.1 CI build using Cirrus CI
 -   Sending an event from GitHub Actions release builds to trigger updating additional HELICS packages when a new release is made
+-   A 32-bit Windows zip install archive for releases
 
 ### Deprecated
 


### PR DESCRIPTION
### Summary
If merged this pull request will add a win32 zip archive to the set of release assets. Primarily for making actual Windows 32-bit helics_app packages instead of labeling them as win32 with a 64-bit executable.

Test release with the added win32 asset: https://github.com/nightlark/HELICS/releases/tag/v2.4.0.2

### Proposed changes
- Add a win32 zip archive to the release builds