### PR TITLE
Windows installer clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Increased code coverage and additional bug fixes.
 -   Configuration of flags and targets for interfaces in json and toml files can be done in multiple sections
 -   The benchmark federates have been changed to use a common base benchmark federate class for more consistent behavior
 -   Switched to including netif as a git submodule
+-   Cleaned up the Windows installer (better component names/descriptions and groups, link to Gitter, and require installing Headers to install SWIG)
 
 ### Fixed
 -   Issue with iterative requests that were not being honored if the federate was acting in isolation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1046,12 +1046,18 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
         "Headers for linking and compiling with HELICS"
     )
     set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for HELICS")
+    set(CPACK_COMPONENT_APPLICATION_DESCRIPTION "HELICS applications (helics_broker, helics_apps, etc)")
     set(CPACK_COMPONENT_CEREAL_DESCRIPTION
         "cereal C++11 serialization library [no support for other language interfaces]"
     )
     set(CPACK_COMPONENT_SWIG_DESCRIPTION
-        "Basic swig interface files for HELICS for building 3rd party language interfaces"
+        "Basic SWIG interface files for building 3rd party language interfaces (requires Development Headers)"
     )
+    set(CPACK_COMPONENT_PYTHON_DESCRIPTION "Python language interface")
+    set(CPACK_COMPONENT_JAVA_DESCRIPTION "Java language interface")
+    set(CPACK_COMPONENT_MATLAB_DESCRIPTION "MATLAB language interface")
+    set(CPACK_COMPONENT_OCTAVE_DESCRIPTION "Octave language interface")
+    set(CPACK_COMPONENT_CSHARP_DESCRIPTION "C# language interface")
 
     set(CPACK_COMPONENT_SWIG_DEPENDS headers)
     set(CPACK_COMPONENT_LIBS_DEPENDS headers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1011,7 +1011,7 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
         set(CPACK_RESOURCE_FILE_README "${HELICS_SOURCE_DIR}/README.md")
     endif(WIN32)
 
-    set(CPACK_COMPONENT_APPLICATIONS_DISPLAY_NAME "Application")
+    set(CPACK_COMPONENT_APPLICATIONS_DISPLAY_NAME "Applications")
     set(CPACK_COMPONENT_LIBS_DISPLAY_NAME "Libraries")
     set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Headers")
     set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Runtime Libraries")
@@ -1023,7 +1023,9 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_CSHARP_DISPLAY_NAME "C#")
 
     set(CPACK_COMPONENT_GROUP_INTERFACES_DISPLAY_NAME "Interfaces")
-    set(CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION "Additional language interfaces for HELICS")
+    set(CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION
+        "Additional language interfaces for HELICS"
+    )
     set(CPACK_COMPONENT_SWIG_GROUP interfaces)
     set(CPACK_COMPONENT_MATLAB_GROUP interfaces)
     set(CPACK_COMPONENT_JAVA_GROUP interfaces)
@@ -1032,11 +1034,13 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_CSHARP_GROUP interfaces)
 
     set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DISPLAY_NAME "Development")
-    set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DESCRIPTION "Files needed to build applications that use HELICS")
+    set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DESCRIPTION
+        "Files needed to build applications that use HELICS"
+    )
     set(CPACK_COMPONENT_HEADERS_GROUP development)
     set(CPACK_COMPONENT_LIBS_GROUP development)
 
-    set(CPACK_COMPONENT_APPLICATION_DESCRIPTION
+    set(CPACK_COMPONENT_APPLICATIONS_DESCRIPTION
         "Executables and helper applications for HELICS"
     )
     set(CPACK_COMPONENT_LIBS_DESCRIPTION
@@ -1046,12 +1050,11 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
         "Headers for linking and compiling with HELICS"
     )
     set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for HELICS")
-    set(CPACK_COMPONENT_APPLICATION_DESCRIPTION "HELICS applications (helics_broker, helics_apps, etc)")
     set(CPACK_COMPONENT_CEREAL_DESCRIPTION
         "cereal C++11 serialization library [no support for other language interfaces]"
     )
     set(CPACK_COMPONENT_SWIG_DESCRIPTION
-        "Basic SWIG interface files for building 3rd party language interfaces (requires Development Headers)"
+        "SWIG files needed for building 3rd party language interfaces (requires Development Headers)"
     )
     set(CPACK_COMPONENT_PYTHON_DESCRIPTION "Python language interface")
     set(CPACK_COMPONENT_JAVA_DESCRIPTION "Java language interface")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -991,16 +991,16 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     # cmake-format: on
 
     set(CPACK_COMPONENTS_ALL
+        Runtime
         applications
         headers
         libs
-        Runtime
+        swig
         matlab
         python
         java
         octave
         csharp
-        swig
         cereal
     )
     if(WIN32)
@@ -1015,12 +1015,30 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_LIBS_DISPLAY_NAME "Libraries")
     set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Headers")
     set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Runtime Libraries")
+    set(CPACK_COMPONENT_SWIG_DISPLAY_NAME "SWIG")
+    set(CPACK_COMPONENT_JAVA_DISPLAY_NAME "Java")
+    set(CPACK_COMPONENT_PYTHON_DISPLAY_NAME "Python")
+    set(CPACK_COMPONENT_MATLAB_DISPLAY_NAME "MATLAB")
+    set(CPACK_COMPONENT_OCTAVE_DISPLAY_NAME "Octave")
+    set(CPACK_COMPONENT_CSHARP_DISPLAY_NAME "C#")
 
