### PR TITLE
Use Python 3.8 for release builds

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -78,10 +78,10 @@ jobs:
         ref: develop
       if: github.event_name == 'schedule'
       
-    # Build with Python 3.6 interface
+    # Build with Python 3.8 interface
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.8'
         architecture: ${{ matrix.arch }}
         
     # Compile HELICS and create the installer
@@ -154,11 +154,11 @@ jobs:
         ref: develop
       if: github.event_name == 'schedule'
       
-    # Build with Python 3.6 interface
+    # Build with Python 3.8 interface
     - uses: actions/setup-python@v1
       if: runner.os != 'Linux'
       with:
-        python-version: '3.6'
+        python-version: '3.8'
         architecture: ${{ matrix.arch }}
  
     # Setup a copy of the macOS SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Everything within a major version number should be code compatible (with the exc
 ### Changed
 
 - All ZeroMQ related files are now located in the network library and under a single namespace
+- Use Python 3.8 instead of 3.6 for any release build installers that include a copy of the Python interface (`pip` or `anaconda` are the recommended ways to install the Python interface)
 
 ### Fixed
 


### PR DESCRIPTION
### Summary
If merged this pull request will swap Python 3.6 for Python 3.8 in the release build workflow. Theoretically addresses #1290, but not the recommended way to install (requires users to manually figure out how to setup search paths for loading the package).

### Proposed changes
- Use Python 3.8 instead of Python 3.6 in release builds
