### PR TITLE
Add spack install to list of package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ Each [release](https://github.com/GMLC-TDC/HELICS/releases/latest) comes with a 
 
 ### Conda
 
-Some support to Conda is provided see [conda install](https://helics.readthedocs.io/en/latest/installation/package_manager.html#install-using-conda-windows-macos-linux) for the Instructions.  It is  supported through a separate [repo](https://github.com/GMLC-TDC/helics-conda).
+Some support to Conda is provided see [conda install](https://helics.readthedocs.io/en/latest/installation/package_manager.html#install-using-conda-windows-macos-linux) for the instructions.  It is  supported through a separate [repo](https://github.com/GMLC-TDC/helics-conda).
+
+### pip
+
+Support for installing the Python interface and HELICS apps is provided with pip, see [pip install](https://helics.readthedocs.io/en/latest/installation/package_manager.html#install-using-pip-windows-macos-linux-other) for the instructions. The files used to build the pip package are in a separate [repo](https://github.com/GMLC-TDC/helics-packaging).
+
+### Spack
+
+HELICS can be installed on Linux (and macOS) using Spack, a package manager aimed at HPC environments. See [spack install](https://helics.readthedocs.io/en/latest/installation/package_manager.html#install-using-spack-macos-linux) for the instructions.
 
 ## Build from Source Instructions
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -37,6 +37,8 @@ Use Spack (requires Spack develop branch or versions released after v0.14.1) on 
 spack install helics
 ```
 
+For more information on supported options (e.g. using a custom HELICS build with MPI support), see the [package managers](https://helics.readthedocs.io/en/latest/installation/package_manager.html) page for more details, or the documentation for your package manager.
+
 ### Using an installer for your operating system
 
 Download pre-compiled libraries from the [releases page](https://github.com/GMLC-TDC/HELICS/releases/latest) and add them to your path.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -29,6 +29,14 @@ pip install helics
 pip install helics-apps
 ```
 
+OR
+
+Use Spack (requires Spack develop branch or versions released after v0.14.1) on HPC systems (Linux/macOS) to install C/C++ HELICS components and apps:
+
+```bash
+spack install helics
+```
+
 ### Using an installer for your operating system
 
 Download pre-compiled libraries from the [releases page](https://github.com/GMLC-TDC/HELICS/releases/latest) and add them to your path.

--- a/docs/installation/package_manager.md
+++ b/docs/installation/package_manager.md
@@ -27,3 +27,26 @@ If you are on an unsupported OS or Python version, you will need to install a co
 Depending on your OS, there could be a copy in the package manager, or you may need to build HELICS from source.
 From there, you can use `pip install helics` as above (NOTE: `pip install helics-apps` *will not work*, your package manager or HELICS build from source should install these).
 The [source distributions section of the PyPI page](https://pypi.org/project/helics/) has some additional useful information on this process.
+
+## Install using Spack (macOS, Linux)
+
+Install Spack (a HELICS package is included in the Spack develop branch and Spack releases after v0.14.1).
+
+Run the following command to install HELICS (this may take a while, Spack builds all dependencies from source!):
+
+```bash
+spack install helics
+```
+
+To get a list of installation options, run:
+
+```bash
+spack info helics
+```
+
+To enable or disable options, use `+`, `-`, and `~`. For example, to build with MPI support on the command run would be:
+
+```bash
+spack install helics +mpi
+```
+


### PR DESCRIPTION

### Summary
If merged this pull request will add spack to the list of package managers for installing HELICS.

### Proposed changes
- Add spack to the various docs listing package managers that can be used to install HELICS
- Add pip to the install options in the README
