### PR TITLE
Fix some issues with the exists query not working on core or brokers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Everything within a major version number should be code compatible (with the exc
 - A `HELICS_BENCHMARK_SHIFT_FACTOR` CMake option was added to allow the benchmarks to scale depending on computational resources
 - "version" and "version_all" queries to get the local version string and the version strings of all the cores/brokers in the federation
 - A few missing operations to the C++98 interface for Message objects, add `helicsMessageClone` and `helicsEndpointCreateMessage` functions in the C interface. Add a test case for some of the C++98 message operations.
+- `helicsQuerySetTarget` and `helicsQuerySetQueryString` operations to modify an existing query in the C interface
 
 ### Deprecated
 

--- a/src/helics/application_api/Federate.cpp
+++ b/src/helics/application_api/Federate.cpp
@@ -1078,7 +1078,7 @@ query_id_t Federate::queryAsync(const std::string& queryStr)
     return query_id_t(cnt);
 }
 
-std::string Federate::queryComplete(query_id_t queryIndex)
+std::string Federate::queryComplete(query_id_t queryIndex)  // NOLINT
 {
     auto asyncInfo = asyncCallInfo->lock();
     auto fnd = asyncInfo->inFlightQueries.find(queryIndex.value());

--- a/src/helics/application_api/Federate.cpp
+++ b/src/helics/application_api/Federate.cpp
@@ -1024,7 +1024,7 @@ std::string Federate::query(const std::string& queryStr)
         if (coreObject) {
             res = coreObject->getIdentifier();
         } else {
-            res = "#unknown";
+            res = "#disconnected";
         }
     } else if (queryStr == "time") {
         res = std::to_string(currentTime);
@@ -1035,7 +1035,7 @@ std::string Federate::query(const std::string& queryStr)
         if (coreObject) {
             res = coreObject->query(getName(), queryStr);
         } else {
-            res = "#unknown";
+            res = "#disconnected";
         }
     }
     return res;
@@ -1050,7 +1050,7 @@ std::string Federate::query(const std::string& target, const std::string& queryS
         if (coreObject) {
             res = coreObject->query(target, queryStr);
         } else {
-            res = "#invalid";
+            res = "#disconnected";
         }
     }
     return res;

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -517,7 +517,7 @@ class HELICS_CXX_EXPORT Federate {
     /** get the federate name*/
     const std::string& getName() const { return name; }
     /** get a shared pointer to the core object used by the federate*/
-    const std::shared_ptr<Core> &getCorePointer() { return coreObject; }
+    const std::shared_ptr<Core>& getCorePointer() { return coreObject; }
     // interface for filter objects
     /** get a count of the number of filter objects stored in the federate*/
     int filterCount() const;

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -516,8 +516,8 @@ class HELICS_CXX_EXPORT Federate {
     Time getCurrentTime() const { return currentTime; }
     /** get the federate name*/
     const std::string& getName() const { return name; }
-    /** get a pointer to the core object used by the federate*/
-    std::shared_ptr<Core> getCorePointer() { return coreObject; }
+    /** get a shared pointer to the core object used by the federate*/
+    const std::shared_ptr<Core> &getCorePointer() { return coreObject; }
     // interface for filter objects
     /** get a count of the number of filter objects stored in the federate*/
     int filterCount() const;

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2340,7 +2340,7 @@ std::string CommonCore::query(const std::string& target, const std::string& quer
                             activeQueries.finishedWithValue(index);
                             return ret;
                         }
-                    }
+                    } break;
                     default:
                         status = std::future_status::ready;  // LCOV_EXCL_LINE
                 }

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2042,7 +2042,7 @@ std::string CommonCore::quickCoreQueries(const std::string& queryStr) const
     if (queryStr == "isconnected") {
         return (isConnected()) ? "true" : "false";
     }
