### PR TITLE
Fix macOS Python interface build

### DIFF
--- a/interfaces/python/CMakeLists.txt
+++ b/interfaces/python/CMakeLists.txt
@@ -216,7 +216,7 @@ if(HELICS_ENABLE_SWIG AND SWIG_EXECUTABLE)
         # m6Ot%20jBCQAJ
         # https://github.com/GMLC-TDC/HELICS/commit/633b218f9351aa452d4#commitcomment-27055932
         set_target_properties(
-            _helics
+            ${SWIG_MODULE_helics_REAL_NAME}
             PROPERTIES LINK_FLAGS "-undefined dynamic_lookup"
         )
     else()


### PR DESCRIPTION
### Summary
If merged this pull request will fix a missed `_helics` target rename in the Python interface CMake file that breaks building the Python interface on macOS with swig. A Python 2 interface is unbuildable on macOS with the 2.4.1 release.

### Proposed changes
- Switch the missed instance of `_helics` to `${SWIG_MODULE_helics_REAL_NAME}`
