### PR TITLE
Missing message functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Everything within a major version number should be code compatible (with the exc
 - A helics::zmq target was added for linking with zeromq if using HELICS as a subproject
 - A `HELICS_BENCHMARK_SHIFT_FACTOR` CMake option was added to allow the benchmarks to scale depending on computational resources
 - "version" and "version_all" queries to get the local version string and the version strings of all the cores/brokers in the federation
-- a few missing operations to the C++98 interface for Message objects, add `helicsMessageClone` and `helicsEndpointCreateMessage` functions in the C interface. Add a test case for some of the C++98 message operations.
+- A few missing operations to the C++98 interface for Message objects, add `helicsMessageClone` and `helicsEndpointCreateMessage` functions in the C interface. Add a test case for some of the C++98 message operations.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Everything within a major version number should be code compatible (with the exc
 - A helics::zmq target was added for linking with zeromq if using HELICS as a subproject
 - A `HELICS_BENCHMARK_SHIFT_FACTOR` CMake option was added to allow the benchmarks to scale depending on computational resources
 - "version" and "version_all" queries to get the local version string and the version strings of all the cores/brokers in the federation
-- a few missing operations to the C++98 interface for Message objects, add `helicsMessageClone` and `helicsEndpointCreateMessage` functions in the C interface.  Add a test case for some of the C++98 message operations.  
+- a few missing operations to the C++98 interface for Message objects, add `helicsMessageClone` and `helicsEndpointCreateMessage` functions in the C interface. Add a test case for some of the C++98 message operations.
 
 ### Deprecated
 

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -25,17 +25,20 @@ class Message {
     explicit Message(helics_message_object hmo) HELICS_NOTHROW: mo(hmo) {}
 
     /** copy constructor*/
-    Message(const Message& mess) HELICS_NOTHROW: mo(helicsMessageClone(mess.mo, HELICS_IGNORE_ERROR)) {}
+    Message(const Message& mess) HELICS_NOTHROW:
+        mo(helicsMessageClone(mess.mo, HELICS_IGNORE_ERROR))
+    {
+    }
     /** copy assignment*/
     Message& operator=(const Message& mess) HELICS_NOTHROW
     {
-        if (mo!=HELICS_NULL_POINTER) {
+        if (mo != HELICS_NULL_POINTER) {
             helicsMessageFree(mo);
         }
         mo = helicsMessageClone(mess.mo, HELICS_IGNORE_ERROR);
         return *this;
     }
-#    ifdef HELICS_HAS_RVALUE_REFS
+#ifdef HELICS_HAS_RVALUE_REFS
     /** copy constructor*/
     Message(Message&& mess) HELICS_NOTHROW: mo(mess.release()) {}
     /** copy assignment*/
@@ -65,7 +68,7 @@ class Message {
         return *this;
     }
     /** set the message source*/
-    Message& source(const char *src)
+    Message& source(const char* src)
     {
         helicsMessageSetSource(mo, src, hThrowOnError());
         return *this;
@@ -79,12 +82,13 @@ class Message {
         return *this;
     }
     /** set the message destination */
-    Message& destination(const char * dest)
+    Message& destination(const char* dest)
     {
         helicsMessageSetDestination(mo, dest, hThrowOnError());
         return *this;
     }
-    /** get the original message source which may be different than source if the message was filtered */
+    /** get the original message source which may be different than source if the message was
+     * filtered */
     const char* originalSource() const { return helicsMessageGetOriginalSource(mo); }
     /** set the original source field*/
     Message& originalSource(const std::string& osrc)
@@ -104,7 +108,8 @@ class Message {
     int size() const { return helicsMessageGetRawDataSize(mo); }
     /** set the size of the message data field*/
     void resize(int newSize) { helicsMessageResize(mo, newSize, hThrowOnError()); }
-    /** reserve a certain amount of size in the message data field which is useful for the append operation*/
+    /** reserve a certain amount of size in the message data field which is useful for the append
+     * operation*/
     void reserve(int newSize) { helicsMessageReserve(mo, newSize, hThrowOnError()); }
     /** get a pointer to the raw data field*/
     void* data() const { return helicsMessageGetRawDataPointer(mo); }
@@ -127,7 +132,7 @@ class Message {
         return *this;
     }
     /** append data to the message data field*/
-     Message& append(const void* raw, int size)
+    Message& append(const void* raw, int size)
     {
         helicsMessageAppendData(mo, raw, size, hThrowOnError());
         return *this;
@@ -149,12 +154,13 @@ class Message {
         return *this;
     }
     /** set an indexed flag in the message*/
-    Message& setFlag(int flag,bool val) { helicsMessageSetFlagOption(mo, flag,val?helics_true:helics_false,hThrowOnError());
+    Message& setFlag(int flag, bool val)
+    {
+        helicsMessageSetFlagOption(mo, flag, val ? helics_true : helics_false, hThrowOnError());
         return *this;
     }
     /** check an indexed flag in the message valid numbers are [0,15]*/
-    bool checkFlag(int flag) const { return (helicsMessageCheckFlag(mo, flag) == helics_true);
-    }
+    bool checkFlag(int flag) const { return (helicsMessageCheckFlag(mo, flag) == helics_true); }
     /** get the messageID*/
     int messageID() const { return helicsMessageGetMessageID(mo); }
     /** set the messageID field of a message object*/
@@ -165,14 +171,15 @@ class Message {
     }
     /** release a C message_object from the structure
     @details for use with the C shared library*/
-    helics_message_object release() { 
+    helics_message_object release()
+    {
         helics_message_object mreturn = mo;
         mo = HELICS_NULL_POINTER;
         return mreturn;
     }
 
   private:
-    helics_message_object mo; //!< C shared library message_object
+    helics_message_object mo;  //!< C shared library message_object
 };
 
 /** Class to manage helics endpoint operations*/
@@ -215,7 +222,7 @@ class Endpoint {
     /** Get a packet from an endpoint **/
     Message getMessage() { return Message(helicsEndpointGetMessageObject(ep)); }
 
-     /** create a message object */
+    /** create a message object */
     Message createMessage()
     {
         return Message(helicsEndpointCreateMessageObject(ep, hThrowOnError()));
@@ -354,7 +361,7 @@ class Endpoint {
         // returns helicsStatus
         helicsEndpointSendMessageObject(ep, message, hThrowOnError());
     }
-#    ifdef HELICS_HAS_RVALUE_REFS
+#ifdef HELICS_HAS_RVALUE_REFS
     /** send a message object
      */
     void sendMessage(Message&& message)
@@ -362,13 +369,15 @@ class Endpoint {
         // returns helicsStatus
         helicsEndpointSendMessageObjectZeroCopy(ep, message.release(), hThrowOnError());
     }
-#endif 
-        /** send a message object
+#endif
+    /** send a message object
      */
     void sendMessageZeroCopy(Message& message)
     {
         // returns helicsStatus
-        helicsEndpointSendMessageObjectZeroCopy(ep, static_cast<helics_message_object>(message), hThrowOnError());
+        helicsEndpointSendMessageObjectZeroCopy(ep,
+                                                static_cast<helics_message_object>(message),
+                                                hThrowOnError());
         message.release();
     }
     /** get the name of the endpoint*/

--- a/src/helics/cpp98/MessageFederate.hpp
+++ b/src/helics/cpp98/MessageFederate.hpp
@@ -98,7 +98,7 @@ class MessageFederate: public virtual Federate {
 
     /** Get a packet for any endpoints in the federate **/
     Message getMessage() { return Message(helicsFederateGetMessageObject(fed)); }
-    
+
     /** create a message object */
     Message createMessage()
     {

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -272,12 +272,11 @@ HELICS_DEPRECATED_EXPORT helics_message helicsEndpointGetMessage(helics_endpoint
  */
 HELICS_EXPORT helics_message_object helicsEndpointGetMessageObject(helics_endpoint endpoint);
 
-
 /**
  * Create a new empty message object.
  *
  * @details The message is empty and isValid will return false since there is no data associated with the message yet.
- * 
+ *
  * @param fed the endpoint object to associate the message with
  * @forcpponly
  * @param[in,out] err An error object to fill out in case of an error.
@@ -697,7 +696,6 @@ HELICS_EXPORT void helicsMessageAppendData(helics_message_object message, const 
  */
 HELICS_EXPORT void helicsMessageCopy(helics_message_object source_message, helics_message_object dest_message, helics_error* err);
 
-
 /**
  * Clone a message object.
  *
@@ -709,11 +707,11 @@ HELICS_EXPORT void helicsMessageCopy(helics_message_object source_message, helic
 HELICS_EXPORT helics_message_object helicsMessageClone(helics_message_object message, helics_error* err);
 
 /**
-* Free a message object from memory
-* @details memory for message is managed so not using this function does not create memory leaks, this is an indication
-* to the system that the memory for this message is done being used and can be reused for a new message.  
-* helicsFederateclearMessages() can also be used to clear up all stored messages at once
-*/
+ * Free a message object from memory
+ * @details memory for message is managed so not using this function does not create memory leaks, this is an indication
+ * to the system that the memory for this message is done being used and can be reused for a new message.
+ * helicsFederateclearMessages() can also be used to clear up all stored messages at once
+ */
 HELICS_EXPORT void helicsMessageFree(helics_message_object message);
 
 /**@}*/

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -710,7 +710,7 @@ HELICS_EXPORT helics_message_object helicsMessageClone(helics_message_object mes
  * Free a message object from memory
  * @details memory for message is managed so not using this function does not create memory leaks, this is an indication
  * to the system that the memory for this message is done being used and can be reused for a new message.
- * helicsFederateclearMessages() can also be used to clear up all stored messages at once
+ * helicsFederateClearMessages() can also be used to clear up all stored messages at once
  */
 HELICS_EXPORT void helicsMessageFree(helics_message_object message);
 

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -1010,7 +1010,7 @@ void helicsMessageCopy(helics_message_object source_message, helics_message_obje
     mess_dest->flags = mess_src->flags;
 }
 
-helics_message_object helicsMessageClone(helics_message_object message,  helics_error* err)
+helics_message_object helicsMessageClone(helics_message_object message, helics_error* err)
 {
     auto* mess = getMessageObj(message, err);
     if (mess == nullptr) {
@@ -1021,8 +1021,8 @@ helics_message_object helicsMessageClone(helics_message_object message,  helics_
         assignError(err, helics_error_invalid_argument, emptyMessageErrorString);
         return nullptr;
     }
-    auto* mess_clone=messages->newMessage();
-          
+    auto* mess_clone = messages->newMessage();
+
     mess_clone->data = mess->data;
     mess_clone->dest = mess->dest;
     mess_clone->original_source = mess->original_source;

--- a/tests/helics/shared_library/test-message-federate_cpp.cpp
+++ b/tests/helics/shared_library/test-message-federate_cpp.cpp
@@ -116,12 +116,11 @@ TEST_F(mfed_tests, Message)
     mFed2->enterExecutingMode();
     mFed1->enterExecutingModeComplete();
 
-    auto m1=epid.createMessage();
+    auto m1 = epid.createMessage();
     std::string data(500, 'a');
     m1.data(data).time(0.0).destination("ep2");
     epid.sendMessage(m1);
     epid.sendMessageZeroCopy(m1);
-
 
     mFed1->requestTimeAsync(2.0);
     helics_time time = mFed2->requestTime(1.0);
@@ -129,8 +128,8 @@ TEST_F(mfed_tests, Message)
     EXPECT_EQ(time, 1.0);
 
     auto cnt = epid2.pendingMessages();
-    EXPECT_EQ(cnt,2U);
-    
+    EXPECT_EQ(cnt, 2U);
+
     auto M1 = epid2.getMessage();
     auto M2 = epid2.getMessage();
     EXPECT_STREQ(M1.c_str(), M2.c_str());
@@ -151,10 +150,8 @@ TEST_F(mfed_tests, Message)
 
     helicscpp::Message M5(std::move(M3));
 
-     EXPECT_EQ(M5.messageID(), M4.messageID());
+    EXPECT_EQ(M5.messageID(), M4.messageID());
     EXPECT_STREQ(M5.source(), M4.source());
-    EXPECT_FALSE(M3.isValid()); // NOLINT
+    EXPECT_FALSE(M3.isValid());  // NOLINT
     mFed1->finalize();
-    
 }
-


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will add some missing functions to the C++98 interface for message operations

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add missing operations to the C++98 interface
- add `helicsEndpointCreateMessage`
- add `helicsMessageClone`
- add `helicsMessageFree`
