### PR TITLE
Update default Travis CI Boost version to 1.72.0

### DIFF
--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -31,7 +31,7 @@ fi
 
 boost_version=$CI_BOOST_VERSION
 if [[ -z "$CI_BOOST_VERSION" ]]; then
-    boost_version=1.65.0
+    boost_version=1.72.0
 fi
 boost_install_path=${CI_DEPENDENCY_DIR}/boost
 


### PR DESCRIPTION

### Summary
If merged this pull request will update the default Boost version used on Travis CI builds to 1.72.0 (all builds except the clang 3.6 and gcc 4.9 builds).

### Proposed changes
- Update default Boost version for Travis CI builds from 1.65.0 to 1.72.0
