### PR TITLE
Fix link in user guide

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -27,7 +27,7 @@ There are a number of classes of HELICS users:
 *   [**Getting Information from a running simulation**](./running_interaction.md) - Getting live information from a running co-simulation.  
 *   [**Integrating a New Simulator**](./simulator_integration.md) - General overview of the process by which a simulator is integrated with HELICS including usage of the common APIs
 *   **Trouble-Shooting HELICS Co-Simulations (forthcoming)** - What to do when the co-simulations don't seem to be working correctly.
-*   [**Simultaneous co-simulations**](./simultaneous_cosimulation.md) - Options for running multiple independent co-simulations on a single system
+*   [**Simultaneous co-simulations**](./simultaneous_cosimulations.md) - Options for running multiple independent co-simulations on a single system
 *   **Large Co-Simulations in HELICS (forthcoming)** - How to run HELICS co-simulations with a large (100+) number of federates
 
 ## Additional Resources ##


### PR DESCRIPTION
User guide link is missing a `s`.