### PR TITLE
missing C++98 functions

### DIFF
--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -91,10 +91,7 @@ class Endpoint {
     /** get the base helics_endpoint object for use in the c API functions*/
     helics_endpoint baseObject() const { return ep; }
     /** check if the input is valid */
-    bool isValid() const
-    {
-        return (helicsEndpointIsValid(ep) == helics_true);
-    }
+    bool isValid() const { return (helicsEndpointIsValid(ep) == helics_true); }
     /* Checks if endpoint has unread messages **/
     bool hasMessage() const
     {

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -90,6 +90,11 @@ class Endpoint {
     operator helics_endpoint() { return ep; }
     /** get the base helics_endpoint object for use in the c API functions*/
     helics_endpoint baseObject() const { return ep; }
+    /** check if the input is valid */
+    bool isValid() const
+    {
+        return (helicsEndpointIsValid(ep) == helics_true);
+    }
     /* Checks if endpoint has unread messages **/
     bool hasMessage() const
     {

--- a/src/helics/cpp98/Filter.hpp
+++ b/src/helics/cpp98/Filter.hpp
@@ -34,6 +34,11 @@ class Filter {
     operator helics_filter() const { return filt; }
     /** get the underlying helics_filter object*/
     helics_filter baseObject() const { return filt; }
+    /** check if the filter is valid */
+    bool isValid() const
+    {
+        return (helicsFilterIsValid(filt) == helics_true);
+    }
     /** get the name for the filter*/
     const char* getName() const { return helicsFilterGetName(filt); }
     /** set a property on a filter

--- a/src/helics/cpp98/Filter.hpp
+++ b/src/helics/cpp98/Filter.hpp
@@ -35,10 +35,7 @@ class Filter {
     /** get the underlying helics_filter object*/
     helics_filter baseObject() const { return filt; }
     /** check if the filter is valid */
-    bool isValid() const
-    {
-        return (helicsFilterIsValid(filt) == helics_true);
-    }
+    bool isValid() const { return (helicsFilterIsValid(filt) == helics_true); }
     /** get the name for the filter*/
     const char* getName() const { return helicsFilterGetName(filt); }
     /** set a property on a filter

--- a/src/helics/cpp98/Input.hpp
+++ b/src/helics/cpp98/Input.hpp
@@ -35,10 +35,7 @@ class Input {
     /** extract the base object*/
     helics_input baseObject() const { return inp; }
     /** check if the input is valid */
-    bool isValid() const
-    {
-        return (helicsInputIsValid(inp) == helics_true);
-    }
+    bool isValid() const { return (helicsInputIsValid(inp) == helics_true); }
     /** Methods to set default values for inputs **/
     /** set the default value as a raw data with length*/
     void setDefault(const char* data, int len) { helicsInputSetDefaultRaw(inp, data, len, NULL); }
@@ -64,7 +61,6 @@ class Input {
         helicsInputSetDefaultVector(
             inp, data.data(), static_cast<int>(data.size() * sizeof(double)), NULL);
     }
-
 
     /** Methods to get subscription values **/
     /** get a raw value as a character vector*/
@@ -166,6 +162,7 @@ class Input {
     {
         helicsInputSetInfo(inp, info.c_str(), HELICS_IGNORE_ERROR);
     }
+
   private:
     helics_input inp; //!< the reference to the underlying publication
 };

--- a/src/helics/cpp98/Input.hpp
+++ b/src/helics/cpp98/Input.hpp
@@ -34,6 +34,11 @@ class Input {
     operator helics_input() const { return inp; }
     /** extract the base object*/
     helics_input baseObject() const { return inp; }
+    /** check if the input is valid */
+    bool isValid() const
+    {
+        return (helicsInputIsValid(inp) == helics_true);
+    }
     /** Methods to set default values for inputs **/
     /** set the default value as a raw data with length*/
     void setDefault(const char* data, int len) { helicsInputSetDefaultRaw(inp, data, len, NULL); }
@@ -59,6 +64,7 @@ class Input {
         helicsInputSetDefaultVector(
             inp, data.data(), static_cast<int>(data.size() * sizeof(double)), NULL);
     }
+
 
     /** Methods to get subscription values **/
     /** get a raw value as a character vector*/
@@ -153,7 +159,13 @@ class Input {
     const char* getType() const { return helicsInputGetType(inp); }
     /** get an associated target*/
     const char* getTarget() const { return helicsSubscriptionGetKey(inp); }
-
+    /** get the interface information field of the filter*/
+    const char* getInfo() const { return helicsInputGetInfo(inp); }
+    /** set the interface information field of the publication*/
+    void setInfo(const std::string& info)
+    {
+        helicsInputSetInfo(inp, info.c_str(), HELICS_IGNORE_ERROR);
+    }
   private:
     helics_input inp; //!< the reference to the underlying publication
 };

--- a/src/helics/cpp98/Publication.hpp
+++ b/src/helics/cpp98/Publication.hpp
@@ -37,10 +37,7 @@ class Publication {
     helics_publication baseObject() const { return pub; }
 
     /** check if the publication is valid */
-    bool isValid() const
-    {
-        return (helicsPublicationIsValid(pub) == helics_true);
-    }
+    bool isValid() const { return (helicsPublicationIsValid(pub) == helics_true); }
 
     /** Methods to publish values **/
 

--- a/src/helics/cpp98/Publication.hpp
+++ b/src/helics/cpp98/Publication.hpp
@@ -35,6 +35,13 @@ class Publication {
     operator helics_publication() const { return pub; }
     /** return the underlying helics_publication object*/
     helics_publication baseObject() const { return pub; }
+
+    /** check if the publication is valid */
+    bool isValid() const
+    {
+        return (helicsPublicationIsValid(pub) == helics_true);
+    }
+
     /** Methods to publish values **/
 
     /** publish raw data from a pointer and length*/

--- a/src/helics/cpp98/helics.hpp
+++ b/src/helics/cpp98/helics.hpp
@@ -20,7 +20,18 @@ namespace helicscpp {
 /** get a string with the helics version info*/
 std::string getHelicsVersionString()
 {
-    return std::string(helicsGetVersion());
+    return std::string{helicsGetVersion()};
+}
+/** get a string with the helics version info*/
+std::string version()
+{
+    return std::string{helicsGetVersion()};
+}
+
+/** do a cleanup of the brokers and cores currently in the library*/
+void cleanupHelicsLibrary()
+{
+    helicsCleanupLibrary();
 }
 
 } // namespace helicscpp

--- a/src/helics/cpp98/helics.hpp
+++ b/src/helics/cpp98/helics.hpp
@@ -20,12 +20,12 @@ namespace helicscpp {
 /** get a string with the helics version info*/
 std::string getHelicsVersionString()
 {
-    return std::string{helicsGetVersion()};
+    return std::string(helicsGetVersion());
 }
 /** get a string with the helics version info*/
 std::string version()
 {
-    return std::string{helicsGetVersion()};
+    return std::string(helicsGetVersion());
 }
 
 /** do a cleanup of the brokers and cores currently in the library*/

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -96,11 +96,11 @@ HELICS_EXPORT helics_endpoint helicsFederateGetEndpoint(helics_federate fed, con
 HELICS_EXPORT helics_endpoint helicsFederateGetEndpointByIndex(helics_federate fed, int index, helics_error* err);
 
 /**
- * check if an endpoint is valid
+ * Check if an endpoint is valid.
  *
  * @param endpoint The endpoint object to check.
  *
- * @return helics_true if the Endpoint object represents a valid endpoint
+ * @return helics_true if the Endpoint object represents a valid endpoint.
  */
 HELICS_EXPORT helics_bool helicsEndpointIsValid(helics_endpoint endpoint);
 

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -96,6 +96,15 @@ HELICS_EXPORT helics_endpoint helicsFederateGetEndpoint(helics_federate fed, con
 HELICS_EXPORT helics_endpoint helicsFederateGetEndpointByIndex(helics_federate fed, int index, helics_error* err);
 
 /**
+ * check if an endpoint is valid
+ *
+ * @param endpoint The endpoint object to check.
+ *
+ * @return helics_true if the Endpoint object represents a valid endpoint
+ */
+HELICS_EXPORT helics_bool helicsEndpointIsValid(helics_endpoint endpoint);
+
+/**
  * Set the default destination for an endpoint if no other endpoint is given.
  *
  * @param endpoint The endpoint to set the destination for.

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -150,6 +150,15 @@ helics_endpoint helicsFederateGetEndpointByIndex(helics_federate fed, int index,
     // LCOV_EXCL_STOP
 }
 
+helics_bool helicsEndpointIsValid(helics_endpoint endpoint)
+{
+    auto* endObj = verifyEndpoint(endpoint, nullptr);
+    if (endObj == nullptr) {
+        return helics_false;
+    }
+    return (endObj->endPtr->isValid()) ? helics_true : helics_false;
+}
+
 void helicsEndpointSetDefaultDestination(helics_endpoint endpoint, const char* dest, helics_error* err)
 {
     auto* endObj = verifyEndpoint(endpoint, err);

--- a/src/helics/shared_api_library/MessageFilters.h
+++ b/src/helics/shared_api_library/MessageFilters.h
@@ -154,11 +154,11 @@ HELICS_EXPORT helics_filter helicsFederateGetFilter(helics_federate fed, const c
 HELICS_EXPORT helics_filter helicsFederateGetFilterByIndex(helics_federate fed, int index, helics_error* err);
 
 /**
- * check if a filter is valid
+ * Check if a filter is valid.
  *
  * @param filt The filter object to check.
  *
- * @return helics_true if the Filter object represents a valid filter
+ * @return helics_true if the Filter object represents a valid filter.
  */
 HELICS_EXPORT helics_bool helicsFilterIsValid(helics_filter filt);
 

--- a/src/helics/shared_api_library/MessageFilters.h
+++ b/src/helics/shared_api_library/MessageFilters.h
@@ -154,6 +154,15 @@ HELICS_EXPORT helics_filter helicsFederateGetFilter(helics_federate fed, const c
 HELICS_EXPORT helics_filter helicsFederateGetFilterByIndex(helics_federate fed, int index, helics_error* err);
 
 /**
+ * check if a filter is valid
+ *
+ * @param filt The filter object to check.
+ *
+ * @return helics_true if the Filter object represents a valid filter
+ */
+HELICS_EXPORT helics_bool helicsFilterIsValid(helics_filter filt);
+
+/**
  * Get the name of the filter and store in the given string.
  *
  * @param filt The given filter.

--- a/src/helics/shared_api_library/MessageFiltersExport.cpp
+++ b/src/helics/shared_api_library/MessageFiltersExport.cpp
@@ -288,6 +288,15 @@ static helics::CloningFilter* getCloningFilter(helics_filter filt, helics_error*
     return dynamic_cast<helics::CloningFilter*>(fObj->filtPtr);
 }
 
+helics_bool helicsFilterIsValid(helics_filter filt)
+{
+    auto filter = getFilter(filt, nullptr);
+    if (filter == nullptr) {
+        return helics_false;
+    }
+    return (filter->isValid()) ? helics_true : helics_false;
+}
+
 /** get the name of the filter*/
 const char* helicsFilterGetName(helics_filter filt)
 {

--- a/src/helics/shared_api_library/MessageFiltersExport.cpp
+++ b/src/helics/shared_api_library/MessageFiltersExport.cpp
@@ -181,7 +181,7 @@ helics_filter helicsCoreRegisterCloningFilter(helics_core cr, const char* name, 
         filt->filtPtr = filt->uFilter.get();
         filt->corePtr = std::move(core);
         filt->cloning = true;
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         coreAddFilter(cr, std::move(filt));
         return ret;
     }
@@ -212,7 +212,7 @@ helics_filter helicsFederateGetFilter(helics_federate fed, const char* name, hel
         filt->filtPtr = &id;
         filt->cloning = id.isCloningFilter();
         filt->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         federateAddFilter(fed, std::move(filt));
         return ret;
     }
@@ -250,7 +250,7 @@ helics_filter helicsFederateGetFilterByIndex(helics_federate fed, int index, hel
         filt->filtPtr = &id;
         filt->fedptr = std::move(fedObj);
         filt->cloning = id.isCloningFilter();
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         federateAddFilter(fed, std::move(filt));
         return ret;
     }
@@ -264,7 +264,7 @@ helics_filter helicsFederateGetFilterByIndex(helics_federate fed, int index, hel
 
 static helics::Filter* getFilter(helics_filter filt, helics_error* err)
 {
-    auto fObj = getFilterObj(filt, err);
+    auto* fObj = getFilterObj(filt, err);
     if (fObj == nullptr) {
         return nullptr;
     }
@@ -273,7 +273,7 @@ static helics::Filter* getFilter(helics_filter filt, helics_error* err)
 
 static helics::CloningFilter* getCloningFilter(helics_filter filt, helics_error* err)
 {
-    auto fObj = getFilterObj(filt, err);
+    auto* fObj = getFilterObj(filt, err);
     if (fObj == nullptr) {
         return nullptr;
     }
@@ -425,7 +425,7 @@ void helicsFilterRemoveDeliveryEndpoint(helics_filter filt, const char* delivery
 
 const char* helicsFilterGetInfo(helics_filter filt)
 {
-    auto filtObj = getFilterObj(filt, nullptr);
+    auto* filtObj = getFilterObj(filt, nullptr);
     if (filtObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -442,7 +442,7 @@ const char* helicsFilterGetInfo(helics_filter filt)
 
 void helicsFilterSetInfo(helics_filter filt, const char* info, helics_error* err)
 {
-    auto filtObj = getFilterObj(filt, err);
+    auto* filtObj = getFilterObj(filt, err);
     if (filtObj == nullptr) {
         return;
     }
@@ -458,7 +458,7 @@ void helicsFilterSetInfo(helics_filter filt, const char* info, helics_error* err
 
 void helicsFilterSetOption(helics_filter filt, int option, helics_bool value, helics_error* err)
 {
-    auto filtObj = getFilterObj(filt, err);
+    auto* filtObj = getFilterObj(filt, err);
     if (filtObj == nullptr) {
         return;
     }
@@ -474,7 +474,7 @@ void helicsFilterSetOption(helics_filter filt, int option, helics_bool value, he
 
 helics_bool helicsFilterGetOption(helics_filter filt, int option)
 {
-    auto filtObj = getFilterObj(filt, nullptr);
+    auto* filtObj = getFilterObj(filt, nullptr);
     if (filtObj == nullptr) {
         return helics_false;
     }
@@ -494,7 +494,7 @@ void helicsFilterSetCustomCallback(
     void* userdata,
     helics_error* err)
 {
-    auto fObj = getFilterObj(filt, err);
+    auto* fObj = getFilterObj(filt, err);
     if (fObj == nullptr || fObj->filtPtr == nullptr) {
         return;
     }
@@ -509,7 +509,7 @@ void helicsFilterSetCustomCallback(
     }
     auto op = std::make_shared<helics::CustomMessageOperator>();
     op->setMessageFunction([filtCall, userdata](std::unique_ptr<helics::Message> message) {
-        auto ms = createMessageObject(message);
+        auto* ms = createMessageObject(message);
         if (filtCall != nullptr) {
             filtCall(ms, userdata);
         }

--- a/src/helics/shared_api_library/MessageFiltersExport.cpp
+++ b/src/helics/shared_api_library/MessageFiltersExport.cpp
@@ -30,7 +30,7 @@ static helics::FilterObject* getFilterObj(helics_filter filt, helics_error* err)
         }
         return nullptr;
     }
-    auto fObj = reinterpret_cast<helics::FilterObject*>(filt);
+    auto* fObj = reinterpret_cast<helics::FilterObject*>(filt);
     if (fObj->valid != filterValidationIdentifier) {
         if (err != nullptr) {
             err->error_code = helics_error_invalid_object;
@@ -43,14 +43,14 @@ static helics::FilterObject* getFilterObj(helics_filter filt, helics_error* err)
 
 static inline void federateAddFilter(helics_federate fed, std::unique_ptr<helics::FilterObject> filt)
 {
-    auto fedObj = reinterpret_cast<helics::FedObject*>(fed);
+    auto* fedObj = reinterpret_cast<helics::FedObject*>(fed);
     filt->valid = filterValidationIdentifier;
     fedObj->filters.push_back(std::move(filt));
 }
 
 static inline void coreAddFilter(helics_core core, std::unique_ptr<helics::FilterObject> filt)
 {
-    auto coreObj = reinterpret_cast<helics::CoreObject*>(core);
+    auto* coreObj = reinterpret_cast<helics::CoreObject*>(core);
     filt->valid = filterValidationIdentifier;
     coreObj->filters.push_back(std::move(filt));
 }
@@ -68,7 +68,7 @@ helics_filter helicsFederateRegisterFilter(helics_federate fed, helics_filter_ty
         filt->filtPtr = &helics::make_filter(static_cast<helics::filter_types>(type), fedObj.get(), AS_STRING(name));
         filt->fedptr = std::move(fedObj);
         filt->custom = (type == helics_filter_type_custom);
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         federateAddFilter(fed, std::move(filt));
         return ret;
     }
@@ -92,7 +92,7 @@ helics_filter helicsFederateRegisterGlobalFilter(helics_federate fed, helics_fil
             helics::interface_visibility::global, static_cast<helics::filter_types>(type), fedObj.get(), AS_STRING(name));
         filt->fedptr = std::move(fedObj);
         filt->custom = (type == helics_filter_type_custom);
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         federateAddFilter(fed, std::move(filt));
         return ret;
     }
@@ -114,7 +114,7 @@ helics_filter helicsCoreRegisterFilter(helics_core cr, helics_filter_type type, 
         filt->filtPtr = filt->uFilter.get();
         filt->corePtr = std::move(core);
         filt->custom = (type == helics_filter_type_custom);
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         coreAddFilter(cr, std::move(filt));
         return ret;
     }
@@ -136,7 +136,7 @@ helics_filter helicsFederateRegisterCloningFilter(helics_federate fed, const cha
         filt->filtPtr = &helics::make_cloning_filter(helics::filter_types::clone, fedObj.get(), std::string{}, AS_STRING(name));
         filt->fedptr = std::move(fedObj);
         filt->cloning = true;
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         federateAddFilter(fed, std::move(filt));
         return ret;
     }
@@ -159,7 +159,7 @@ helics_filter helicsFederateRegisterGlobalCloningFilter(helics_federate fed, con
             &helics::make_cloning_filter(helics::GLOBAL, helics::filter_types::clone, fedObj.get(), std::string{}, AS_STRING(name));
         filt->fedptr = std::move(fedObj);
         filt->cloning = true;
-        auto ret = reinterpret_cast<helics_filter>(filt.get());
+        auto* ret = reinterpret_cast<helics_filter>(filt.get());
         federateAddFilter(fed, std::move(filt));
         return ret;
     }
@@ -226,7 +226,7 @@ helics_filter helicsFederateGetFilter(helics_federate fed, const char* name, hel
 
 int helicsFederateGetFilterCount(helics_federate fed)
 {
-    auto fedObj = getFed(fed, nullptr);
+    auto* fedObj = getFed(fed, nullptr);
     if (fedObj == nullptr) {
         return 0;
     }
@@ -290,7 +290,7 @@ static helics::CloningFilter* getCloningFilter(helics_filter filt, helics_error*
 
 helics_bool helicsFilterIsValid(helics_filter filt)
 {
-    auto filter = getFilter(filt, nullptr);
+    auto* filter = getFilter(filt, nullptr);
     if (filter == nullptr) {
         return helics_false;
     }
@@ -300,7 +300,7 @@ helics_bool helicsFilterIsValid(helics_filter filt)
 /** get the name of the filter*/
 const char* helicsFilterGetName(helics_filter filt)
 {
-    auto filter = getFilter(filt, nullptr);
+    auto* filter = getFilter(filt, nullptr);
     if (filter == nullptr) {
         return emptyStr.c_str();
     }
@@ -310,7 +310,7 @@ const char* helicsFilterGetName(helics_filter filt)
 
 void helicsFilterSet(helics_filter filt, const char* prop, double val, helics_error* err)
 {
-    auto filter = getFilter(filt, err);
+    auto* filter = getFilter(filt, err);
     if (filter == nullptr) {
         return;
     }
@@ -325,7 +325,7 @@ void helicsFilterSet(helics_filter filt, const char* prop, double val, helics_er
 
 void helicsFilterSetString(helics_filter filt, const char* prop, const char* val, helics_error* err)
 {
-    auto filter = getFilter(filt, err);
+    auto* filter = getFilter(filt, err);
     if (filter == nullptr) {
         return;
     }
@@ -340,13 +340,13 @@ void helicsFilterSetString(helics_filter filt, const char* prop, const char* val
 
 void helicsFilterAddDestinationTarget(helics_filter filt, const char* dest, helics_error* err)
 {
-    auto cfilt = getFilter(filt, err);
-    if (cfilt == nullptr) {
+    auto* filter = getFilter(filt, err);
+    if (filter == nullptr) {
         return;
     }
     CHECK_NULL_STRING(dest, void());
     try {
-        cfilt->addDestinationTarget(dest);
+        filter->addDestinationTarget(dest);
     }
     // LCOV_EXCL_START
     catch (...) {
@@ -357,13 +357,13 @@ void helicsFilterAddDestinationTarget(helics_filter filt, const char* dest, heli
 
 void helicsFilterAddSourceTarget(helics_filter filt, const char* src, helics_error* err)
 {
-    auto cfilt = getFilter(filt, err);
-    if (cfilt == nullptr) {
+    auto* filter = getFilter(filt, err);
+    if (filter == nullptr) {
         return;
     }
     CHECK_NULL_STRING(src, void());
     try {
-        cfilt->addSourceTarget(src);
+        filter->addSourceTarget(src);
     }
     // LCOV_EXCL_START
     catch (...) {
@@ -374,13 +374,13 @@ void helicsFilterAddSourceTarget(helics_filter filt, const char* src, helics_err
 
 void helicsFilterAddDeliveryEndpoint(helics_filter filt, const char* delivery, helics_error* err)
 {
-    auto cfilt = getCloningFilter(filt, err);
-    if (cfilt == nullptr) {
+    auto* filter = getCloningFilter(filt, err);
+    if (filter == nullptr) {
         return;
     }
     CHECK_NULL_STRING(delivery, void());
     try {
-        cfilt->addDeliveryEndpoint(delivery);
+        filter->addDeliveryEndpoint(delivery);
     }
     // LCOV_EXCL_START
     catch (...) {
@@ -391,13 +391,13 @@ void helicsFilterAddDeliveryEndpoint(helics_filter filt, const char* delivery, h
 
 void helicsFilterRemoveTarget(helics_filter filt, const char* target, helics_error* err)
 {
-    auto cfilt = getFilter(filt, err);
-    if (cfilt == nullptr) {
+    auto* filter = getFilter(filt, err);
+    if (filter == nullptr) {
         return;
     }
     CHECK_NULL_STRING(target, void());
     try {
-        cfilt->removeTarget(target);
+        filter->removeTarget(target);
     }
     // LCOV_EXCL_START
     catch (...) {
@@ -408,13 +408,13 @@ void helicsFilterRemoveTarget(helics_filter filt, const char* target, helics_err
 
 void helicsFilterRemoveDeliveryEndpoint(helics_filter filt, const char* delivery, helics_error* err)
 {
-    auto cfilt = getCloningFilter(filt, err);
-    if (cfilt == nullptr) {
+    auto* filter = getCloningFilter(filt, err);
+    if (filter == nullptr) {
         return;
     }
     CHECK_NULL_STRING(delivery, void());
     try {
-        cfilt->removeDeliveryEndpoint(delivery);
+        filter->removeDeliveryEndpoint(delivery);
     }
     // LCOV_EXCL_START
     catch (...) {

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -296,6 +296,15 @@ HELICS_EXPORT void helicsFederatePublishJSON(helics_federate fed, const char* js
  * @{
  */
 
+ /**
+  * check if a publication is valid
+  *
+  * @param pub The publication to check.
+  *
+  * @return helics_true if the publication is a valid publication
+  */
+HELICS_EXPORT helics_bool helicsPublicationIsValid(helics_publication pub);
+
 /**
  * Publish raw data from a char * and length.
  *
@@ -420,6 +429,15 @@ HELICS_EXPORT void helicsPublicationPublishNamedPoint(helics_publication pub, co
  * @endforcpponly
  */
 HELICS_EXPORT void helicsPublicationAddTarget(helics_publication pub, const char* target, helics_error* err);
+
+/**
+ * check if an input is valid
+ *
+ * @param ipt The input to check.
+ *
+ * @return helics_true if the Input object represents a valid input
+ */
+HELICS_EXPORT helics_bool helicsInputIsValid(helics_input ipt);
 
 /**
  * Add a publication to the list of data that an input subscribes to.

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -297,11 +297,11 @@ HELICS_EXPORT void helicsFederatePublishJSON(helics_federate fed, const char* js
  */
 
  /**
-  * check if a publication is valid
+  * Check if a publication is valid.
   *
   * @param pub The publication to check.
   *
-  * @return helics_true if the publication is a valid publication
+  * @return helics_true if the publication is a valid publication.
   */
 HELICS_EXPORT helics_bool helicsPublicationIsValid(helics_publication pub);
 
@@ -431,11 +431,11 @@ HELICS_EXPORT void helicsPublicationPublishNamedPoint(helics_publication pub, co
 HELICS_EXPORT void helicsPublicationAddTarget(helics_publication pub, const char* target, helics_error* err);
 
 /**
- * check if an input is valid
+ * Check if an input is valid.
  *
  * @param ipt The input to check.
  *
- * @return helics_true if the Input object represents a valid input
+ * @return helics_true if the Input object represents a valid input.
  */
 HELICS_EXPORT helics_bool helicsInputIsValid(helics_input ipt);
 

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -296,7 +296,7 @@ HELICS_EXPORT void helicsFederatePublishJSON(helics_federate fed, const char* js
  * @{
  */
 
- /**
+/**
   * Check if a publication is valid.
   *
   * @param pub The publication to check.

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -701,6 +701,24 @@ void helicsPublicationAddTarget(helics_publication pub, const char* target, heli
     pubObj->pubPtr->addTarget(target);
 }
 
+helics_bool helicsPublicationIsValid(helics_publication pub)
+{
+    auto pubObj = verifyPublication(pub, nullptr);
+    if (pubObj == nullptr) {
+        return helics_false;
+    }
+    return (pubObj->pubPtr->isValid()) ? helics_true : helics_false;
+}
+
+helics_bool helicsInputIsValid(helics_input ipt)
+{
+    auto inpObj = verifyInput(ipt, nullptr);
+    if (inpObj == nullptr) {
+        return helics_false;
+    }
+    return (inpObj->inputPtr->isValid()) ? helics_true : helics_false;
+}
+
 void helicsInputAddTarget(helics_input ipt, const char* target, helics_error* err)
 {
     auto inpObj = verifyInput(ipt, err);

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -34,7 +34,7 @@ static helics::InputObject* verifyInput(helics_input inp, helics_error* err)
         }
         return nullptr;
     }
-    auto inpObj = reinterpret_cast<helics::InputObject*>(inp);
+    auto* inpObj = reinterpret_cast<helics::InputObject*>(inp);
     if (inpObj->valid != InputValidationIdentifier) {
         if (err != nullptr) {
             err->error_code = helics_error_invalid_object;
@@ -55,7 +55,7 @@ static helics::PublicationObject* verifyPublication(helics_publication pub, heli
         }
         return nullptr;
     }
-    auto pubObj = reinterpret_cast<helics::PublicationObject*>(pub);
+    auto* pubObj = reinterpret_cast<helics::PublicationObject*>(pub);
     if (pubObj->valid != PublicationValidationIdentifier) {
         if (err != nullptr) {
             err->error_code = helics_error_invalid_object;
@@ -68,14 +68,14 @@ static helics::PublicationObject* verifyPublication(helics_publication pub, heli
 
 static inline void addInput(helics_federate fed, std::unique_ptr<helics::InputObject> inp)
 {
-    auto fedObj = reinterpret_cast<helics::FedObject*>(fed);
+    auto* fedObj = reinterpret_cast<helics::FedObject*>(fed);
     inp->valid = InputValidationIdentifier;
     fedObj->inputs.push_back(std::move(inp));
 }
 
 static inline void addPublication(helics_federate fed, std::unique_ptr<helics::PublicationObject> pub)
 {
-    auto fedObj = reinterpret_cast<helics::FedObject*>(fed);
+    auto* fedObj = reinterpret_cast<helics::FedObject*>(fed);
     pub->valid = PublicationValidationIdentifier;
     fedObj->pubs.push_back(std::move(pub));
 }
@@ -91,7 +91,7 @@ helics_input helicsFederateRegisterSubscription(helics_federate fed, const char*
         auto sub = std::make_unique<helics::InputObject>();
         sub->inputPtr = &fedObj->registerSubscription(AS_STRING(key), AS_STRING(units));
         sub->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(sub.get());
+        auto* ret = reinterpret_cast<helics_input>(sub.get());
         addInput(fed, std::move(sub));
         return ret;
     }
@@ -115,7 +115,7 @@ helics_publication
         auto pub = std::make_unique<helics::PublicationObject>();
         pub->pubPtr = &fedObj->registerPublication(AS_STRING(key), AS_STRING(type), AS_STRING(units));
         pub->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_publication>(pub.get());
+        auto* ret = reinterpret_cast<helics_publication>(pub.get());
         addPublication(fed, std::move(pub));
         return ret;
     }
@@ -147,7 +147,7 @@ helics_publication
         pub->pubPtr = &(
             fedObj->registerPublication(AS_STRING(key), helics::typeNameStringRef(static_cast<helics::data_type>(type)), AS_STRING(units)));
         pub->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_publication>(pub.get());
+        auto* ret = reinterpret_cast<helics_publication>(pub.get());
         addPublication(fed, std::move(pub));
         return ret;
     }
@@ -173,7 +173,7 @@ helics_publication helicsFederateRegisterGlobalTypePublication(
         auto pub = std::make_unique<helics::PublicationObject>();
         pub->pubPtr = &fedObj->registerGlobalPublication(AS_STRING(key), AS_STRING(type), AS_STRING(units));
         pub->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_publication>(pub.get());
+        auto* ret = reinterpret_cast<helics_publication>(pub.get());
         addPublication(fed, std::move(pub));
         return ret;
     }
@@ -210,7 +210,7 @@ helics_publication helicsFederateRegisterGlobalPublication(
         pub->pubPtr = &(fedObj->registerGlobalPublication(
             AS_STRING(key), helics::typeNameStringRef(static_cast<helics::data_type>(type)), AS_STRING(units)));
         pub->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_publication>(pub.get());
+        auto* ret = reinterpret_cast<helics_publication>(pub.get());
         addPublication(fed, std::move(pub));
         return ret;
     }
@@ -231,7 +231,7 @@ helics_input helicsFederateRegisterTypeInput(helics_federate fed, const char* ke
         auto inp = std::make_unique<helics::InputObject>();
         inp->inputPtr = &(fedObj->registerInput(AS_STRING(key), AS_STRING(type), AS_STRING(units)));
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -265,7 +265,7 @@ helics_input helicsFederateRegisterInput(helics_federate fed, const char* key, h
         inp->inputPtr =
             &(fedObj->registerInput(AS_STRING(key), helics::typeNameStringRef(static_cast<helics::data_type>(type)), AS_STRING(units)));
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -287,7 +287,7 @@ helics_input
         auto inp = std::make_unique<helics::InputObject>();
         inp->inputPtr = &(fedObj->registerGlobalInput(AS_STRING(key), AS_STRING(type), AS_STRING(units)));
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -322,7 +322,7 @@ helics_input
         inp->inputPtr =
             &(fedObj->registerInput(AS_STRING(key), helics::typeNameStringRef(static_cast<helics::data_type>(type)), AS_STRING(units)));
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -387,7 +387,7 @@ helics_publication helicsFederateGetPublication(helics_federate fed, const char*
         auto pubObj = std::make_unique<helics::PublicationObject>();
         pubObj->pubPtr = &pub;
         pubObj->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_publication>(pubObj.get());
+        auto* ret = reinterpret_cast<helics_publication>(pubObj.get());
         addPublication(fed, std::move(pubObj));
         return ret;
     }
@@ -418,7 +418,7 @@ helics_publication helicsFederateGetPublicationByIndex(helics_federate fed, int 
         pub->pubPtr = &id;
 
         pub->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_publication>(pub.get());
+        auto* ret = reinterpret_cast<helics_publication>(pub.get());
         addPublication(fed, std::move(pub));
         return ret;
     }
@@ -452,7 +452,7 @@ helics_input helicsFederateGetInput(helics_federate fed, const char* key, helics
         auto inp = std::make_unique<helics::InputObject>();
         inp->inputPtr = &id;
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -482,7 +482,7 @@ helics_input helicsFederateGetInputByIndex(helics_federate fed, int index, helic
         auto inp = std::make_unique<helics::InputObject>();
         inp->inputPtr = &id;
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -513,7 +513,7 @@ helics_input helicsFederateGetSubscription(helics_federate fed, const char* key,
         auto inp = std::make_unique<helics::InputObject>();
         inp->inputPtr = &id;
         inp->fedptr = std::move(fedObj);
-        auto ret = reinterpret_cast<helics_input>(inp.get());
+        auto* ret = reinterpret_cast<helics_input>(inp.get());
         addInput(fed, std::move(inp));
         return ret;
     }
@@ -543,7 +543,7 @@ void helicsFederateClearUpdates(helics_federate fed)
 /* getting and publishing values */
 void helicsPublicationPublishRaw(helics_publication pub, const void* data, int datalen, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -557,7 +557,7 @@ void helicsPublicationPublishRaw(helics_publication pub, const void* data, int d
 
 void helicsPublicationPublishString(helics_publication pub, const char* str, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -571,7 +571,7 @@ void helicsPublicationPublishString(helics_publication pub, const char* str, hel
 
 void helicsPublicationPublishInteger(helics_publication pub, int64_t val, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -585,7 +585,7 @@ void helicsPublicationPublishInteger(helics_publication pub, int64_t val, helics
 
 void helicsPublicationPublishBoolean(helics_publication pub, helics_bool val, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -599,7 +599,7 @@ void helicsPublicationPublishBoolean(helics_publication pub, helics_bool val, he
 
 void helicsPublicationPublishDouble(helics_publication pub, double val, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -613,7 +613,7 @@ void helicsPublicationPublishDouble(helics_publication pub, double val, helics_e
 
 void helicsPublicationPublishTime(helics_publication pub, helics_time val, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -628,7 +628,7 @@ void helicsPublicationPublishTime(helics_publication pub, helics_time val, helic
 
 void helicsPublicationPublishChar(helics_publication pub, char val, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -642,7 +642,7 @@ void helicsPublicationPublishChar(helics_publication pub, char val, helics_error
 
 void helicsPublicationPublishComplex(helics_publication pub, double real, double imag, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -656,7 +656,7 @@ void helicsPublicationPublishComplex(helics_publication pub, double real, double
 
 void helicsPublicationPublishVector(helics_publication pub, const double* vectorInput, int vectorLength, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -674,7 +674,7 @@ void helicsPublicationPublishVector(helics_publication pub, const double* vector
 
 void helicsPublicationPublishNamedPoint(helics_publication pub, const char* str, double val, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -692,7 +692,7 @@ void helicsPublicationPublishNamedPoint(helics_publication pub, const char* str,
 
 void helicsPublicationAddTarget(helics_publication pub, const char* target, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -703,7 +703,7 @@ void helicsPublicationAddTarget(helics_publication pub, const char* target, heli
 
 helics_bool helicsPublicationIsValid(helics_publication pub)
 {
-    auto pubObj = verifyPublication(pub, nullptr);
+    auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
         return helics_false;
     }
@@ -712,7 +712,7 @@ helics_bool helicsPublicationIsValid(helics_publication pub)
 
 helics_bool helicsInputIsValid(helics_input ipt)
 {
-    auto inpObj = verifyInput(ipt, nullptr);
+    auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
         return helics_false;
     }
@@ -721,7 +721,7 @@ helics_bool helicsInputIsValid(helics_input ipt)
 
 void helicsInputAddTarget(helics_input ipt, const char* target, helics_error* err)
 {
-    auto inpObj = verifyInput(ipt, err);
+    auto* inpObj = verifyInput(ipt, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -731,7 +731,7 @@ void helicsInputAddTarget(helics_input ipt, const char* target, helics_error* er
 
 int helicsInputGetRawValueSize(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return (0);
     }
@@ -753,7 +753,7 @@ bool checkOutArgString(const char* outputString, int maxlen, helics_error* err)
 
 void helicsInputGetRawValue(helics_input inp, void* data, int maxDatalen, int* actualSize, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (actualSize != nullptr) { // for initialization
         *actualSize = 0;
     }
@@ -790,7 +790,7 @@ void helicsInputGetString(helics_input inp, char* outputString, int maxStringLen
     if (actualLength != nullptr) { // for initialization
         *actualLength = 0;
     }
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -813,7 +813,7 @@ void helicsInputGetString(helics_input inp, char* outputString, int maxStringLen
 
 int64_t helicsInputGetInteger(helics_input inp, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return (-101);
     }
@@ -828,7 +828,7 @@ int64_t helicsInputGetInteger(helics_input inp, helics_error* err)
 
 helics_bool helicsInputGetBoolean(helics_input inp, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return helics_false;
     }
@@ -846,7 +846,7 @@ helics_bool helicsInputGetBoolean(helics_input inp, helics_error* err)
 
 double helicsInputGetDouble(helics_input inp, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return helics_time_invalid;
     }
@@ -861,7 +861,7 @@ double helicsInputGetDouble(helics_input inp, helics_error* err)
 
 helics_time helicsInputGetTime(helics_input inp, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return helics_time_invalid;
     }
@@ -879,7 +879,7 @@ helics_time helicsInputGetTime(helics_input inp, helics_error* err)
 
 char helicsInputGetChar(helics_input inp, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return '\x15'; //NAK (negative acknowledgment) symbol
     }
@@ -896,7 +896,7 @@ char helicsInputGetChar(helics_input inp, helics_error* err)
 
 void helicsInputGetComplex(helics_input inp, double* real, double* imag, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -918,7 +918,7 @@ void helicsInputGetComplex(helics_input inp, double* real, double* imag, helics_
 
 helics_complex helicsInputGetComplexObject(helics_input inp, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
 
     if (inpObj == nullptr) {
         // time invalid is just an invalid double
@@ -939,7 +939,7 @@ helics_complex helicsInputGetComplexObject(helics_input inp, helics_error* err)
 
 int helicsInputGetVectorSize(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return 0;
     }
@@ -955,7 +955,7 @@ int helicsInputGetVectorSize(helics_input inp)
 
 int helicsInputGetStringSize(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return 0;
     }
@@ -971,7 +971,7 @@ int helicsInputGetStringSize(helics_input inp)
 
 void helicsInputGetVector(helics_input inp, double data[], int maxlen, int* actualSize, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (actualSize != nullptr) {
         *actualSize = 0;
     }
@@ -998,7 +998,7 @@ void helicsInputGetVector(helics_input inp, double data[], int maxlen, int* actu
 
 void helicsInputGetNamedPoint(helics_input inp, char* outputString, int maxStringLen, int* actualLength, double* val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (actualLength != nullptr) {
         *actualLength = 0;
     }
@@ -1039,7 +1039,7 @@ void helicsInputGetNamedPoint(helics_input inp, char* outputString, int maxStrin
 
 void helicsInputSetDefaultRaw(helics_input inp, const void* data, int dataLen, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1059,7 +1059,7 @@ void helicsInputSetDefaultRaw(helics_input inp, const void* data, int dataLen, h
 
 void helicsInputSetDefaultString(helics_input inp, const char* str, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1075,7 +1075,7 @@ void helicsInputSetDefaultString(helics_input inp, const char* str, helics_error
 
 void helicsInputSetDefaultInteger(helics_input inp, int64_t val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1084,7 +1084,7 @@ void helicsInputSetDefaultInteger(helics_input inp, int64_t val, helics_error* e
 
 void helicsInputSetDefaultBoolean(helics_input inp, helics_bool val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1093,7 +1093,7 @@ void helicsInputSetDefaultBoolean(helics_input inp, helics_bool val, helics_erro
 
 void helicsInputSetDefaultDouble(helics_input inp, double val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1102,7 +1102,7 @@ void helicsInputSetDefaultDouble(helics_input inp, double val, helics_error* err
 
 void helicsInputSetDefaultTime(helics_input inp, helics_time val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1113,7 +1113,7 @@ void helicsInputSetDefaultTime(helics_input inp, helics_time val, helics_error* 
 
 void helicsInputSetDefaultChar(helics_input inp, char val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1122,7 +1122,7 @@ void helicsInputSetDefaultChar(helics_input inp, char val, helics_error* err)
 
 void helicsInputSetDefaultComplex(helics_input inp, double real, double imag, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1132,7 +1132,7 @@ void helicsInputSetDefaultComplex(helics_input inp, double real, double imag, he
 
 void helicsInputSetDefaultVector(helics_input inp, const double* vectorInput, int vectorLength, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1152,7 +1152,7 @@ void helicsInputSetDefaultVector(helics_input inp, const double* vectorInput, in
 
 void helicsInputSetDefaultNamedPoint(helics_input inp, const char* str, double val, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1168,7 +1168,7 @@ void helicsInputSetDefaultNamedPoint(helics_input inp, const char* str, double v
 
 const char* helicsInputGetType(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1186,7 +1186,7 @@ const char* helicsInputGetType(helics_input inp)
 
 const char* helicsInputGetPublicationType(helics_input ipt)
 {
-    auto inpObj = verifyInput(ipt, nullptr);
+    auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1204,7 +1204,7 @@ const char* helicsInputGetPublicationType(helics_input ipt)
 
 const char* helicsPublicationGetType(helics_publication pub)
 {
-    auto pubObj = verifyPublication(pub, nullptr);
+    auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1222,7 +1222,7 @@ const char* helicsPublicationGetType(helics_publication pub)
 
 const char* helicsInputGetKey(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1240,7 +1240,7 @@ const char* helicsInputGetKey(helics_input inp)
 
 const char* helicsSubscriptionGetKey(helics_input sub)
 {
-    auto inpObj = verifyInput(sub, nullptr);
+    auto* inpObj = verifyInput(sub, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1258,7 +1258,7 @@ const char* helicsSubscriptionGetKey(helics_input sub)
 
 const char* helicsPublicationGetKey(helics_publication pub)
 {
-    auto pubObj = verifyPublication(pub, nullptr);
+    auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1275,7 +1275,7 @@ const char* helicsPublicationGetKey(helics_publication pub)
 
 const char* helicsInputGetInjectionUnits(helics_input ipt)
 {
-    auto inpObj = verifyInput(ipt, nullptr);
+    auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1292,7 +1292,7 @@ const char* helicsInputGetInjectionUnits(helics_input ipt)
 
 const char* helicsInputGetExtractionUnits(helics_input ipt)
 {
-    auto inpObj = verifyInput(ipt, nullptr);
+    auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1314,7 +1314,7 @@ const char* helicsInputGetUnits(helics_input inp)
 
 const char* helicsPublicationGetUnits(helics_publication pub)
 {
-    auto pubObj = verifyPublication(pub, nullptr);
+    auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1324,7 +1324,7 @@ const char* helicsPublicationGetUnits(helics_publication pub)
 
 const char* helicsInputGetInfo(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1341,7 +1341,7 @@ const char* helicsInputGetInfo(helics_input inp)
 
 void helicsInputSetInfo(helics_input inp, const char* info, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1356,7 +1356,7 @@ void helicsInputSetInfo(helics_input inp, const char* info, helics_error* err)
 }
 const char* helicsPublicationGetInfo(helics_publication pub)
 {
-    auto pubObj = verifyPublication(pub, nullptr);
+    auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
         return emptyStr.c_str();
     }
@@ -1373,7 +1373,7 @@ const char* helicsPublicationGetInfo(helics_publication pub)
 
 void helicsPublicationSetInfo(helics_publication pub, const char* info, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -1389,7 +1389,7 @@ void helicsPublicationSetInfo(helics_publication pub, const char* info, helics_e
 
 helics_bool helicsInputGetOption(helics_input inp, int option)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return helics_false;
     }
@@ -1405,7 +1405,7 @@ helics_bool helicsInputGetOption(helics_input inp, int option)
 
 void helicsInputSetOption(helics_input inp, int option, helics_bool value, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1421,7 +1421,7 @@ void helicsInputSetOption(helics_input inp, int option, helics_bool value, helic
 
 helics_bool helicsPublicationGetOption(helics_publication pub, int option)
 {
-    auto pubObj = verifyPublication(pub, nullptr);
+    auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
         return helics_false;
     }
@@ -1437,7 +1437,7 @@ helics_bool helicsPublicationGetOption(helics_publication pub, int option)
 
 void helicsPublicationSetOption(helics_publication pub, int option, helics_bool value, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -1453,7 +1453,7 @@ void helicsPublicationSetOption(helics_publication pub, int option, helics_bool 
 
 void helicsPublicationSetMinimumChange(helics_publication pub, double tolerance, helics_error* err)
 {
-    auto pubObj = verifyPublication(pub, err);
+    auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
@@ -1462,7 +1462,7 @@ void helicsPublicationSetMinimumChange(helics_publication pub, double tolerance,
 
 void helicsInputSetMinimumChange(helics_input inp, double tolerance, helics_error* err)
 {
-    auto inpObj = verifyInput(inp, err);
+    auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {
         return;
     }
@@ -1471,7 +1471,7 @@ void helicsInputSetMinimumChange(helics_input inp, double tolerance, helics_erro
 
 helics_bool helicsInputIsUpdated(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return helics_false;
     }
@@ -1482,7 +1482,7 @@ helics_bool helicsInputIsUpdated(helics_input inp)
 
 helics_time helicsInputLastUpdateTime(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return helics_time_invalid;
     }
@@ -1499,7 +1499,7 @@ helics_time helicsInputLastUpdateTime(helics_input inp)
 
 void helicsInputClearUpdate(helics_input inp)
 {
-    auto inpObj = verifyInput(inp, nullptr);
+    auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return;
     }
@@ -1515,7 +1515,7 @@ void helicsInputClearUpdate(helics_input inp)
 int helicsFederateGetPublicationCount(helics_federate fed)
 {
     // this call should be with a nullptr since it can fail and still be a successful call
-    auto vfedObj = getValueFed(fed, nullptr);
+    auto* vfedObj = getValueFed(fed, nullptr);
     if (vfedObj == nullptr) {
         return 0;
     }
@@ -1525,7 +1525,7 @@ int helicsFederateGetPublicationCount(helics_federate fed)
 int helicsFederateGetInputCount(helics_federate fed)
 {
     // this call should be with a nullptr since it can fail and still be a successful call
-    auto vfedObj = getValueFed(fed, nullptr);
+    auto* vfedObj = getValueFed(fed, nullptr);
     if (vfedObj == nullptr) {
         return 0;
     }

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -47,6 +47,7 @@ TEST_P(filter_type_tests, registration)
     CE(auto ep1 = helicsFederateRegisterEndpoint(fFed, "fout", "", &err));
     EXPECT_TRUE(ep1 != nullptr);
     CE(auto f3 = helicsFederateRegisterFilter(fFed, helics_filter_type_custom, "c4", &err));
+    EXPECT_EQ(helicsFilterIsValid(f3), helics_true);
     helicsFilterAddSourceTarget(f3, "filter0/fout", nullptr);
     EXPECT_TRUE(f3 != f2);
 

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -3474,7 +3474,7 @@ TEST(evil_endpoint_test, helicsEndpointIsValid)
     char rdata[256];
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
     EXPECT_NE(helicsEndpointIsValid(nullptr), helics_true);
-    
+
     //auto res2=helicsEndpointSetDefaultDestination(nullptr, const char* dest, nullptr);
     EXPECT_NE(helicsEndpointIsValid(evil_ept), helics_true);
 }

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -2113,6 +2113,15 @@ TEST(evil_value_federate_test, helicsFederateGetInputCount)
 
 //section Publication interface Functions
 //functions applying to a \ref helics_publication object
+
+TEST(evil_pub_test, helicsPublicationIsValid)
+{
+    char rdata[256];
+    auto evil_pub = reinterpret_cast<helics_publication>(rdata);
+    EXPECT_NE(helicsPublicationIsValid(nullptr), helics_true);
+    EXPECT_NE(helicsPublicationIsValid(evil_pub), helics_true);
+}
+
 TEST(evil_pub_test, helicsPublicationPublishRaw)
 {
     //void helicsPublicationPublishRaw(helics_publication pub, const void* data, int inputDataLength, helics_error* err);
@@ -2383,6 +2392,15 @@ TEST(evil_pub_test, helicsPublicationSetOption)
 
 //section Input interface Functions
 //functions applying to a \ref helics_input object
+
+TEST(evil_input_test, helicsInputIsValid)
+{
+    char rdata[256];
+    auto evil_input = reinterpret_cast<helics_input>(rdata);
+    EXPECT_NE(helicsInputIsValid(nullptr), helics_true);
+    EXPECT_NE(helicsInputIsValid(evil_input), helics_true);
+}
+
 TEST(evil_input_test, helicsInputAddTarget)
 {
     //void helicsInputAddTarget(helics_input ipt, const char* target, helics_error* err);
@@ -3449,6 +3467,18 @@ TEST(evil_message_object_test, helicsMessageAppendData)
 
 //section Endpoint interface Functions
 //functions applying to a \ref helics_endpoint object
+
+TEST(evil_endpoint_test, helicsEndpointIsValid)
+{
+    //void helicsEndpointSetDefaultDestination(helics_endpoint endpoint, const char* dest, helics_error* err);
+    char rdata[256];
+    auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
+    EXPECT_NE(helicsEndpointIsValid(nullptr), helics_true);
+    
+    //auto res2=helicsEndpointSetDefaultDestination(nullptr, const char* dest, nullptr);
+    EXPECT_NE(helicsEndpointIsValid(evil_ept), helics_true);
+}
+
 TEST(evil_endpoint_test, helicsEndpointSetDefaultDestination)
 {
     //void helicsEndpointSetDefaultDestination(helics_endpoint endpoint, const char* dest, helics_error* err);
@@ -3771,6 +3801,15 @@ TEST(evil_filter_fed_test, helicsFederateGetFilterByIndex)
 
 //section Filter interface Functions
 //Functions applying to a \ref helics_filter object
+
+TEST(evil_filter_test, helicsFilterIsValid)
+{
+    char rdata[256];
+    auto evil_filt = reinterpret_cast<helics_filter>(rdata);
+    EXPECT_NE(helicsFilterIsValid(nullptr), helics_true);
+    EXPECT_NE(helicsFilterIsValid(evil_filt), helics_true);
+}
+
 TEST(evil_filter_test, helicsFilterGetName)
 {
     //const char*  helicsFilterGetName(helics_filter filt);

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -311,6 +311,7 @@ TEST_P(mfed_type_tests, send_receive_2fed_multisend)
     CE(auto epid = helicsFederateRegisterEndpoint(mFed1, "ep1", nullptr, &err));
     CE(auto epid2 = helicsFederateRegisterGlobalEndpoint(mFed2, "ep2", "random", &err));
 
+    EXPECT_EQ(helicsEndpointIsValid(epid), helics_true);
     CE(helicsFederateSetTimeProperty(mFed1, helics_property_time_delta, 1.0, &err));
     CE(helicsFederateSetTimeProperty(mFed2, helics_property_time_delta, 1.0, &err));
 

--- a/tests/helics/shared_library/test-value-federate1.cpp
+++ b/tests/helics/shared_library/test-value-federate1.cpp
@@ -267,12 +267,13 @@ TEST_F(vfed_single_tests, default_value_tests)
     helicsInputSetDefaultDouble(inp_double, 10000.0, &err);
 
     helicsInputSetOption(inp_double2, helics_handle_option_connection_required, helics_true, &err);
-
+    EXPECT_EQ(helicsInputIsValid(inp_double2), helics_true);
     //anonymous publication
     auto pub = helicsFederateRegisterPublication(vFed1, nullptr, helics_data_type_int, "MW", &err);
     helicsPublicationSetOption(pub, helics_handle_option_connection_required, helics_true, &err);
     helicsPublicationAddTarget(pub, "fed0/key7", &err);
     helicsPublicationAddTarget(pub, "fed0/key8", &err);
+    EXPECT_EQ(helicsPublicationIsValid(pub), helics_true);
 
     helicsInputSetDefaultRaw(inp_raw1, nullptr, -2, &err);
     EXPECT_EQ(err.error_code, 0);

--- a/tests/helics/shared_library/test-value-federate1.cpp
+++ b/tests/helics/shared_library/test-value-federate1.cpp
@@ -898,8 +898,10 @@ TEST_P(vfed_type_tests, subscriber_and_publisher_registration)
     helicsFederateSetFlagOption(vFed, helics_handle_option_connection_optional, helics_true, &err);
     // register the publications
     helics_publication pubid = helicsFederateRegisterTypePublication(vFed, "pub1", "", "", &err);
-    helics_publication pubid2 = helicsFederateRegisterGlobalTypePublication(vFed, "pub2", "int", "", &err);
-    helics_publication pubid3 = helicsFederateRegisterPublication(vFed, "pub3", helics_data_type_double, "V", &err);
+    helics_publication pubid2 =
+        helicsFederateRegisterGlobalTypePublication(vFed, "pub2", "int", "", &err);
+    helics_publication pubid3 =
+        helicsFederateRegisterPublication(vFed, "pub3", helics_data_type_double, "V", &err);
     EXPECT_EQ(err.error_code, helics_ok);
     // these aren't meant to match the publications
     auto subid = helicsFederateRegisterSubscription(vFed, "sub1", "", &err);
@@ -910,12 +912,12 @@ TEST_P(vfed_type_tests, subscriber_and_publisher_registration)
     CE(helicsFederateEnterExecutingMode(vFed, &err));
 
     // check subscriptions
-    const char *subname = helicsSubscriptionGetKey(subid);
-    const char *subname2 = helicsSubscriptionGetKey(subid2);
+    const char* subname = helicsSubscriptionGetKey(subid);
+    const char* subname2 = helicsSubscriptionGetKey(subid2);
 
     EXPECT_STREQ(subname, "sub1");
     EXPECT_STREQ(subname2, "sub2");
-    const char *subname3 = helicsSubscriptionGetKey(subid3);
+    const char* subname3 = helicsSubscriptionGetKey(subid3);
     EXPECT_STREQ(subname3, "sub3");
 
     // subtype=helicsInputGetType (subid);
@@ -928,17 +930,17 @@ TEST_P(vfed_type_tests, subscriber_and_publisher_registration)
     EXPECT_STREQ(subunit3, "V");
 
     // check publications
-    const char *pubname = helicsPublicationGetKey(pubid);
-    const char *pubname2 = helicsPublicationGetKey(pubid2);
+    const char* pubname = helicsPublicationGetKey(pubid);
+    const char* pubname2 = helicsPublicationGetKey(pubid2);
 
     EXPECT_STREQ(pubname, "fed0/pub1");
     EXPECT_STREQ(pubname2, "pub2");
-    const char *pubname3 = helicsPublicationGetKey(pubid3);
+    const char* pubname3 = helicsPublicationGetKey(pubid3);
     EXPECT_STREQ(pubname3, "fed0/pub3");
 
-    const char *pubtype = helicsPublicationGetType(pubid3);
+    const char* pubtype = helicsPublicationGetType(pubid3);
     EXPECT_STREQ(pubtype, "double");
-    const char *pubunit3 = helicsPublicationGetUnits(pubid3);
+    const char* pubunit3 = helicsPublicationGetUnits(pubid3);
     EXPECT_STREQ(pubunit3, "V");
 
     CE(helicsFederateFinalize(vFed, &err));

--- a/tests/helics/shared_library/test-value-federate1.cpp
+++ b/tests/helics/shared_library/test-value-federate1.cpp
@@ -686,7 +686,7 @@ void runFederateTestVectorD(
     helics_time gtime;
     int maxlen = (len1 > len2) ? len1 : len2;
     maxlen = (maxlen > len) ? maxlen : len;
-    double* val = new double[maxlen];
+    auto* val = new double[maxlen];
     helics_error err = helicsErrorInitialize();
     FederateTestFixture fixture;
     fixture.SetupTest(helicsCreateValueFederate, core, 1, 1.0);
@@ -892,36 +892,30 @@ TEST_P(vfed_type_tests, single_transfer_vector2)
 
 TEST_P(vfed_type_tests, subscriber_and_publisher_registration)
 {
-    helics_publication pubid, pubid2, pubid3;
-    helics_input subid, subid2, subid3;
-    const char *pubname, *pubname2, *pubname3, *pubtype, *pubunit3;
-    const char *subname, *subname2, *subname3;
-    const char* subunit3;
-
     SetupTest(helicsCreateValueFederate, GetParam(), 1, 1.0);
     auto vFed = GetFederateAt(0);
 
-    helicsFederateSetFlagOption(vFed, helics_handle_option_connection_optional, true, &err);
+    helicsFederateSetFlagOption(vFed, helics_handle_option_connection_optional, helics_true, &err);
     // register the publications
-    pubid = helicsFederateRegisterTypePublication(vFed, "pub1", "", "", &err);
-    pubid2 = helicsFederateRegisterGlobalTypePublication(vFed, "pub2", "int", "", &err);
-    pubid3 = helicsFederateRegisterPublication(vFed, "pub3", helics_data_type_double, "V", &err);
+    helics_publication pubid = helicsFederateRegisterTypePublication(vFed, "pub1", "", "", &err);
+    helics_publication pubid2 = helicsFederateRegisterGlobalTypePublication(vFed, "pub2", "int", "", &err);
+    helics_publication pubid3 = helicsFederateRegisterPublication(vFed, "pub3", helics_data_type_double, "V", &err);
     EXPECT_EQ(err.error_code, helics_ok);
     // these aren't meant to match the publications
-    subid = helicsFederateRegisterSubscription(vFed, "sub1", "", &err);
-    subid2 = helicsFederateRegisterSubscription(vFed, "sub2", "", &err);
-    subid3 = helicsFederateRegisterSubscription(vFed, "sub3", "V", &err);
+    auto subid = helicsFederateRegisterSubscription(vFed, "sub1", "", &err);
+    auto subid2 = helicsFederateRegisterSubscription(vFed, "sub2", "", &err);
+    auto subid3 = helicsFederateRegisterSubscription(vFed, "sub3", "V", &err);
     EXPECT_EQ(err.error_code, helics_ok);
     // enter execution
     CE(helicsFederateEnterExecutingMode(vFed, &err));
 
     // check subscriptions
-    subname = helicsSubscriptionGetKey(subid);
-    subname2 = helicsSubscriptionGetKey(subid2);
+    const char *subname = helicsSubscriptionGetKey(subid);
+    const char *subname2 = helicsSubscriptionGetKey(subid2);
 
     EXPECT_STREQ(subname, "sub1");
     EXPECT_STREQ(subname2, "sub2");
-    subname3 = helicsSubscriptionGetKey(subid3);
+    const char *subname3 = helicsSubscriptionGetKey(subid3);
     EXPECT_STREQ(subname3, "sub3");
 
     // subtype=helicsInputGetType (subid);
@@ -930,21 +924,21 @@ TEST_P(vfed_type_tests, subscriber_and_publisher_registration)
     // EXPECT_EQ (subtype2, "int64");
     // subtype3=helicsInputGetType (subid3);
     // EXPECT_EQ (subtype3, "def");
-    subunit3 = helicsInputGetUnits(subid3);
+    auto subunit3 = helicsInputGetUnits(subid3);
     EXPECT_STREQ(subunit3, "V");
 
     // check publications
-    pubname = helicsPublicationGetKey(pubid);
-    pubname2 = helicsPublicationGetKey(pubid2);
+    const char *pubname = helicsPublicationGetKey(pubid);
+    const char *pubname2 = helicsPublicationGetKey(pubid2);
 
     EXPECT_STREQ(pubname, "fed0/pub1");
     EXPECT_STREQ(pubname2, "pub2");
-    pubname3 = helicsPublicationGetKey(pubid3);
+    const char *pubname3 = helicsPublicationGetKey(pubid3);
     EXPECT_STREQ(pubname3, "fed0/pub3");
 
-    pubtype = helicsPublicationGetType(pubid3);
+    const char *pubtype = helicsPublicationGetType(pubid3);
     EXPECT_STREQ(pubtype, "double");
-    pubunit3 = helicsPublicationGetUnits(pubid3);
+    const char *pubunit3 = helicsPublicationGetUnits(pubid3);
     EXPECT_STREQ(pubunit3, "V");
 
     CE(helicsFederateFinalize(vFed, &err));
@@ -999,7 +993,7 @@ TEST_P(vfed_simple_type_tests, test_info_field)
 {
     SetupTest(helicsCreateValueFederate, GetParam(), 1, 1.0);
     auto vFed = GetFederateAt(0);
-    helicsFederateSetFlagOption(vFed, helics_handle_option_connection_optional, true, &err);
+    helicsFederateSetFlagOption(vFed, helics_handle_option_connection_optional, helics_true, &err);
     // register the publications/subscriptions
 
     auto subid1 = helicsFederateRegisterSubscription(vFed, "sub1", "", &err);


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will add some missing C and C++98 API functions including set/get Info on inputs and isValid functions for endpoints, publications, inputs, and filters in the C API

Fixes Issues #1211 and #1213 

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add isValid to the C++98 and C API for inputs, publications, endpoints, and filters
- add get/setInfo to the C++98 input objects.
- add a few test of the added functions
