### PR TITLE
Update GitHub actions to use actions/checkout@v2

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -33,10 +33,10 @@ jobs:
 #        script: |
 #          github.issues.createComment({...context.issue, body: 'Okay, commit https://github.com/${{ github.repository }}/commit/${{ github.sha }} is being formatted. A PR with the changes will be open soon! :sunglasses:'})
     - name: Checkout event Ref
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       if: github.event_name != 'pull_request'
     - name: Checkout PR Head Ref
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       if: github.event_name == 'pull_request'
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'published'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       
     - name: Create archive
       # Creates the archive then moves it to an artifact subfolder
@@ -51,11 +51,11 @@ jobs:
             msvc_ver: 'msvc2019'
     steps:
     - name: Checkout event ref
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       if: github.event.action == 'published'
     
     - name: Checkout develop branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         ref: develop
       if: github.event_name == 'schedule'
@@ -118,11 +118,11 @@ jobs:
 
     steps:
     - name: Checkout event ref
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       if: github.event.action == 'published'
     
     - name: Checkout develop branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         ref: develop
       if: github.event_name == 'schedule'
@@ -202,11 +202,11 @@ jobs:
 
     steps:
     - name: Checkout event ref
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       if: github.event.action == 'published'
     
     - name: Checkout develop branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         ref: develop
       if: github.event_name == 'schedule'
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'published'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       
     - name: Get all submodules archive
       uses: actions/download-artifact@v1

--- a/.github/workflows/swig-interface-gen.yml
+++ b/.github/workflows/swig-interface-gen.yml
@@ -14,7 +14,7 @@ jobs:
       image: helics/buildenv:interface-gen
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Run SWIG
       run: |
         rm -rf interfaces/*/interface/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Increased code coverage and additional bug fixes.
 -   Configuration of flags and targets for interfaces in json and toml files can be done in multiple sections
 -   The benchmark federates have been changed to use a common base benchmark federate class for more consistent behavior
 -   Switched to including netif as a git submodule
+-   Updated the GitHub actions (clang-format, swig interface updates, and release builds) to use actions/checkout@v2
 
 ### Fixed
 -   Issue with iterative requests that were not being honored if the federate was acting in isolation


### PR DESCRIPTION
### Summary
If merged this pull request will update the GH actions checkout action to v2 (only checks out a single commit instead of all history). Checkouts for release builds now consistently take <=5s, whereas with the v1 checkout action it was taking 8 to 13+.

A test release build using the new checkout action can be found here: https://github.com/nightlark/HELICS/releases/tag/v2.4.0.3

### Proposed changes
- Update the GH checkout action used to v2
