### PR TITLE
Add 'helics-release-build' dispatch event trigger

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,6 +1,11 @@
 name: Build release artifacts
 
 on:
+  # Handles a 'helics-release-build' dispatch event type
+  # The event payload should contain these fields:
+  # packages - a list of which packages to build
+  # commit (optional) - the commit-ish to do a release build with
+  repository_dispatch:
   schedule:
     - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
   release:
@@ -13,9 +18,13 @@ jobs:
   create-all-submodule-archive:
     name: Create all submodule archive
     runs-on: ubuntu-latest
-    if: github.event.action == 'published'
+    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'all')))
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout event ref
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.commit }}
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
       
     - name: Create archive
       # Creates the archive then moves it to an artifact subfolder
@@ -38,6 +47,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
+    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, ${{ matrix.msvc_ver }}) || contains(github.event.client_payload.packages, 'all')))
     strategy:
       matrix:
         os: [windows-2016, windows-latest]
@@ -52,7 +62,9 @@ jobs:
     steps:
     - name: Checkout event ref
       uses: actions/checkout@v2
-      if: github.event.action == 'published'
+      with:
+        ref: ${{ github.event.client_payload.commit }}
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -96,6 +108,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
+    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('installer-{0}', ${{ matrix.id }})) || contains(github.event.client_payload.packages, 'all')))
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -125,7 +138,9 @@ jobs:
     steps:
     - name: Checkout event ref
       uses: actions/checkout@v2
-      if: github.event.action == 'published'
+      with:
+        ref: ${{ github.event.client_payload.commit }}
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -183,6 +198,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
+    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('sharedlib-{0}', ${{ matrix.id }})) || contains(github.event.client_payload.packages, 'all')))
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:
@@ -209,7 +225,9 @@ jobs:
     steps:
     - name: Checkout event ref
       uses: actions/checkout@v2
-      if: github.event.action == 'published'
+      with:
+        ref: ${{ github.event.client_payload.commit }}
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -47,7 +47,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, matrix.msvc_ver) || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'all'))
     strategy:
       matrix:
         os: [windows-2016, windows-latest]
@@ -108,7 +108,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
-    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('installer-{0}', matrix.id)) || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'all'))
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -198,7 +198,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('sharedlib-{0}', matrix.id)) || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'all'))
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,10 +27,16 @@ jobs:
       if: github.event.action == 'published' || github.event.action == 'helics-release-build'
       
     - name: Create archive
+      if: github.event.action != 'helics-release-build'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")" && mkdir artifact && mv "Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}")-source.tar.gz" artifact/
-      
+    - name: Create archive (no version)
+      if: github.event.action == 'helics-release-build'
+      # Creates the archive then moves it to an artifact subfolder
+      run: ./scripts/_git-all-archive.sh && mkdir artifact && mv "Helics-source.tar.gz" artifact/
+     
     - name: Upload archive to release
+      if: github.event.action != 'helics-release-build'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UPLOAD_URL: ${{ github.event.release.upload_url }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -47,7 +47,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, ${{ matrix.msvc_ver }}) || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, matrix.msvc_ver) || contains(github.event.client_payload.packages, 'all')))
     strategy:
       matrix:
         os: [windows-2016, windows-latest]
@@ -108,7 +108,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
-    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('installer-{0}', ${{ matrix.id }})) || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('installer-{0}', matrix.id)) || contains(github.event.client_payload.packages, 'all')))
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -198,7 +198,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('sharedlib-{0}', ${{ matrix.id }})) || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action != 'helics-release-build') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, format('sharedlib-{0}', matrix.id)) || contains(github.event.client_payload.packages, 'all')))
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,7 +3,7 @@ name: Build release artifacts
 on:
   # Handles a 'helics-release-build' dispatch event type
   # The event payload should contain these fields:
-  # packages - a list of which packages to build
+  # packages - a list of which packages to build (everything, archive, msvc, installer, sharedlib)
   # commit (optional) - the commit-ish to do a release build with
   repository_dispatch:
   schedule:
@@ -18,7 +18,7 @@ jobs:
   create-all-submodule-archive:
     name: Create all submodule archive
     runs-on: ubuntu-latest
-    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'all')))
+    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'everything')))
     steps:
     - name: Checkout event ref
       uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'all'))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'everything'))
     strategy:
       matrix:
         os: [windows-2016, windows-latest]
@@ -114,7 +114,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'all'))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'everything'))
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -204,7 +204,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'all'))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'everything'))
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Increased code coverage and additional bug fixes.  The error propagation in HELI
 -  `localError`, and `GlobalError` function calls the Federate API and in the C++ and sharedLibrary.  
 -  `helics_terminate_on_error` flag to escalate what would be a local error into a global one that will halt the co-simulation.  This flag can be specified through the flag to federates or to brokers and cores through a command line option `--terminate_on_error` 
 -   A 32-bit Windows zip install archive for releases
+-   Support for a 'helics-release-build' event trigger to the release build GitHub Actions workflow
 
 ### Deprecated
 


### PR DESCRIPTION
### Summary
If merged this pull request will add an alternate way to trigger building release artifacts, either all of the assets or a subset based on asset "type", and with an option to set which branch/tag they should be built for.

It can't limit by os/arch yet because the matrix information isn't available for use in conditionals at the job level.

### Proposed changes
- Trigger release builds for 'helics-release-build' events -- recognizes `everything`, `archive`, `msvc`, `installer*`, and `sharedlib*` package names.
