### PR TITLE
Fix the timing benchmark federate names

### DIFF
--- a/benchmarks/helics/TimingHubFederate.hpp
+++ b/benchmarks/helics/TimingHubFederate.hpp
@@ -23,7 +23,7 @@ class TimingHub: public BenchmarkFederate {
   public:
     TimingHub(): BenchmarkFederate("TimingHub") {}
 
-    std::string getName() override { return "echohub"; }
+    std::string getName() override { return "timinghub"; }
 
     void setupArgumentParsing() override
     {

--- a/benchmarks/helics/TimingLeafFederate.hpp
+++ b/benchmarks/helics/TimingLeafFederate.hpp
@@ -22,7 +22,7 @@ class TimingLeaf: public BenchmarkFederate {
   public:
     TimingLeaf(): BenchmarkFederate("TimingLeaf") {}
 
-    std::string getName() override { return "echoleaf_" + std::to_string(index); }
+    std::string getName() override { return "timingleaf_" + std::to_string(index); }
 
     void setupArgumentParsing() override { opt_index->required(); }
 


### PR DESCRIPTION

### Summary
If merged this pull request will fix the timing hub and leaf federate names

### Proposed changes
- Change `echohub` to `timinghub`
- Change `echoleaf_` to `timingleaf_`
