### PR TITLE
sporadic websocket failure fix

### DIFF
--- a/tests/helics/webserver/webServerWebSocketTests.cpp
+++ b/tests/helics/webserver/webServerWebSocketTests.cpp
@@ -56,7 +56,7 @@ class webTest: public ::testing::Test {
 
         // These objects perform our I/O
         tcp::resolver resolver(ioc);
-        stream = std::make_unique<websocket::stream<tcp::socket>>(ioc);
+        stream = std::make_unique<websocket::stream<tcp::socket>>(ioc); //NOLINT
 
         // Look up the domain name
         auto const results = resolver.resolve(localhost, "26247");
@@ -87,7 +87,7 @@ class webTest: public ::testing::Test {
         stream.reset();
     }
 
-    std::string sendText(const std::string& message)
+    static std::string sendText(const std::string& message)
     {
         // Send the message
         stream->write(net::buffer(message));
@@ -132,7 +132,7 @@ class webTest: public ::testing::Test {
         helics::BrokerFactory::cleanUpBrokers();
     }
     // You can define per-test tear-down logic as usual.
-    virtual void TearDown() {}
+    virtual void TearDown() override {}
 
   private:
     // Some expensive resource shared by all tests.

--- a/tests/helics/webserver/webServerWebSocketTests.cpp
+++ b/tests/helics/webserver/webServerWebSocketTests.cpp
@@ -247,7 +247,15 @@ TEST_F(webTest, core)
     auto result = sendText(generateJsonString(query));
     EXPECT_FALSE(result.empty());
     auto val = loadJson(result);
-    EXPECT_EQ(val["cores"].size(), 1U);
+    if (val["cores"].empty()) {
+        // on occasion the core might not be registered with the broker in low CPU count systems
+        // so we need to wait.
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        result = sendText(generateJsonString(query));
+        EXPECT_FALSE(result.empty());
+        val = loadJson(result);
+    }
+    ASSERT_EQ(val["cores"].size(), 1U);
     EXPECT_STREQ(val["cores"][0]["name"].asCString(), "cr1");
 
     query["target"] = "cr1";

--- a/tests/helics/webserver/webServerWebSocketTests.cpp
+++ b/tests/helics/webserver/webServerWebSocketTests.cpp
@@ -132,7 +132,7 @@ class webTest: public ::testing::Test {
         helics::BrokerFactory::cleanUpBrokers();
     }
     // You can define per-test tear-down logic as usual.
-    virtual void TearDown() override {}
+    void TearDown() final {}
 
   private:
     // Some expensive resource shared by all tests.


### PR DESCRIPTION
The http sporadic failure can also occur in the websocket test program so needs the same fix as PR #1250

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will fix a sporadic failure in the websocket server tests.  This has only been observed once, but that could be because the HTTP test would often fail in the same circumstances.  
