### PR TITLE
Add cpplint job on GitHub Actions

### DIFF
--- a/.github/workflows/static-analyzers.yml
+++ b/.github/workflows/static-analyzers.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run cpplint
-      run: cpplint --filter=-whitespace,-readability/multiline_comment,-build/c++11 --counting=detailed --recursive examples benchmarks src tests
+      run: cpplint --counting=detailed --recursive examples benchmarks src tests

--- a/.github/workflows/static-analyzers.yml
+++ b/.github/workflows/static-analyzers.yml
@@ -1,0 +1,15 @@
+name: Static Analyzers
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    container: sharaku/cpplint:latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run cpplint
+      run: cpplint --filter=-whitespace,-readability/multiline_comment,-build/c++11 --counting=detailed --recursive examples benchmarks src tests

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,27 @@
+set noparent
+
+# Checks to eventually enable
+filter=-build/header_guard  # 32 found
+filter=-build/include  # 41 found
+filter=-build/include_subdir  # 39 found
+filter=-build/include_what_you_use  # 345 found
+filter=-build/namespaces  # 72 found
+filter=-build/namespaces_literals  # 12 found
+filter=-legal/copyright  # 2 found
+filter=-readability/braces  # 76 found
+filter=-readability/casting  # 16 found
+filter=-readability/check  # 35 found
+filter=-readability/inheritance  # 367 found
+filter=-runtime/explicit  # 11 found
+filter=-runtime/indentation_namespace  # 89 found; might conflict with clang-format
+filter=-runtime/int  # 10 found
+filter=-runtime/string  # 36 found
+filter=-readability/multiline_comment,-readability/multiline_string  # Errors due to cpplint not handling multiline comments/strings well
+
+# Unused checks
+filter=-build/c++11  # Reports C++11 headers that aren't allowed for specific Google projects.
+filter=-build/include_order  # Forces include ordering that may not always be desirable
+filter=-runtime/references  # Disallows non-const references (forces use of pointer)
+filter=-readability/nolint  # Conflicts with clang-tidy
+filter=-readability/todo  # Requires TODO to have a username
+filter=-whitespace  # Formatting determined by clang-format


### PR DESCRIPTION
### Summary
If merged this pull request will add a cpplint job running on GitHub Actions. Whitespace, multiline comment, and disallowed c++11 feature checks are disabled in cpplint; the first two seem to be primarily for following google style guidelines (and result in a huge number of errors [13000+]), and the latter is C++ headers that google doesn't allow using (regex, thread, etc).

Directories with source files checked (recursive) are: examples, benchmarks, src, tests

When the final set of categories is decided, a subsequent PR will be needed to fix the identified issues to make the test pass.

### Proposed changes
- Add a cpplint job running on GitHub Actions
