### PR TITLE
Set BOOST_ROOT to Boost 1.72.0 on Windows Azure CI

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -51,11 +51,11 @@ jobs:
 #    displayName: 'Configure Python interface'
 #    condition: and(ne( variables['imageName'], 'vs2015-win2012r2' ), eq( variables['langArch'], 'x64' ))
     
-  - task: CMake@1
-    inputs:
-      cmakeArgs: -DBUILD_JAVA_INTERFACE=ON .
-    displayName: 'Configure Java interface'
-    condition: eq( variables['langArch'], 'x64' )
+#  - task: CMake@1
+#    inputs:
+#      cmakeArgs: -DBUILD_JAVA_INTERFACE=ON .
+#    displayName: 'Configure Java interface'
+#    condition: eq( variables['langArch'], 'x64' )
 
   # -----------------------
   # Build HELICS

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -37,6 +37,8 @@ jobs:
   # -----------------------
   # Configure HELICS
   # -----------------------
+  - bash: |
+      echo "##vso[task.setvariable variable=BOOST_ROOT]$BOOST_ROOT_1_72_0"
   - task: CMake@1
     inputs:
       cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..


### PR DESCRIPTION
### Summary
If merged this pull request will fix the failed Boost find on Windows Azure Pipelines builds. It seems Azure Pipelines and GitHub Actions are using the same VM images, and Boost was removed from the PATH environment variable (or BOOST_ROOT is just no longer set).

### Proposed changes
- Set BOOST_ROOT to the Boost 1.72.0 install on Azure pipelines Windows images
- Disables Java interface builds on Windows
