### PR TITLE
change CSharp interface module name to be helics instead of csharp

### DIFF
--- a/interfaces/csharp/CMakeLists.txt
+++ b/interfaces/csharp/CMakeLists.txt
@@ -10,7 +10,7 @@
 if(SWIG_EXECUTABLE)
     # Enable generation using swig
 
-    set_property(SOURCE helicsCsharp.i PROPERTY SWIG_MODULE_NAME csharp)
+    set_property(SOURCE helicsCsharp.i PROPERTY SWIG_MODULE_NAME helics)
     # set_source_files_properties(helicsCsharp.i PROPERTIES SWIG_FLAGS
     # "-outfile;helics.cs")
     set(CMAKE_SWIG_FLAGS "-outfile;helics.cs;-namespace;gmlc")


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will change the namespace in the csharp interface to helics to better match other modules.  

FIx #1147 

and https://github.com/GMLC-TDC/HELICS-Examples/issues/31
