### PR TITLE
Use sourceline key for Travis CI apt sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ jobs:
         apt:
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+            - llvm-toolchain-trusty-5.0
           packages:
             - libstdc++-6-dev
             - clang-5.0
@@ -151,7 +151,7 @@ jobs:
         apt:
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.6 main"
+            - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
             - libzmq3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,8 @@ jobs:
         apt:
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
-            - llvm-toolchain-trusty-5.0
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - libstdc++-6-dev
             - clang-5.0
@@ -151,7 +152,8 @@ jobs:
         apt:
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
-            - llvm-toolchain-precise-3.6
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.6 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - clang-3.6
             - libzmq3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,26 +144,26 @@ jobs:
         - TEST_TYPE=Packaging
       after_script: ${TRAVIS_BUILD_DIR}/scripts/upload-ci-artifact.sh
 
-    - <<: *linux_base
-      name: "Clang 3.6"
-      if: (branch = develop AND type IN (pull_request, cron)) OR (branch = master AND type IN (push, pull_request))
-      compiler: clang
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.6 main"
-              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-          packages:
-            - clang-3.6
-            - libzmq3-dev
-      env:
-        - MATRIX_EVAL="COMPILER=clang && CC='clang-3.6' && CXX='clang++-3.6'"
-        - CCACHE_CPP2=yes
-        - USE_SWIG=true
-        - CI_BOOST_VERSION=1.58.0
-        - SKIP_TEST_RUN=true
-        - JOB_OPTION_FLAGS="-DHELICS_DISABLE_BOOST=ON"
+#    - <<: *linux_base
+#      name: "Clang 3.6"
+#      if: (branch = develop AND type IN (pull_request, cron)) OR (branch = master AND type IN (push, pull_request))
+#      compiler: clang
+#      addons:
+#        apt:
+#          sources:
+#            - sourceline: "ppa:ubuntu-toolchain-r/test"
+#            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.6 main"
+#              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
+#          packages:
+#            - clang-3.6
+#            - libzmq3-dev
+#      env:
+#        - MATRIX_EVAL="COMPILER=clang && CC='clang-3.6' && CXX='clang++-3.6'"
+#        - CCACHE_CPP2=yes
+#        - USE_SWIG=true
+#        - CI_BOOST_VERSION=1.58.0
+#        - SKIP_TEST_RUN=true
+#        - JOB_OPTION_FLAGS="-DHELICS_DISABLE_BOOST=ON"
 
     - os: windows
       name: "MinGW"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ _basic_env:
   addons:
     apt:
       sources:
-        - ubuntu-toolchain-r-test
+        - sourceline: "ppa:ubuntu-toolchain-r/test"
       packages:
         - g++-6
         - valgrind
@@ -92,7 +92,7 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-6
             - libzmq3-dev
@@ -110,8 +110,8 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
           packages:
             - libstdc++-6-dev
             - clang-5.0
@@ -130,7 +130,7 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-4.9
             - libzmq3-dev
@@ -150,8 +150,8 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.6 main"
           packages:
             - clang-3.6
             - libzmq3-dev


### PR DESCRIPTION
### Summary
If merged this pull request will specify Travis APT sources using the sourceline key in the Travis config file. Hopefully it resolves the disallowed sources error that Travis is giving.

### Proposed changes
- Use sourceline key in Travis yaml file for setting apt sources