+    cpack_add_component_group(interfaces
+        DISPLAY_NAME "Interfaces"
+        DESCRIPTION  "Additional language interfaces for HELICS"
+    )
+    set(CPACK_COMPONENT_SWIG_GROUP interfaces)
     set(CPACK_COMPONENT_MATLAB_GROUP interfaces)
     set(CPACK_COMPONENT_JAVA_GROUP interfaces)
     set(CPACK_COMPONENT_OCTAVE_GROUP interfaces)
     set(CPACK_COMPONENT_PYTHON_GROUP interfaces)
     set(CPACK_COMPONENT_CSHARP_GROUP interfaces)
+
+    cpack_add_component_group(development
+        DISPLAY_NAME "Development"
+        DESCRIPTION  "Files needed to build applications that use HELICS"
+    )
+    set(CPACK_COMPONENT_HEADERS_GROUP development)
+    set(CPACK_COMPONENT_LIBS_GROUP development)
 
     set(CPACK_COMPONENT_APPLICATION_DESCRIPTION
         "Executables and helper applications for HELICS"
@@ -1038,10 +1056,8 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_SWIG_DESCRIPTION
         "Basic swig interface files for HELICS for building 3rd party language interfaces"
     )
-    set(CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION
-        "additional language interfaces for HELICS"
-    )
 
+    set(CPACK_COMPONENT_SWIG_DEPENDS headers)
     set(CPACK_COMPONENT_LIBS_DEPENDS headers)
     set(CPACK_COMPONENT_RUNTIME_REQUIRED ON)
 
@@ -1061,6 +1077,10 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     endif()
 
     if(WIN32)
+        # title at the top of the installer
+        set(CPACK_NSIS_PACKAGE_NAME "HELICS v${HELICS_VERSION}")
+        # name shown in the add/remove program control panel
+        set(CPACK_NSIS_DISPLAY_NAME "HELICS v${HELICS_VERSION}")
         set(CPACK_PACKAGE_ICON "${HELICS_SOURCE_DIR}\\\\docs\\\\img\\\\HELICS.ico")
         set(CPACK_NSIS_MUI_ICON "${HELICS_SOURCE_DIR}/docs/img/HELICS.ico")
         set(CPACK_NSIS_INSTALL_ROOT "C:\\\\local")
@@ -1073,11 +1093,13 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
         set(CPACK_NSIS_EXECUTABLES_DIRECTORY ${CMAKE_INSTALL_BINDIR})
         set(CPACK_NSIS_MENU_LINKS
             "https://www.github.com/GMLC-TDC/HELICS"
-            "HELICS Github"
+            "HELICS GitHub"
             "https://helics.readthedocs.io/en/latest"
-            "Helics Documentation"
+            "HELICS Documentation"
             "https://www.helics.org"
-            "Helics Web page"
+            "HELICS Website"
+            "https://gitter.im/GMLC-TDC/HELICS"
+            "HELICS Gitter Chat"
             "https://www.youtube.com/channel/UCPa81c4BVXEYXt2EShTzbcg"
             "TDC YouTube channel"
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,10 +1022,8 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_OCTAVE_DISPLAY_NAME "Octave")
     set(CPACK_COMPONENT_CSHARP_DISPLAY_NAME "C#")
 
-    cpack_add_component_group(interfaces
-        DISPLAY_NAME "Interfaces"
-        DESCRIPTION  "Additional language interfaces for HELICS"
-    )
+    set(CPACK_COMPONENT_GROUP_INTERFACES_DISPLAY_NAME "Interfaces")
+    set(CPACK_COMPONENT_GROUP_INTERFACES_DESCRIPTION "Additional language interfaces for HELICS")
     set(CPACK_COMPONENT_SWIG_GROUP interfaces)
     set(CPACK_COMPONENT_MATLAB_GROUP interfaces)
     set(CPACK_COMPONENT_JAVA_GROUP interfaces)
@@ -1033,10 +1031,8 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_PYTHON_GROUP interfaces)
     set(CPACK_COMPONENT_CSHARP_GROUP interfaces)
 
-    cpack_add_component_group(development
-        DISPLAY_NAME "Development"
-        DESCRIPTION  "Files needed to build applications that use HELICS"
-    )
+    set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DISPLAY_NAME "Development")
+    set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DESCRIPTION "Files needed to build applications that use HELICS")
     set(CPACK_COMPONENT_HEADERS_GROUP development)
     set(CPACK_COMPONENT_LIBS_GROUP development)
 


### PR DESCRIPTION
### Summary
If merged this pull request will change CPack settings to make the Windows installer nicer to use and look a bit more polished.

Recent test installer build here: https://github.com/nightlark/HELICS/releases/download/v2.4.0.7/Helics-2.4.1-win64.exe

### Proposed changes
- Clean-up component names and descriptions
- Set Windows NSIS display names (e.g. show `HELICS v2.4.0` instead of `helics_2_4_0` as the program name)
- Add Gitter link to the installer
- Group `Headers` and `Libraries` components under a `Development` group
- Set `SWIG` component to depend on the `Headers` component