-    if (queryStr == "name" || queryStr=="identifier") {
+    if (queryStr == "name" || queryStr == "identifier") {
         return getIdentifier();
     }
     if (queryStr == "exists") {
@@ -2298,7 +2298,7 @@ std::string CommonCore::query(const std::string& target, const std::string& quer
     querycmd.messageID = index;
     querycmd.setStringData(target);
 
-    if (target == "core" || target == getIdentifier()||target.empty()) {
+    if (target == "core" || target == getIdentifier() || target.empty()) {
         auto res = quickCoreQueries(queryStr);
         if (!res.empty()) {
             return res;

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2005,12 +2005,12 @@ std::string CommonCore::filteredEndpointQuery(const FederateState* fed) const
 std::string CommonCore::federateQuery(const FederateState* fed, const std::string& queryStr) const
 {
     if (fed == nullptr) {
-        if ((queryStr == "exists") || (queryStr == "exist")) {
+        if (queryStr == "exists") {
             return "false";
         }
         return "#invalid";
     }
-    if ((queryStr == "exists") || (queryStr == "exist")) {
+    if (queryStr == "exists") {
         return "true";
     }
     if (queryStr == "version") {
@@ -2036,14 +2036,17 @@ std::string CommonCore::federateQuery(const FederateState* fed, const std::strin
 std::string CommonCore::quickCoreQueries(const std::string& queryStr) const
 {
     if ((queryStr == "queries") || (queryStr == "available_queries")) {
-        return "[isinit;isconnected;name;address;queries;address;federates;inputs;endpoints;filtered_endpoints;"
+        return "[isinit;isconnected;exists;name;identifier;address;queries;address;federates;inputs;endpoints;filtered_endpoints;"
                "publications;filters;version;version_all;federate_map;dependency_graph;data_flow_graph;dependencies;dependson;dependents;current_time;global_time;current_state]";
     }
     if (queryStr == "isconnected") {
         return (isConnected()) ? "true" : "false";
     }
-    if (queryStr == "name") {
+    if (queryStr == "name" || queryStr=="identifier") {
         return getIdentifier();
+    }
+    if (queryStr == "exists") {
+        return "true";
     }
     if (queryStr == "version") {
         return versionString;
@@ -2279,7 +2282,7 @@ std::string CommonCore::coreQuery(const std::string& queryStr) const
 std::string CommonCore::query(const std::string& target, const std::string& queryStr)
 {
     if (brokerState.load() >= broker_state_t::terminating) {
-        if ((target == "core") || (target == getIdentifier())) {
+        if (target == "core" || target == getIdentifier() || target.empty()) {
             auto res = quickCoreQueries(queryStr);
             if (!res.empty()) {
                 return res;
@@ -2295,16 +2298,13 @@ std::string CommonCore::query(const std::string& target, const std::string& quer
     querycmd.messageID = index;
     querycmd.setStringData(target);
 
-    if ((target == "core") || (target == getIdentifier())) {
+    if (target == "core" || target == getIdentifier()||target.empty()) {
         auto res = quickCoreQueries(queryStr);
         if (!res.empty()) {
             return res;
         }
         if (queryStr == "address") {
             return getAddress();
-        }
-        if (queryStr == "version") {
-            return versionString;
         }
         querycmd.setAction(CMD_BROKER_QUERY);
         querycmd.dest_id = direct_core_id;

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2668,7 +2668,7 @@ void CoreBroker::processLocalQuery(const ActionMessage& m)
 }
 
 /** check for fed queries that can be answered by the broker*/
-std::string CoreBroker::checkFedQuery(const BasicFedInfo& fed, const std::string& query)
+static std::string checkFedQuery(const BasicFedInfo& fed, const std::string& query)
 {
     std::string response;
     if (query == "exists") {
@@ -2691,7 +2691,7 @@ else if (query == "isinit")
     return response;
 }
 /** check for broker queries that can be answered by the broker*/
-std::string CoreBroker::checkBrokerQuery(const BasicBrokerInfo& brk, const std::string& query)
+static std::string checkBrokerQuery(const BasicBrokerInfo& brk, const std::string& query)
 {
     std::string response;
     if (query == "exists") {

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2681,7 +2681,10 @@ static std::string checkFedQuery(const BasicFedInfo& fed, const std::string& que
     } else if (query == "state") {
         response = state_string(fed.state);
     } else if (query == "isinit") {
-        response = (fed.state >= connection_state::operating) ? "true" : "false";
+        if (fed.state >= connection_state::operating) {
+            response = "true";
+            // if it is false we need to actually go check the federate directly
+        }
     }
     return response;
 }
@@ -2699,7 +2702,10 @@ static std::string checkBrokerQuery(const BasicBrokerInfo& brk, const std::strin
     } else if (query == "state") {
         response = state_string(brk.state);
     } else if (query == "isinit") {
-        response = (brk.state >= connection_state::operating) ? "true" : "false";
+        if (brk.state >= connection_state::operating) {
+            response = "true";
+            // if it is false we need to actually go check the federate directly
+        }
     }
     return response;
 }

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2677,9 +2677,16 @@ std::string CoreBroker::checkFedQuery(const BasicFedInfo& fed, const std::string
                     fed.state <= connection_state::operating) ?
             "true" :
             "false";
-    } else if (query == "state" || query=="current_state") {
+    } else if (query == "state" ) {
         response = state_string(fed.state);
     }
+else if (query == "isinit")
+{
+    response =
+        (fed.state >= connection_state::operating) ?
+        "true" :
+        "false";
+}
     return response;
 }
 /** check for broker queries that can be answered by the broker*/
@@ -2693,8 +2700,10 @@ std::string CoreBroker::checkBrokerQuery(const BasicBrokerInfo& brk, const std::
             (brk.state >= connection_state::connected && brk.state <= connection_state::operating) ?
             "true" :
             "false";
-    } else if (query == "state" || query == "current_state") {
+    } else if (query == "state" ) {
         response = state_string(brk.state);
+    } else if (query == "isinit") {
+        response = (brk.state >= connection_state::operating) ? "true" : "false";
     }
     return response;
 }
@@ -2764,7 +2773,7 @@ void CoreBroker::processQuery(ActionMessage& m)
         if (((route == parent_route_id) && (isRootc))||!response.empty()) {
             if (response.empty())
             {
-                response = "#invald";
+                response = "#invalid";
             }
             ActionMessage queryResp(CMD_QUERY_REPLY);
             queryResp.dest_id = m.source_id;

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2323,7 +2323,7 @@ void CoreBroker::setLogFile(const std::string& lfile)
 std::string CoreBroker::query(const std::string& target, const std::string& queryStr)
 {
     auto gid = global_id.load();
-    if ((target == "broker") || (target == getIdentifier())) {
+    if (target == "broker" || target == getIdentifier()||target.empty()) {
         ActionMessage querycmd(CMD_BROKER_QUERY);
         querycmd.source_id = querycmd.dest_id = gid;
         auto index = ++queryCounter;
@@ -2414,13 +2414,16 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
     if (request == "isconnected") {
         return (isConnected()) ? std::string("true") : std::string("false");
     }
-    if (request == "name") {
+    if (request == "name" || request=="identifier") {
         return getIdentifier();
     }
+    if (request == "exists" ) {
+        return "true";
+    }
     if ((request == "queries") || (request == "available_queries")) {
-        return "[isinit;isconnected;name;address;queries;address;counts;summary;federates;brokers;inputs;endpoints;"
+        return "[isinit;isconnected;name;identifier;address;queries;address;counts;summary;federates;brokers;inputs;endpoints;"
                "publications;filters;federate_map;dependency_graph;data_flow_graph;dependencies;dependson;dependents;"
-               "current_time;current_state;global_time;version;version_all]";
+               "current_time;current_state;global_time;version;version_all;exists]";
     }
     if (request == "address") {
         return getAddress();

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2730,7 +2730,7 @@ void CoreBroker::processQuery(ActionMessage& m)
             queryResp.source_id = global_broker_id_local;
             queryResp.messageID = m.messageID;
 
-            queryResp.payload = "#invalid";
+            queryResp.payload = (m.payload=="exists")?"false":"#invalid";
             if (queryResp.dest_id == global_broker_id_local) {
                 activeQueries.setDelayedValue(m.messageID, queryResp.payload);
             } else {

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2323,7 +2323,7 @@ void CoreBroker::setLogFile(const std::string& lfile)
 std::string CoreBroker::query(const std::string& target, const std::string& queryStr)
 {
     auto gid = global_id.load();
-    if (target == "broker" || target == getIdentifier()||target.empty()) {
+    if (target == "broker" || target == getIdentifier() || target.empty()) {
         ActionMessage querycmd(CMD_BROKER_QUERY);
         querycmd.source_id = querycmd.dest_id = gid;
         auto index = ++queryCounter;
@@ -2414,10 +2414,10 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
     if (request == "isconnected") {
         return (isConnected()) ? std::string("true") : std::string("false");
     }
-    if (request == "name" || request=="identifier") {
+    if (request == "name" || request == "identifier") {
         return getIdentifier();
     }
-    if (request == "exists" ) {
+    if (request == "exists") {
         return "true";
     }
     if ((request == "queries") || (request == "available_queries")) {
@@ -2730,7 +2730,7 @@ void CoreBroker::processQuery(ActionMessage& m)
             queryResp.source_id = global_broker_id_local;
             queryResp.messageID = m.messageID;
 
-            queryResp.payload = (m.payload=="exists")?"false":"#invalid";
+            queryResp.payload = (m.payload == "exists") ? "false" : "#invalid";
             if (queryResp.dest_id == global_broker_id_local) {
                 activeQueries.setDelayedValue(m.messageID, queryResp.payload);
             } else {

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -316,10 +316,6 @@ class CoreBroker: public Broker, public BrokerBase {
     void removeNamedTarget(ActionMessage& command);
     /** answer a query or route the message the appropriate location*/
     void processQuery(ActionMessage& m);
-    /** check for fed queries that can be answered by the broker*/
-    std::string checkFedQuery(const BasicFedInfo& fed, const std::string& query);
-    /** check for broker queries that can be answered by the broker*/
-    std::string checkBrokerQuery(const BasicBrokerInfo& brk, const std::string& query);
 
     /** answer a query or route the message the appropriate location*/
     void processQueryResponse(const ActionMessage& m);

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -316,6 +316,11 @@ class CoreBroker: public Broker, public BrokerBase {
     void removeNamedTarget(ActionMessage& command);
     /** answer a query or route the message the appropriate location*/
     void processQuery(ActionMessage& m);
+    /** check for fed queries that can be answered by the broker*/
+    std::string checkFedQuery(const BasicFedInfo& fed, const std::string& query);
+    /** check for broker queries that can be answered by the broker*/
+    std::string checkBrokerQuery(const BasicBrokerInfo& brk, const std::string& query);
+
     /** answer a query or route the message the appropriate location*/
     void processQueryResponse(const ActionMessage& m);
     /** generate an answer to a local query*/

--- a/src/helics/cpp98/Broker.hpp
+++ b/src/helics/cpp98/Broker.hpp
@@ -138,11 +138,11 @@ class Broker {
     }
 
     /** make a query of the broker
-  @details this call is blocking until the value is returned which make take some time depending
+  @details this call is blocking until the value is returned which may take some time depending
   on the size of the federation and the specific string being queried
   @param target  the target of the query can be "federation", "federate", "broker", "core", or a
   specific name of a federate, core, or broker
-  @param queryStr a string with the query see other documentation for specific properties to
+  @param queryStr a string with the query, see other documentation for specific properties to
   query, can be defined by the federate
   @return a string with the value requested.  this is either going to be a vector of strings value
   or a JSON string stored in the first element of the vector.  The string "#invalid" is returned

--- a/src/helics/cpp98/Broker.hpp
+++ b/src/helics/cpp98/Broker.hpp
@@ -137,17 +137,17 @@ class Broker {
                                                    hThrowOnError());
     }
 
-     /** make a query of the broker
-   @details this call is blocking until the value is returned which make take some time depending
-   on the size of the federation and the specific string being queried
-   @param target  the target of the query can be "federation", "federate", "broker", "core", or a
-   specific name of a federate, core, or broker
-   @param queryStr a string with the query see other documentation for specific properties to
-   query, can be defined by the federate
-   @return a string with the value requested.  this is either going to be a vector of strings value
-   or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
-   if the query was not valid
-   */
+    /** make a query of the broker
+  @details this call is blocking until the value is returned which make take some time depending
+  on the size of the federation and the specific string being queried
+  @param target  the target of the query can be "federation", "federate", "broker", "core", or a
+  specific name of a federate, core, or broker
+  @param queryStr a string with the query see other documentation for specific properties to
+  query, can be defined by the federate
+  @return a string with the value requested.  this is either going to be a vector of strings value
+  or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
+  if the query was not valid
+  */
     std::string query(const std::string& target, const std::string& queryStr) const
     {
         // returns helics_query

--- a/src/helics/cpp98/Broker.hpp
+++ b/src/helics/cpp98/Broker.hpp
@@ -137,6 +137,26 @@ class Broker {
                                                    hThrowOnError());
     }
 
+     /** make a query of the broker
+   @details this call is blocking until the value is returned which make take some time depending
+   on the size of the federation and the specific string being queried
+   @param target  the target of the query can be "federation", "federate", "broker", "core", or a
+   specific name of a federate, core, or broker
+   @param queryStr a string with the query see other documentation for specific properties to
+   query, can be defined by the federate
+   @return a string with the value requested.  this is either going to be a vector of strings value
+   or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
+   if the query was not valid
+   */
+    std::string query(const std::string& target, const std::string& queryStr) const
+    {
+        // returns helics_query
+        helics_query q = helicsCreateQuery(target.c_str(), queryStr.c_str());
+        std::string result(helicsQueryBrokerExecute(q, broker, hThrowOnError()));
+        helicsQueryFree(q);
+        return result;
+    }
+
   protected:
     helics_broker broker;  //!< underlying broker information
 };

--- a/src/helics/cpp98/Core.hpp
+++ b/src/helics/cpp98/Core.hpp
@@ -32,7 +32,7 @@ class Core {
         core = helicsCreateCoreFromArgs(type.c_str(), name.c_str(), argc, argv, hThrowOnError());
     }
     /** construct a core from a core pointer */
-    Core(helics_core cr) HELICS_NOTHROW: core(cr) {}
+    explicit Core(helics_core cr) HELICS_NOTHROW: core(cr) {}
 
     /** destructor*/
     ~Core() { helicsCoreFree(core); }

--- a/src/helics/cpp98/Core.hpp
+++ b/src/helics/cpp98/Core.hpp
@@ -31,6 +31,9 @@ class Core {
     {
         core = helicsCreateCoreFromArgs(type.c_str(), name.c_str(), argc, argv, hThrowOnError());
     }
+    /** construct a core from a core pointer */
+    Core(helics_core cr) HELICS_NOTHROW: core(cr) {}
+
     /** destructor*/
     ~Core() { helicsCoreFree(core); }
     /** implicit operator so the object can be used with the c api functions natively*/
@@ -118,6 +121,25 @@ class Core {
         helicsCoreSetGlobal(core, valueName.c_str(), value.c_str(), hThrowOnError());
     }
 
+       /** make a query of the core
+@details this call is blocking until the value is returned which make take some time depending
+on the size of the federation and the specific string being queried
+@param target  the target of the query can be "federation", "federate", "broker", "core", or a
+specific name of a federate, core, or broker
+@param queryStr a string with the query see other documentation for specific properties to
+query, can be defined by the federate
+@return a string with the value requested.  this is either going to be a vector of strings value
+or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
+if the query was not valid
+*/
+    std::string query(const std::string& target, const std::string& queryStr) const
+    {
+        // returns helics_query
+        helics_query q = helicsCreateQuery(target.c_str(), queryStr.c_str());
+        std::string result(helicsQueryCoreExecute(q, core, hThrowOnError()));
+        helicsQueryFree(q);
+        return result;
+    }
   protected:
     helics_core core;  //!< reference to the underlying core object
 };

--- a/src/helics/cpp98/Core.hpp
+++ b/src/helics/cpp98/Core.hpp
@@ -122,11 +122,11 @@ class Core {
     }
 
     /** make a query of the core
-@details this call is blocking until the value is returned which make take some time depending
+@details this call is blocking until the value is returned which may take some time depending
 on the size of the federation and the specific string being queried
 @param target  the target of the query can be "federation", "federate", "broker", "core", or a
 specific name of a federate, core, or broker
-@param queryStr a string with the query see other documentation for specific properties to
+@param queryStr a string with the query, see other documentation for specific properties to
 query, can be defined by the federate
 @return a string with the value requested.  this is either going to be a vector of strings value
 or a JSON string stored in the first element of the vector.  The string "#invalid" is returned

--- a/src/helics/cpp98/Core.hpp
+++ b/src/helics/cpp98/Core.hpp
@@ -121,7 +121,7 @@ class Core {
         helicsCoreSetGlobal(core, valueName.c_str(), value.c_str(), hThrowOnError());
     }
 
-       /** make a query of the core
+    /** make a query of the core
 @details this call is blocking until the value is returned which make take some time depending
 on the size of the federation and the specific string being queried
 @param target  the target of the query can be "federation", "federate", "broker", "core", or a
@@ -140,6 +140,7 @@ if the query was not valid
         helicsQueryFree(q);
         return result;
     }
+
   protected:
     helics_core core;  //!< reference to the underlying core object
 };

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -449,7 +449,8 @@ class Federate {
 
     /** make a query of the federate
     @details this call is blocking until the value is returned which make take some time depending
-    on the size of the federation and the specific string being queried, query without a target assumes the target is the federate
+    on the size of the federation and the specific string being queried, query without a target
+    assumes the target is the federate
 
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
@@ -589,8 +590,8 @@ class Federate {
         helicsFederateLogLevelMessage(fed, level, message.c_str(), hThrowOnError());
     }
     /** get a Core Object*/
-    helics_core getCore() { return helicsFederateGetCoreObject(fed, hThrowOnError());
-    }
+    helics_core getCore() { return helicsFederateGetCoreObject(fed, hThrowOnError()); }
+
   protected:
     helics_federate fed;  //!< underlying helics_federate object
     bool exec_async_iterate;  //!< indicator that the federate is in an async operation

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -448,11 +448,11 @@ class Federate {
     }
 
     /** make a query of the federate
-    @details this call is blocking until the value is returned which make take some time depending
+    @details this call is blocking until the value is returned which may take some time depending
     on the size of the federation and the specific string being queried, query without a target
     assumes the target is the federate
 
-    @param queryStr a string with the query see other documentation for specific properties to
+    @param queryStr a string with the query, see other documentation for specific properties to
     query, can be defined by the federate
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -426,7 +426,8 @@ class Federate {
     }
     /** get the federate name*/
     const char* getName() const { return helicsFederateGetName(fed); }
-    /** make a query of the core
+
+    /** make a query of the federate
     @details this call is blocking until the value is returned which make take some time depending
     on the size of the federation and the specific string being queried
     @param target  the target of the query can be "federation", "federate", "broker", "core", or a
@@ -445,6 +446,26 @@ class Federate {
         helicsQueryFree(q);
         return result;
     }
+
+    /** make a query of the federate
+    @details this call is blocking until the value is returned which make take some time depending
+    on the size of the federation and the specific string being queried, query without a target assumes the target is the federate
+
+    @param queryStr a string with the query see other documentation for specific properties to
+    query, can be defined by the federate
+    @return a string with the value requested.  this is either going to be a vector of strings value
+    or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
+    if the query was not valid
+    */
+    std::string query(const std::string& queryStr) const
+    {
+        // returns helics_query
+        helics_query q = helicsCreateQuery(HELICS_NULL_POINTER, queryStr.c_str());
+        std::string result(helicsQueryExecute(q, fed, hThrowOnError()));
+        helicsQueryFree(q);
+        return result;
+    }
+
     /** define a filter interface
     @details a filter will modify messages coming from or going to target endpoints
     @param type the type of the filter to register
@@ -567,7 +588,9 @@ class Federate {
     {
         helicsFederateLogLevelMessage(fed, level, message.c_str(), hThrowOnError());
     }
-
+    /** get a Core Object*/
+    helics_core getCore() { return helicsFederateGetCoreObject(fed, hThrowOnError());
+    }
   protected:
     helics_federate fed;  //!< underlying helics_federate object
     bool exec_async_iterate;  //!< indicator that the federate is in an async operation

--- a/src/helics/shared_api_library/helics.h
+++ b/src/helics/shared_api_library/helics.h
@@ -1467,6 +1467,29 @@ HELICS_EXPORT const char* helicsQueryExecuteComplete(helics_query query, helics_
 HELICS_EXPORT helics_bool helicsQueryIsCompleted(helics_query query);
 
 /**
+ * Update the target of a query.
+ *
+ * @param query The query object to change the target of.
+ * @param target the name of the target to query
+ *
+ * @forcpponly
+ * @param[in,out] err An error object that will contain an error code and string if any error occurred during the execution of the function.
+ * @endforcpponly
+ */
+HELICS_EXPORT void helicsQuerySetTarget(helics_query query, const char* target, helics_error* err);
+
+/**
+ * Update the queryString of a query.
+ *
+ * @param query The query object to change the target of.
+ * @param queryString the new queryString
+ * @forcpponly
+ * @param[in,out] err An error object that will contain an error code and string if any error occurred during the execution of the function.
+ * @endforcpponly
+ */
+HELICS_EXPORT void helicsQuerySetQueryString(helics_query query, const char* queryString, helics_error* err);
+
+/**
  * Free the memory associated with a query object.
  */
 HELICS_EXPORT void helicsQueryFree(helics_query query);

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -944,6 +944,22 @@ helics_bool helicsQueryIsCompleted(helics_query query)
     return helics_false;
 }
 
+void helicsQuerySetTarget(helics_query query, const char* target, helics_error* err) {
+    auto* queryObj = getQueryObj(query, err);
+    if (queryObj == nullptr) {
+        return ;
+    }
+    queryObj->target = AS_STRING(target);
+}
+
+void helicsQuerySetQueryString(helics_query query, const char* queryString, helics_error* err) {
+    auto* queryObj = getQueryObj(query, err);
+    if (queryObj == nullptr) {
+        return;
+    }
+    queryObj->query = AS_STRING(queryString);
+}
+
 void helicsQueryFree(helics_query query)
 {
     auto* queryObj = getQueryObj(query, nullptr);

--- a/tests/helics/shared_library/CMakeLists.txt
+++ b/tests/helics/shared_library/CMakeLists.txt
@@ -31,7 +31,8 @@ set(cpp_shared_library_test_sources
     test-value-federate2_cpp.cpp
     # FilterTests_cpp.cpp
     test-message-federate_cpp.cpp
-    # FederateTests.cpp TimingTests.cpp iterationTests.cpp subPubObjectTests.cpp QueryTests.cpp
+    # FederateTests.cpp TimingTests.cpp iterationTests.cpp subPubObjectTests.cpp 
+    QueryTests_cpp.cpp
 )
 
 add_executable(

--- a/tests/helics/shared_library/CMakeLists.txt
+++ b/tests/helics/shared_library/CMakeLists.txt
@@ -31,7 +31,7 @@ set(cpp_shared_library_test_sources
     test-value-federate2_cpp.cpp
     # FilterTests_cpp.cpp
     test-message-federate_cpp.cpp
-    # FederateTests.cpp TimingTests.cpp iterationTests.cpp subPubObjectTests.cpp 
+    # FederateTests.cpp TimingTests.cpp iterationTests.cpp subPubObjectTests.cpp
     QueryTests_cpp.cpp
 )
 

--- a/tests/helics/shared_library/QueryTests_cpp.cpp
+++ b/tests/helics/shared_library/QueryTests_cpp.cpp
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2017-2020,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable
+Energy, LLC.  See the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "../src/helics/cpp98/Broker.hpp"
+#include "../src/helics/cpp98/Core.hpp"
+#include "../src/helics/cpp98/MessageFederate.hpp"
+#include "cpptestFixtures.hpp"
+
+#include <gtest/gtest.h>
+
+struct query_tests: public FederateTestFixture_cpp, public ::testing::Test {
+};
+
+TEST_F(query_tests, exists)
+{
+    SetupTest<helicscpp::MessageFederate>("test_2", 2, 1.0);
+    auto mFed1 = GetFederateAs<helicscpp::MessageFederate>(0);
+    auto mFed2 = GetFederateAs<helicscpp::MessageFederate>(1);
+
+    mFed1->registerEndpoint("ept1");
+    mFed2->registerEndpoint("ept2");
+
+    mFed1->enterExecutingModeAsync();
+    mFed2->enterExecutingMode();
+    mFed1->enterExecutingModeComplete();
+
+    mFed1->requestTimeAsync(1.0);
+    mFed2->requestTime(1.0);
+    mFed1->requestTimeComplete();
+    auto res = mFed1->query("exists");
+    EXPECT_EQ(res, "true");
+
+    res = mFed1->query(mFed2->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+    auto core1 = helicscpp::Core(mFed1->getCore());
+
+    res = mFed1->query(core1.getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = mFed1->query(helicscpp::Core(mFed2->getCore()).getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    auto& brk = brokers.front();
+    res = mFed1->query(brk->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query(mFed1->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query(mFed2->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query("root", "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query(core1.getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query(helicscpp::Core(mFed2->getCore()).getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = core1.query(brk->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = core1.query(mFed1->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = core1.query(mFed2->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = core1.query("root", "exists");
+    EXPECT_EQ(res, "true");
+
+    res = core1.query(core1.getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = core1.query(helicscpp::Core(mFed2->getCore()).getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    mFed1->finalize();
+    mFed2->finalize();
+
+    core1.waitForDisconnect();
+}

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -342,13 +342,13 @@ TEST_F(query, exists)
     res = mFed1->query(brk->getIdentifier(), "exists");
     EXPECT_EQ(res, "true");
 
-    res= brk->query(mFed1->getName(), "exists");
+    res = brk->query(mFed1->getName(), "exists");
     EXPECT_EQ(res, "true");
 
-     res = brk->query(mFed2->getName(), "exists");
+    res = brk->query(mFed2->getName(), "exists");
     EXPECT_EQ(res, "true");
 
-     res = brk->query("root", "exists");
+    res = brk->query("root", "exists");
     EXPECT_EQ(res, "true");
 
     res = brk->query(mFed1->getCorePointer()->getIdentifier(), "exists");
@@ -356,7 +356,6 @@ TEST_F(query, exists)
 
     res = brk->query(mFed2->getCorePointer()->getIdentifier(), "exists");
     EXPECT_EQ(res, "true");
-
 
     res = brk->query("unknown_fed", "exists");
     EXPECT_EQ(res, "false");
@@ -366,7 +365,6 @@ TEST_F(query, exists)
     mFed1->finalize();
     mFed2->finalize();
 }
-
 
 TEST_F(query, current_state)
 {

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -310,6 +310,64 @@ TEST_F(query, version)
     mFed2->finalize();
 }
 
+TEST_F(query, exists)
+{
+    SetupTest<helics::MessageFederate>("test_3", 2);
+    auto mFed1 = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed2 = GetFederateAs<helics::MessageFederate>(1);
+
+    mFed1->registerEndpoint("ept1");
+    mFed2->registerEndpoint("ept2");
+
+    mFed1->enterExecutingModeAsync();
+    mFed2->enterExecutingMode();
+    mFed1->enterExecutingModeComplete();
+
+    mFed1->requestTimeAsync(1.0);
+    mFed2->requestTime(1.0);
+    mFed1->requestTimeComplete();
+    auto res = mFed1->query("exists");
+    EXPECT_EQ(res, "true");
+
+    res = mFed1->query(mFed2->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = mFed1->query(mFed1->getCorePointer()->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = mFed1->query(mFed2->getCorePointer()->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    auto brk = brokers.front();
+    res = mFed1->query(brk->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res= brk->query(mFed1->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+     res = brk->query(mFed2->getName(), "exists");
+    EXPECT_EQ(res, "true");
+
+     res = brk->query("root", "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query(mFed1->getCorePointer()->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+    res = brk->query(mFed2->getCorePointer()->getIdentifier(), "exists");
+    EXPECT_EQ(res, "true");
+
+
+    res = brk->query("unknown_fed", "exists");
+    EXPECT_EQ(res, "false");
+
+    res = mFed1->getCorePointer()->query("unknown_fed", "exists");
+
+    mFed1->finalize();
+    mFed2->finalize();
+}
+
+
 TEST_F(query, current_state)
 {
     SetupTest<helics::ValueFederate>("test_2", 2);


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->
### Summary
<!-- please finish the following statement -->
If merged this pull request will add some exists queries to the core and broker and make them work a little cleaner.  

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- add some tests to for the exists queries in the C++ and C++98 interfaces.
- add query operations to the Core and Broker Classes in the C++98 API. 
- change the getCorePointer() method in the C++ federate to return a reference instead of a new shared pointer to allow it to be copied if needed and just used as a reference if not.  
