### PR TITLE
Deprecate Federate Error method

### DIFF
--- a/src/helics/application_api/Federate.cpp
+++ b/src/helics/application_api/Federate.cpp
@@ -530,12 +530,6 @@ void Federate::disconnect()
     coreObject = nullptr;
 }
 
-void Federate::error(int errorcode)
-{
-    std::string errorString = "error " + std::to_string(errorcode) + " in federate " + name;
-    error(errorcode, errorString);
-}
-
 void Federate::completeOperation()
 {
     switch (currentMode.load()) {
@@ -559,16 +553,26 @@ void Federate::completeOperation()
     }
 }
 
+void Federate::error(int errorcode)
+{
+    localError(errorcode);
+}
+
 void Federate::error(int errorcode, const std::string& message)
 {
-    if (!coreObject) {
-        throw(
-            InvalidFunctionCall("cannot generate error on uninitialized or disconnected Federate"));
-    }
-    // deal with pending operations first
-    completeOperation();
-    currentMode = modes::error;
-    coreObject->logMessage(fedID, errorcode, message);
+    localError(errorcode,message);
+}
+
+void Federate::localError(int errorcode)
+{
+    std::string errorString = "local error " + std::to_string(errorcode) + " in federate " + name;
+    localError(errorcode, errorString);
+}
+
+void Federate::globalError(int errorcode)
+{
+    std::string errorString = "global error " + std::to_string(errorcode) + " in federate " + name;
+    globalError(errorcode, errorString);
 }
 
 void Federate::localError(int errorcode, const std::string& message)

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -166,10 +166,10 @@ class HELICS_CXX_EXPORT Federate {
     virtual void disconnect();
     /** specify the simulator had an unrecoverable error
      */
-    void error(int errorcode);
+    [[deprecated("please use localError method")]] void error(int errorcode);
     /** specify the simulator had an error with error code and message
      */
-    void error(int errorcode, const std::string& message);
+    [[deprecated("please use localError method")]] void error(int errorcode, const std::string& message);
     /** specify the simulator had a local error with error code and message
     */
     void localError(int errorcode, const std::string& message);
@@ -177,6 +177,14 @@ class HELICS_CXX_EXPORT Federate {
     /** specify the simulator had a local error with error code and message
     */
     void globalError(int errorcode, const std::string& message);
+
+    /** specify the simulator had a local error with error code
+    */
+    void localError(int errorcode);
+
+    /** specify the simulator had a local error with error code
+    */
+    void globalError(int errorcode);
 
     /** specify a separator to use for naming separation between the federate name and the interface name
      setSeparator('.') will result in future registrations of local endpoints such as fedName.endpoint

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -165,24 +165,37 @@ class HELICS_CXX_EXPORT Federate {
     /** disconnect a simulation from the core (will also call finalize before disconnecting if necessary)*/
     virtual void disconnect();
     /** specify the simulator had an unrecoverable error
-     */
+    @param errorcode an integral code for the error
+    @deprecated please use localError instead
+    */
     [[deprecated("please use localError method")]] void error(int errorcode);
+
     /** specify the simulator had an error with error code and message
+    @param errorcode an integral code for the error
+    @param message a string describing the error to display in the log
+    @deprecated please use localError instead
      */
     [[deprecated("please use localError method")]] void error(int errorcode, const std::string& message);
+
     /** specify the simulator had a local error with error code and message
+    @param errorcode an integral code for the error
+    @param message a string describing the error to display in the log
     */
     void localError(int errorcode, const std::string& message);
 
-    /** specify the simulator had a local error with error code and message
+    /** specify the simulator had a global error with error code and message
+    @param errorcode an integral code for the error
+    @param message a string describing the error to display in the log
     */
     void globalError(int errorcode, const std::string& message);
 
     /** specify the simulator had a local error with error code
+    @param errorcode an integral code for the error
     */
     void localError(int errorcode);
 
-    /** specify the simulator had a local error with error code
+    /** specify the simulator had a global error with error code
+    @param errorcode an integral code for the error
     */
     void globalError(int errorcode);
 

--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -758,7 +758,7 @@ TEST(federate_tests, forceErrorExec)
     auto Fed1 = std::make_shared<helics::Federate>("fed1", fi);
 
     Fed1->enterExecutingMode();
-    Fed1->error(9827);
+    Fed1->localError(9827);
 
     EXPECT_THROW(Fed1->enterInitializingMode(), helics::InvalidFunctionCall);
     EXPECT_THROW(Fed1->enterExecutingMode(), helics::InvalidFunctionCall);
@@ -775,7 +775,7 @@ TEST(federate_tests, forceErrorExecAsync)
     auto Fed1 = std::make_shared<helics::Federate>("fed1", fi);
 
     Fed1->enterExecutingModeAsync(helics::iteration_request::force_iteration);
-    Fed1->error(9827);
+    Fed1->localError(9827);
 
     EXPECT_THROW(Fed1->enterInitializingMode(), helics::InvalidFunctionCall);
     EXPECT_THROW(Fed1->enterExecutingMode(), helics::InvalidFunctionCall);
@@ -792,7 +792,7 @@ TEST(federate_tests, forceErrorInitAsync)
     auto Fed1 = std::make_shared<helics::Federate>("fed1", fi);
 
     Fed1->enterInitializingModeAsync();
-    Fed1->error(9827);
+    Fed1->localError(9827);
 
     EXPECT_THROW(Fed1->enterInitializingMode(), helics::InvalidFunctionCall);
     EXPECT_THROW(Fed1->enterExecutingMode(), helics::InvalidFunctionCall);
@@ -810,7 +810,7 @@ TEST(federate_tests, forceErrorPendingTimeAsync)
 
     Fed1->enterExecutingMode();
     Fed1->requestTimeAsync(2.0);
-    Fed1->error(9827);
+    Fed1->globalError(9827);
 
     EXPECT_THROW(Fed1->requestTime(3.0), helics::InvalidFunctionCall);
 
@@ -921,7 +921,7 @@ TEST(federate_tests, forceErrorPendingTimeIterativeAsync)
 
     Fed1->enterExecutingMode();
     Fed1->requestTimeIterativeAsync(2.0, helics::iteration_request::no_iterations);
-    Fed1->error(9827);
+    Fed1->localError(9827);
 
     EXPECT_THROW(Fed1->requestTime(3.0), helics::InvalidFunctionCall);
 
@@ -938,7 +938,7 @@ TEST(federate_tests, forceErrorFinalizeAsync)
 
     Fed1->enterExecutingMode();
     Fed1->finalizeAsync();
-    Fed1->error(9827);
+    Fed1->localError(9827);
 
     EXPECT_THROW(Fed1->requestTime(3.0), helics::InvalidFunctionCall);
 
@@ -978,7 +978,8 @@ TEST(federate_tests, error_after_disconnect)
         helics::InvalidFunctionCall);
     EXPECT_THROW(
         Fed1->setInfo(helics::interface_handle{0}, "information"), helics::InvalidFunctionCall);
-    EXPECT_THROW(Fed1->error(99), helics::InvalidFunctionCall);
+    EXPECT_THROW(Fed1->localError(99), helics::InvalidFunctionCall);
+    EXPECT_THROW(Fed1->globalError(99), helics::InvalidFunctionCall);
 }
 
 static constexpr const char* simple_global_files[] = {"example_globals1.json",


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will deprecate the error method in the Application_api federate object.  this function is duplicative of localError and `localError` or `globalError` should be used for better control over the error process.  