### PR TITLE
Add info on Windows dependency issues to install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ HELICS is also highly scalable, enabling everything from simple connections betw
 ### Windows
 
 Each [release](https://github.com/GMLC-TDC/HELICS/releases/latest) comes with a Windows installer and zip file containing the HELICS apps and C shared library with Python 3.6 and Java 1.8 interfaces, zip files containing compiled HELICS static libraries built against several MSVC versions, and an archive containing just the C shared library with headers. For building with Debug support it is generally recommended to build from Source or use HELICS as a subproject.
+Make sure the latest [Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) is installed.
 
 ### Conda
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -37,11 +37,12 @@ Use Spack (requires Spack develop branch or versions released after v0.14.1) on 
 spack install helics
 ```
 
-For more information on supported options (e.g. using a custom HELICS build with MPI support), see the [package managers](https://helics.readthedocs.io/en/latest/installation/package_manager.html) page for more details, or the documentation for your package manager.
+For more information on supported options (e.g. using a custom HELICS build with MPI support) and troubleshooting tips, see the [package managers](https://helics.readthedocs.io/en/latest/installation/package_manager.html) page for more details, or the documentation for your package manager.
 
 ### Using an installer for your operating system
 
 Download pre-compiled libraries from the [releases page](https://github.com/GMLC-TDC/HELICS/releases/latest) and add them to your path.
+Windows users should install the latest version of the [Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads).
 The installers come with bindings for Python (3.6), MATLAB, and Java extensions precompiled as part of the installation.
 All you need to do is add the relevant folders to your User's PATH variables.
 

--- a/docs/installation/linking.md
+++ b/docs/installation/linking.md
@@ -19,6 +19,9 @@ If you not using cmake then link against the helics-shared.lib/so/dylib as appro
 
 If you are using CMake and want to use static libraries or use the apps library as a static library then HELICS supports building as a subproject and linking the targets HELICS\::apps or HELICS::application-api.  
 
+## Troubleshooting shared library errors on Windows
+If you encounter an error along the lines of `DLL load failed: The specified module could not be found` when attempting to use the C shared library, it is likely a required system dependency is missing. You can determine which DLL it is unable to find using a tool like https://github.com/lucasg/Dependencies to show which dependencies were not found when attempting to open the helics C shared library DLL. It is fine if it shows it can't find `WS2_32.dll`, but all other DLLs should be found.
+The most likely to be missing is `vcruntime140_1.dll`, which can be fixed by downloading the latest Visual C++ Redistributable from https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads and installing it.
 
 ## Summary
 

--- a/docs/installation/package_manager.md
+++ b/docs/installation/package_manager.md
@@ -50,3 +50,8 @@ To enable or disable options, use `+`, `-`, and `~`. For example, to build with 
 spack install helics +mpi
 ```
 
+## Troubleshooting shared library errors on Windows
+If you encounter an error along the lines of `DLL load failed: The specified module could not be found` when attempting to use the C shared library installed by a package manager, it is likely a required system dependency is missing. You can determine which DLL it is unable to find using a tool like https://github.com/lucasg/Dependencies to see what dependency is missing for the helics C shared library DLL. It is fine if it shows it can't find `WS2_32.dll`, but all other DLLs should be found.
+The most likely to be missing is `vcruntime140_1.dll`, which can be fixed by downloading the latest Visual C++ Redistributable from https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads and installing it.
+
+


### PR DESCRIPTION
### Summary
If merged this pull request will add a few notes saying to make sure the latest Visual C++ Redistributable is installed in the Windows installers/package manager docs, and a blurb on a tool to use for troubleshooting Windows dependency issues with the HELICS shared library.

Based on debugging dependency problem in #1139.

### Proposed changes
- Add links to Visual C++ Redistributable
- Add Windows shared library troubleshooting blurb
