### PR TITLE
(Modified) Watts-Strogatz Benchmark

### DIFF
--- a/benchmarks/.clang-tidy
+++ b/benchmarks/.clang-tidy
@@ -19,8 +19,8 @@ bugprone-*,
 -bugprone-narrowing-conversions,
 cert-*,
 -cert-err58-cpp,
--cert-msc32-c
--cert-msc51-cpp
+-cert-msc32-c,
+-cert-msc51-cpp,
 portability-*,
 readability-*,
 -readability-magic-numbers,

--- a/benchmarks/.clang-tidy
+++ b/benchmarks/.clang-tidy
@@ -19,6 +19,8 @@ bugprone-*,
 -bugprone-narrowing-conversions,
 cert-*,
 -cert-err58-cpp,
+-cert-msc32-c
+-cert-msc51-cpp
 portability-*,
 readability-*,
 -readability-magic-numbers,

--- a/benchmarks/helics/BenchmarkMain.cpp
+++ b/benchmarks/helics/BenchmarkMain.cpp
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "RingTransmitMessageFederate.hpp"
 #include "TimingHubFederate.hpp"
 #include "TimingLeafFederate.hpp"
+#include "WattsStrogatzFederate.hpp"
 #include "helics/core/helicsCLI11.hpp"
 
 #include <chrono>
@@ -55,6 +56,7 @@ int main(int argc, char* argv[])
 
     addBM<TimingHub>(app, "timinghub", "Timing Hub benchmark federate");
     addBM<TimingLeaf>(app, "timingleaf", "Timing Leaf benchmark federate");
+    addBM<WattsStrogatzFederate>(app, "watts-strogatz", "Watts-Strogatz benchmark federate");
 
     auto ret = app.helics_parse(argc, argv);
     if (ret != helics::helicsCLI11App::parse_output::ok) {

--- a/benchmarks/helics/BenchmarkMain.cpp
+++ b/benchmarks/helics/BenchmarkMain.cpp
@@ -27,14 +27,15 @@ std::shared_ptr<BenchmarkFederate> fed;
 template<class T>
 void addBM(helics::helicsCLI11App& app, std::string name, std::string description)
 {
- try {
-    app.add_subcommand(std::move(name), std::move(description))
-        ->callback([]() { fed = std::make_shared<T>(); })
-        ->footer([] {
-            T().initialize("", "--help");
-            return std::string{};
-        });
-} catch (...) {
+    try {
+        app.add_subcommand(std::move(name), std::move(description))
+            ->callback([]() { fed = std::make_shared<T>(); })
+            ->footer([] {
+                T().initialize("", "--help");
+                return std::string{};
+            });
+    }
+    catch (...) {
         std::cerr << "Exception when adding CLI11 subcommand occurred\n";
         exit(1);
     }
@@ -43,15 +44,18 @@ void addBM(helics::helicsCLI11App& app, std::string name, std::string descriptio
 int main(int argc, char* argv[])
 {
     try {
-        helics::helicsCLI11App app("HELICS benchmark federates for use in multinode benchmark setups",
-                                   "helics_benchmarks");
+        helics::helicsCLI11App app(
+            "HELICS benchmark federates for use in multinode benchmark setups",
+            "helics_benchmarks");
         app.ignore_case()->prefix_command()->ignore_underscore();
         addBM<EchoHub>(app, "echohub", "Echo Hub benchmark federate");
         addBM<EchoLeaf>(app, "echoleaf", "Echo Leaf benchmark federate");
         addBM<EchoMessageHub>(app, "echomessagehub", "Echo Message Hub benchmark federate");
         addBM<EchoMessageLeaf>(app, "echomessageleaf", "Echo Message Leaf benchmark federate");
 
-        addBM<MessageExchangeFederate>(app, "messageexchange", "Message Exchange benchmark federate");
+        addBM<MessageExchangeFederate>(app,
+                                       "messageexchange",
+                                       "Message Exchange benchmark federate");
 
         addBM<PholdFederate>(app, "phold", "PHOLD benchmark federate");
 
@@ -63,47 +67,48 @@ int main(int argc, char* argv[])
         addBM<TimingHub>(app, "timinghub", "Timing Hub benchmark federate");
         addBM<TimingLeaf>(app, "timingleaf", "Timing Leaf benchmark federate");
         addBM<WattsStrogatzFederate>(app, "watts-strogatz", "Watts-Strogatz benchmark federate");
-    
 
-    auto ret = app.helics_parse(argc, argv);
-    if (ret != helics::helicsCLI11App::parse_output::ok) {
-        switch (ret) {
-            case helics::helicsCLI11App::parse_output::help_call:
-            case helics::helicsCLI11App::parse_output::help_all_call:
-            case helics::helicsCLI11App::parse_output::version_call:
-                return 0;
-            default:
-                return static_cast<int>(ret);
+        auto ret = app.helics_parse(argc, argv);
+        if (ret != helics::helicsCLI11App::parse_output::ok) {
+            switch (ret) {
+                case helics::helicsCLI11App::parse_output::help_call:
+                case helics::helicsCLI11App::parse_output::help_all_call:
+                case helics::helicsCLI11App::parse_output::version_call:
+                    return 0;
+                default:
+                    return static_cast<int>(ret);
+            }
         }
+
+        helics::FederateInfo fi;
+        int rc = fed->initialize(fi, app.remaining_for_passthrough(true));
+        if (rc != 0) {
+            exit(rc);
+        }
+
+        // setup benchmark timing
+        std::chrono::time_point<std::chrono::steady_clock> start_time;
+        std::chrono::time_point<std::chrono::steady_clock> end_time;
+        fed->setBeforeFinalizeCallback(
+            [&end_time]() { end_time = std::chrono::steady_clock::now(); });
+
+        // run the benchmark
+        try {
+            fed->run([&start_time]() { start_time = std::chrono::steady_clock::now(); });
+        }
+        catch (...) {
+            std::cerr << "Exception occurred while running the benchmark\n";
+            exit(1);
+        }
+
+        // print duration
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
+        fed->addResult<decltype(elapsed)>("ELAPSED TIME (ns)", "real_time", elapsed);
+        fed->printResults();
     }
-
-    helics::FederateInfo fi;
-    int rc = fed->initialize(fi, app.remaining_for_passthrough(true));
-    if (rc != 0) {
-        exit(rc);
-    }
-
-    // setup benchmark timing
-    std::chrono::time_point<std::chrono::steady_clock> start_time;
-    std::chrono::time_point<std::chrono::steady_clock> end_time;
-    fed->setBeforeFinalizeCallback([&end_time]() { end_time = std::chrono::steady_clock::now(); });
-
-    // run the benchmark
-    try {
-        fed->run([&start_time]() { start_time = std::chrono::steady_clock::now(); });
-    } catch(...) {
-        std::cerr << "Exception occurred while running the benchmark\n";
-        exit(1);
-    }
-
-    // print duration
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
-    fed->addResult<decltype(elapsed)>("ELAPSED TIME (ns)", "real_time", elapsed);
-    fed->printResults();
-    } catch (...) {
+    catch (...) {
         std::cerr << "Uncaught exception occurred\n";
         exit(1);
     }
-        
 }

--- a/benchmarks/helics/BenchmarkMain.cpp
+++ b/benchmarks/helics/BenchmarkMain.cpp
@@ -42,6 +42,7 @@ void addBM(helics::helicsCLI11App& app, std::string name, std::string descriptio
 
 int main(int argc, char* argv[])
 {
+    try {
         helics::helicsCLI11App app("HELICS benchmark federates for use in multinode benchmark setups",
                                    "helics_benchmarks");
         app.ignore_case()->prefix_command()->ignore_underscore();
@@ -100,6 +101,9 @@ int main(int argc, char* argv[])
         std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
     fed->addResult<decltype(elapsed)>("ELAPSED TIME (ns)", "real_time", elapsed);
     fed->printResults();
-
+    } catch (...) {
+        std::cerr << "Uncaught exception occurred\n";
+        exit(1);
+    }
         
 }

--- a/benchmarks/helics/BenchmarkMain.cpp
+++ b/benchmarks/helics/BenchmarkMain.cpp
@@ -27,17 +27,21 @@ std::shared_ptr<BenchmarkFederate> fed;
 template<class T>
 void addBM(helics::helicsCLI11App& app, std::string name, std::string description)
 {
+ try {
     app.add_subcommand(std::move(name), std::move(description))
         ->callback([]() { fed = std::make_shared<T>(); })
         ->footer([] {
             T().initialize("", "--help");
             return std::string{};
         });
+} catch (...) {
+        std::cerr << "Exception when adding CLI11 subcommand occurred\n";
+        exit(1);
+    }
 }
 
 int main(int argc, char* argv[])
 {
-    try {
         helics::helicsCLI11App app("HELICS benchmark federates for use in multinode benchmark setups",
                                    "helics_benchmarks");
         app.ignore_case()->prefix_command()->ignore_underscore();
@@ -58,10 +62,7 @@ int main(int argc, char* argv[])
         addBM<TimingHub>(app, "timinghub", "Timing Hub benchmark federate");
         addBM<TimingLeaf>(app, "timingleaf", "Timing Leaf benchmark federate");
         addBM<WattsStrogatzFederate>(app, "watts-strogatz", "Watts-Strogatz benchmark federate");
-    } catch (...) {
-        std::cerr << "Exception setting up CLI11 parser\n";
-        exit(1);
-    }
+    
 
     auto ret = app.helics_parse(argc, argv);
     if (ret != helics::helicsCLI11App::parse_output::ok) {
@@ -94,4 +95,6 @@ int main(int argc, char* argv[])
         std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
     fed->addResult<decltype(elapsed)>("ELAPSED TIME (ns)", "real_time", elapsed);
     fed->printResults();
+
+        
 }

--- a/benchmarks/helics/BenchmarkMain.cpp
+++ b/benchmarks/helics/BenchmarkMain.cpp
@@ -88,7 +88,12 @@ int main(int argc, char* argv[])
     fed->setBeforeFinalizeCallback([&end_time]() { end_time = std::chrono::steady_clock::now(); });
 
     // run the benchmark
-    fed->run([&start_time]() { start_time = std::chrono::steady_clock::now(); });
+    try {
+        fed->run([&start_time]() { start_time = std::chrono::steady_clock::now(); });
+    } catch(...) {
+        std::cerr << "Exception occurred while running the benchmark\n";
+        exit(1);
+    }
 
     // print duration
     auto elapsed =

--- a/benchmarks/helics/BenchmarkMain.cpp
+++ b/benchmarks/helics/BenchmarkMain.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<BenchmarkFederate> fed;
 template<class T>
 void addBM(helics::helicsCLI11App& app, std::string name, std::string description)
 {
-    app.add_subcommand(name, description)
+    app.add_subcommand(std::move(name), std::move(description))
         ->callback([]() { fed = std::make_shared<T>(); })
         ->footer([] {
             T().initialize("", "--help");
@@ -37,26 +37,31 @@ void addBM(helics::helicsCLI11App& app, std::string name, std::string descriptio
 
 int main(int argc, char* argv[])
 {
-    helics::helicsCLI11App app("HELICS benchmark federates for use in multinode benchmark setups",
-                               "helics_benchmarks");
-    app.ignore_case()->prefix_command()->ignore_underscore();
-    addBM<EchoHub>(app, "echohub", "Echo Hub benchmark federate");
-    addBM<EchoLeaf>(app, "echoleaf", "Echo Leaf benchmark federate");
-    addBM<EchoMessageHub>(app, "echomessagehub", "Echo Message Hub benchmark federate");
-    addBM<EchoMessageLeaf>(app, "echomessageleaf", "Echo Message Leaf benchmark federate");
+    try {
+        helics::helicsCLI11App app("HELICS benchmark federates for use in multinode benchmark setups",
+                                   "helics_benchmarks");
+        app.ignore_case()->prefix_command()->ignore_underscore();
+        addBM<EchoHub>(app, "echohub", "Echo Hub benchmark federate");
+        addBM<EchoLeaf>(app, "echoleaf", "Echo Leaf benchmark federate");
+        addBM<EchoMessageHub>(app, "echomessagehub", "Echo Message Hub benchmark federate");
+        addBM<EchoMessageLeaf>(app, "echomessageleaf", "Echo Message Leaf benchmark federate");
 
-    addBM<MessageExchangeFederate>(app, "messageexchange", "Message Exchange benchmark federate");
+        addBM<MessageExchangeFederate>(app, "messageexchange", "Message Exchange benchmark federate");
 
-    addBM<PholdFederate>(app, "phold", "PHOLD benchmark federate");
+        addBM<PholdFederate>(app, "phold", "PHOLD benchmark federate");
 
-    addBM<RingTransmit>(app, "ringtransmit", "Ring Transmit benchmark federate");
-    addBM<RingTransmitMessage>(app,
-                               "ringtransmitmessage",
-                               "Ring Transmit Message benchmark federate");
+        addBM<RingTransmit>(app, "ringtransmit", "Ring Transmit benchmark federate");
+        addBM<RingTransmitMessage>(app,
+                                   "ringtransmitmessage",
+                                   "Ring Transmit Message benchmark federate");
 
-    addBM<TimingHub>(app, "timinghub", "Timing Hub benchmark federate");
-    addBM<TimingLeaf>(app, "timingleaf", "Timing Leaf benchmark federate");
-    addBM<WattsStrogatzFederate>(app, "watts-strogatz", "Watts-Strogatz benchmark federate");
+        addBM<TimingHub>(app, "timinghub", "Timing Hub benchmark federate");
+        addBM<TimingLeaf>(app, "timingleaf", "Timing Leaf benchmark federate");
+        addBM<WattsStrogatzFederate>(app, "watts-strogatz", "Watts-Strogatz benchmark federate");
+    } catch (...) {
+        std::cerr << "Exception setting up CLI11 parser\n";
+        exit(1);
+    }
 
     auto ret = app.helics_parse(argc, argv);
     if (ret != helics::helicsCLI11App::parse_output::ok) {
@@ -77,7 +82,8 @@ int main(int argc, char* argv[])
     }
 
     // setup benchmark timing
-    std::chrono::time_point<std::chrono::steady_clock> start_time, end_time;
+    std::chrono::time_point<std::chrono::steady_clock> start_time;
+    std::chrono::time_point<std::chrono::steady_clock> end_time;
     fed->setBeforeFinalizeCallback([&end_time]() { end_time = std::chrono::steady_clock::now(); });
 
     // run the benchmark

--- a/benchmarks/helics/CMakeLists.txt
+++ b/benchmarks/helics/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HELICS_BENCHMARKS
     messageSendBenchmarks
     pholdBenchmarks
     timingBenchmarks
+    wattsStrogatzBenchmarks
 )
 
 set(HELICS_MULTINODE_BENCHMARKS
@@ -32,6 +33,7 @@ set(HELICS_MULTINODE_BENCHMARKS
     EchoMessageLeafFederate
     TimingHubFederate
     TimingLeafFederate
+    WattsStrogatzFederate
 )
 
 if(NOT DEFINED HELICS_BENCHMARK_SHIFT_FACTOR)

--- a/benchmarks/helics/PholdFederate.hpp
+++ b/benchmarks/helics/PholdFederate.hpp
@@ -46,8 +46,6 @@ class PholdFederate: public BenchmarkFederate {
     std::uniform_int_distribution<unsigned int> rand_uniform_int;
 
   public:
-    // TODO(@nightlark): output cluster name in a summary file, along with node count and feds per
-    // node
     PholdFederate(): BenchmarkFederate("PHOLD") {}
 
     // functions for setting parameters
@@ -57,16 +55,6 @@ class PholdFederate: public BenchmarkFederate {
     void setInitialEventCount(unsigned int count) { initEvCount_ = count; }
     void setLocalProbability(double p) { localProbability_ = p; }
     void setLookahead(double v) { lookahead_ = v; }
-
-    // functions for setting callbacks
-    void setBeforeFinalizeCallback(std::function<void()> cb = nullptr)
-    {
-        callBeforeFinalize = std::move(cb);
-    }
-    void setAfterFinalizeCallback(std::function<void()> cb = nullptr)
-    {
-        callAfterFinalize = std::move(cb);
-    }
 
     std::string getName() override { return "phold_" + std::to_string(index); }
 

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -50,10 +50,10 @@ class WattsStrogatzFederate: public BenchmarkFederate {
     WattsStrogatzFederate(): BenchmarkFederate("WattsStrogatzFederate") {}
 
     // functions for setting parameters
-    void setGenerateRandomSeed(bool b) { generateRandomSeed = b; };
-    void setRandomSeed(unsigned int s) { seed = s; };
-    void setDegree(int val) { k = val; };
-    void setRewireProbability(double val) { b = val; };
+    void setGenerateRandomSeed(bool b) { generateRandomSeed = b; }
+    void setRandomSeed(unsigned int s) { seed = s; }
+    void setDegree(int val) { k = val; }
+    void setRewireProbability(double val) { b = val; }
 
     std::string getName() override { return getNameForIndex(index); }
     std::string getNameForIndex(int i) { return "watts_" + std::to_string(i); }
@@ -113,8 +113,8 @@ class WattsStrogatzFederate: public BenchmarkFederate {
 
     void doFedInit() override
     {
-        // Construct the Watts-Strogatz graph,
-        // for benchmark setup reasons from within the Federates, it is a directed graph (typically
+        // Construct the Watts-Strogatz graph.
+        // For benchmark setup reasons from within the Federates, it is a directed graph (typically
         // it is undirected). The doParamInit check on k < maxIndex - 1 ensures that currentEdges
         // and availableEdges will not include our own index, avoiding self-loops.
         std::vector<unsigned int> currentEdges;

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -1,0 +1,194 @@
+/*
+Copyright (c) 2017-2020,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable
+Energy, LLC.  See the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include "BenchmarkFederate.hpp"
+#include "helics/application_api/Endpoints.hpp"
+#include "helics/application_api/MessageFederate.hpp"
+#include "helics/core/ActionMessage.hpp"
+
+#include <algorithm>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+/** class implementing a Watts-Strogatz-like communication pattern with messages*/
+class WattsStrogatzFederate: public BenchmarkFederate {
+  public:
+    int initialMessageCount{20}; // number of messages the federate should send when it starts (too high results in lower degrees being slower than high, possibly queue or buffer related for a socket, and can make the udp benchmark hang indefinitely)
+
+    // A typical Watts-Strogatz graph uses degree K for total connections to neighbors, K/2 on each side.
+    // Since this requires more coordination to setup than is easily done from within Federates, this
+    // simplified version has each node setup the connectiosn on its right side only (so k=K/2 in this benchmark)
+    int k{1}; // degree
+    double b{0}; // re-wire probability for each of k rightmost neighbors
+
+    // Classes related to the exponential and uniform distribution random number generator
+    bool generateRandomSeed{false};
+    unsigned int seed{0xABad5eed}; // suggestions for seed choice were not having a majority of the bits as 0 is better
+    std::mt19937 rand_gen;
+    std::exponential_distribution<double> rand_exp;
+    std::uniform_real_distribution<double> rand_rewire;
+    std::uniform_int_distribution<unsigned int> rand_available_link;
+    std::uniform_int_distribution<unsigned int> rand_transmit_link;
+
+  private:
+    helics::Endpoint* ept{nullptr};
+    std::vector<std::string> links; // links to other federates
+
+  public:
+    WattsStrogatzFederate(): BenchmarkFederate("WattsStrogatzFederate") {}
+
+    // functions for setting parameters
+    void setGenerateRandomSeed(bool b) { generateRandomSeed = b; };
+    void setRandomSeed(unsigned int s) { seed = s; };
+    void setDegree(int val) { k = val; };
+    void setRewireProbability(double val) { b = val; };
+
+    std::string getName() override { return getNameForIndex(index); }
+    std::string getNameForIndex(int i) { return "watts_" + std::to_string(i); }
+
+    void setupArgumentParsing() override
+    {
+        deltaTime = helics::Time(10, time_units::ns);
+        finalTime = helics::Time(2500, time_units::ns);
+
+        app->add_flag("--gen_rand_seed", generateRandomSeed, "enable generating a random seed");
+        app->add_option("--set_rand_seed", seed, "set the random seed");
+        app->add_option("--degree", k, "set the degree (K/2), the number of edges to the right of each node");
+        app->add_option("--rewire_probability", b, "set the probability of rewiring an edge");
+        app->add_option("--initial_message_count", initialMessageCount, "the initial number of messages this federate should send");
+        opt_index->required();
+        opt_max_index->required();
+    }
+
+    void doParamInit(helics::FederateInfo& /*fi*/) override
+    {
+        if (k < 1 || k > maxIndex - 1) {
+            std::cerr << "ERROR: Degree can't be less than 1 or more than the federate count - 1" << std::endl;
+            exit(1);
+        }
+
+        if (app->get_option("--set_rand_seed")->count() == 0) {
+            std::mt19937 random_engine(0x600d5eed);
+            std::uniform_int_distribution<unsigned int> rand_seed_uniform;
+            for (int i = 0; i < index; i++) {
+                rand_seed_uniform(random_engine);
+            }
+            setRandomSeed(rand_seed_uniform(random_engine));
+        }
+
+        // set up based on given params
+        // en.cppreference.com/w/cpp/numeric/random/exponential_distribution
+        if (generateRandomSeed) {
+            std::random_device rd;
+            rand_gen.seed(rd());
+        } else {
+            rand_gen.seed(seed);
+        }
+        rand_rewire = std::uniform_real_distribution<double>(0.0, 1.0);
+        // create random number distribution for rewiring links (there are maxIndex-k-2 available links)
+        if (maxIndex-k > 1) {
+            rand_available_link = std::uniform_int_distribution<unsigned int>(0, maxIndex - k - 2);
+        }
+        // create random number distribution for picking a link to transmit on
+        rand_transmit_link = std::uniform_int_distribution<unsigned int>(0, k-1);
+    }
+
+    void doFedInit() override
+    {
+        // Construct the Watts-Strogatz graph,
+        // for benchmark setup reasons from within the Federates, it is a directed graph (typically it is undirected).
+        // The doParamInit check on k < maxIndex - 1 ensures that currentEdges and availableEdges will not include our own index,
+        // avoiding self-loops.
+        std::vector<unsigned int> currentEdges;
+        std::vector<unsigned int> availableEdges;
+        currentEdges.reserve(k);
+        availableEdges.reserve(maxIndex - k - 1);
+
+        // Construct half of a ring lattice
+        for (int i = 1; i <= k; i++) {
+            currentEdges.push_back((index+i)%maxIndex);
+        }
+        
+        // Create the set of links available as rewiring choices
+        for (int i = 1; i <= maxIndex-k-1; i++) {
+            auto edge = index - i;
+            if (edge < 0) {
+                edge += maxIndex;
+            }
+            availableEdges.push_back(edge);
+        }
+
+        // Re-wire links
+        if (!availableEdges.empty()) {
+            for (unsigned int i = 0; i < currentEdges.size(); i++) {
+                // Decide if the link should be rewired or not
+                if (rand_rewire(rand_gen) < b) {
+                    // Criteria for the new link:
+                    // 1. Avoid self-loops
+                    // 2. Avoid duplication with links that exist at this point in the algorithm
+                    
+                    // Pick a new link from the available edges
+                    auto newLink = rand_available_link(rand_gen);
+
+                    // Swap current link with available edge
+                    auto tmp = availableEdges[newLink];
+                    availableEdges[newLink] = currentEdges[i];
+                    currentEdges[i] = tmp;
+                } else {
+                    // No link rewiring for this link
+                }
+            }
+        }
+
+        // Confirm one last time that the number of edges matches the degree
+        if (currentEdges.size() != static_cast<unsigned int>(k)) {
+            std::cerr << "ERROR: The number of edges doesn't match the degree\n";
+            exit(1);
+        }
+
+        // Setup list of connected edges based on currentEdges set
+        links.reserve(k);
+        for (unsigned int i = 0; i < currentEdges.size(); i++) {
+            links.push_back(getNameForIndex(currentEdges[i]) + "/ept");
+        }
+
+        // Create endpoint for our federate
+        ept = &fed->registerEndpoint("ept");
+    }
+
+    void doMakeReady() override
+    {
+        // send initial messages
+        std::string txstring(100, '1');
+        for (int i; i < initialMessageCount; i++) {
+            helics::Time evTime = fed->getCurrentTime() + deltaTime;
+            ept->send(links[rand_transmit_link(rand_gen)], txstring, evTime);
+        }
+    }
+
+    void doMainLoop() override
+    {
+        std::string txstring(100, '1');
+        auto nextTime = helics::timeZero;
+
+        while (nextTime < finalTime) {
+            nextTime = fed->requestTime(finalTime);
+            while (ept->hasMessage()) {
+                // Pick a random link to pass the message along
+                auto transmit_link = links[rand_transmit_link(rand_gen)];
+                auto m = fed->getMessage(*ept);
+                m->dest = transmit_link;
+                m->source = ept->getName();
+                m->time = fed->getCurrentTime() + deltaTime;
+                ept->send(std::move(m));
+            }
+        }
+    }
+};

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -167,7 +167,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
         // Setup list of connected edges based on currentEdges set
         links.reserve(k);
         for (auto edgeIndex : currentEdges) {
-            links.push_back(getNameForIndex(currentEdges[i]) + "/ept");
+            links.push_back(getNameForIndex(edgeIndex) + "/ept");
         }
 
         // Create endpoint for our federate

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -56,7 +56,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
     void setRewireProbability(double val) { b = val; }
 
     std::string getName() override { return getNameForIndex(index); }
-    std::string getNameForIndex(int i) { return "watts_" + std::to_string(i); }
+    static std::string getNameForIndex(int i) { return "watts_" + std::to_string(i); }
 
     void setupArgumentParsing() override
     {
@@ -138,7 +138,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
 
         // Re-wire links
         if (!availableEdges.empty()) {
-            for (unsigned int i = 0; i < currentEdges.size(); i++) {
+            for (unsigned int i = 0; i < currentEdges.size(); i++) { // NOLINT(modernize-loop-convert)
                 // Decide if the link should be rewired or not
                 if (rand_rewire(rand_gen) < b) {
                     // Criteria for the new link:
@@ -166,7 +166,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
 
         // Setup list of connected edges based on currentEdges set
         links.reserve(k);
-        for (unsigned int i = 0; i < currentEdges.size(); i++) {
+        for (auto edgeIndex : currentEdges) {
             links.push_back(getNameForIndex(currentEdges[i]) + "/ept");
         }
 

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -178,7 +178,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
     {
         // send initial messages
         std::string txstring(100, '1');
-        for (int i; i < initialMessageCount; i++) {
+        for (int i = 0; i < initialMessageCount; i++) {
             helics::Time evTime = fed->getCurrentTime() + deltaTime;
             ept->send(links[rand_transmit_link(rand_gen)], txstring, evTime);
         }

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -138,7 +138,8 @@ class WattsStrogatzFederate: public BenchmarkFederate {
 
         // Re-wire links
         if (!availableEdges.empty()) {
-            for (unsigned int i = 0; i < currentEdges.size(); i++) { // NOLINT(modernize-loop-convert)
+            // NOLINTNEXTLINE(modernize-loop-convert)
+            for (unsigned int i = 0; i < currentEdges.size(); i++) {
                 // Decide if the link should be rewired or not
                 if (rand_rewire(rand_gen) < b) {
                     // Criteria for the new link:

--- a/benchmarks/helics/WattsStrogatzFederate.hpp
+++ b/benchmarks/helics/WattsStrogatzFederate.hpp
@@ -21,7 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 class WattsStrogatzFederate: public BenchmarkFederate {
   public:
     int initialMessageCount{
-        20};  // number of messages the federate should send when it starts (too high results in
+        10};  // number of messages the federate should send when it starts (too high results in
               // lower degrees being slower than high, possibly queue or buffer related for a
               // socket, and can make the udp benchmark hang indefinitely)
 
@@ -30,10 +30,10 @@ class WattsStrogatzFederate: public BenchmarkFederate {
     // Federates, this simplified version has each node setup the connectiosn on its right side only
     // (so k=K/2 in this benchmark)
     int k{1};  // degree
-    double b{0};  // re-wire probability for each of k rightmost neighbors
+    double b{0.6};  // re-wire probability for each of k rightmost neighbors
 
     // Classes related to the exponential and uniform distribution random number generator
-    bool generateRandomSeed{false};
+    bool generateRandomSeed{true};
     unsigned int seed{0xABad5eed};  // suggestions for seed choice were not having a majority of the
                                     // bits as 0 is better
     std::mt19937 rand_gen;
@@ -61,7 +61,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
     void setupArgumentParsing() override
     {
         deltaTime = helics::Time(10, time_units::ns);
-        finalTime = helics::Time(2500, time_units::ns);
+        finalTime = helics::Time(5000, time_units::ns);
 
         app->add_flag("--gen_rand_seed", generateRandomSeed, "enable generating a random seed");
         app->add_option("--set_rand_seed", seed, "set the random seed");
@@ -160,7 +160,7 @@ class WattsStrogatzFederate: public BenchmarkFederate {
         }
 
         // Confirm one last time that the number of edges matches the degree
-        if (currentEdges.size() != static_cast<unsigned int>(k)) {
+        if (currentEdges.size() != static_cast<size_t>(k)) {
             std::cerr << "ERROR: The number of edges doesn't match the degree\n";
             exit(1);
         }
@@ -187,7 +187,6 @@ class WattsStrogatzFederate: public BenchmarkFederate {
 
     void doMainLoop() override
     {
-        std::string txstring(100, '1');
         auto nextTime = helics::timeZero;
 
         while (nextTime < finalTime) {

--- a/benchmarks/helics/wattsStrogatzBenchmarks.cpp
+++ b/benchmarks/helics/wattsStrogatzBenchmarks.cpp
@@ -19,6 +19,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 using helics::core_type;
 
+static constexpr int64_t maxscale{1 << (4 + HELICS_BENCHMARK_SHIFT_FACTOR)};
+
 // WattsStrogatzArguments sets up parameterized arguments for the multicore benchmark runs.
 // The degree argument has constraints based on the federate count so the Ranges function
 // in google benchmarks can't be used.
@@ -28,7 +30,7 @@ using helics::core_type;
 // p is the rewire probability (0-100) for links between federates.
 static void WattsStrogatzArguments(benchmark::internal::Benchmark* b)
 {
-    for (int f = 2; f <= 16; f *= 2) {
+    for (int f = 2; f <= maxscale; f *= 2) {
         for (int d = 2; d <= f; d *= 2) {
             for (int p = 0; p <= 100; p += 25) {
                 b->Args({f, d - 1, p});

--- a/benchmarks/helics/wattsStrogatzBenchmarks.cpp
+++ b/benchmarks/helics/wattsStrogatzBenchmarks.cpp
@@ -19,10 +19,11 @@ SPDX-License-Identifier: BSD-3-Clause
 
 using helics::core_type;
 
-static void WattsStrogatzArguments(benchmark::internal::Benchmark* b) {
+static void WattsStrogatzArguments(benchmark::internal::Benchmark* b)
+{
     for (int f = 2; f <= 16; f *= 2) {
         for (int d = 2; d <= f; d *= 2) {
-            b->Args({f, d-1});
+            b->Args({f, d - 1});
         }
     }
 }
@@ -41,13 +42,14 @@ static void BM_wattsStrogatz2_singleCore(benchmark::State& state)
 
         std::vector<WattsStrogatzFederate> links(feds);
         for (int ii = 0; ii < feds; ++ii) {
-            std::string bmInit =
-                "--index=" + std::to_string(ii) + " --max_index=" + std::to_string(feds) + " --degree=" + std::to_string(degree);
+            std::string bmInit = "--index=" + std::to_string(ii) +
+                " --max_index=" + std::to_string(feds) + " --degree=" + std::to_string(degree);
             links[ii].initialize(wcore->getIdentifier(), bmInit);
         }
 
-        std::thread rthread([&](WattsStrogatzFederate& link) { link.run([&brr]() { brr.wait(); }); },
-                            std::ref(links[1]));
+        std::thread rthread(
+            [&](WattsStrogatzFederate& link) { link.run([&brr]() { brr.wait(); }); },
+            std::ref(links[1]));
 
         links[0].makeReady();
         brr.wait();
@@ -92,15 +94,15 @@ static void BM_wattsStrogatz_multiCore(benchmark::State& state, core_type cType)
                 std::string("--restrictive_time_policy --federates=1 --broker=" +
                             broker->getIdentifier()));
             cores[ii]->connect();
-            std::string bmInit =
-                "--index=" + std::to_string(ii) + " --max_index=" + std::to_string(feds) + " --degree=" + std::to_string(degree);
+            std::string bmInit = "--index=" + std::to_string(ii) +
+                " --max_index=" + std::to_string(feds) + " --degree=" + std::to_string(degree);
             links[ii].initialize(cores[ii]->getIdentifier(), bmInit);
         }
         std::vector<std::thread> threadlist(feds - 1);
         for (int ii = 0; ii < feds - 1; ++ii) {
-            threadlist[ii] =
-                std::thread([&](WattsStrogatzFederate& link) { link.run([&brr]() { brr.wait(); }); },
-                            std::ref(links[ii + 1]));
+            threadlist[ii] = std::thread(
+                [&](WattsStrogatzFederate& link) { link.run([&brr]() { brr.wait(); }); },
+                std::ref(links[ii + 1]));
         }
 
         links[0].makeReady();

--- a/benchmarks/helics/wattsStrogatzBenchmarks.cpp
+++ b/benchmarks/helics/wattsStrogatzBenchmarks.cpp
@@ -19,7 +19,10 @@ SPDX-License-Identifier: BSD-3-Clause
 
 using helics::core_type;
 
-// This sets up parameterized arguments for the multicore benchmark runs.
+// WattsStrogatzArguments sets up parameterized arguments for the multicore benchmark runs.
+// The degree argument has constraints based on the federate count so the Ranges function
+// in google benchmarks can't be used.
+//
 // f is the number of federates, ranging from 2 to 16 using powers of two.
 // d is the degree (number of outgoing links) for each federate, with a range from 1 to f-1.
 // p is the rewire probability (0-100) for links between federates.

--- a/benchmarks/helics/wattsStrogatzBenchmarks.cpp
+++ b/benchmarks/helics/wattsStrogatzBenchmarks.cpp
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2017-2020,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable
+Energy, LLC.  See the top-level NOTICE for additional details. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "WattsStrogatzFederate.hpp"
+#include "helics/core/BrokerFactory.hpp"
+#include "helics/core/CoreFactory.hpp"
+#include "helics_benchmark_main.h"
+
+#include <benchmark/benchmark.h>
+#include <chrono>
+#include <fstream>
+#include <gmlc/concurrency/Barrier.hpp>
+#include <iostream>
+#include <thread>
+
+using helics::core_type;
+
+static void WattsStrogatzArguments(benchmark::internal::Benchmark* b) {
+    for (int f = 2; f <= 16; f *= 2) {
+        for (int d = 2; d <= f; d *= 2) {
+            b->Args({f, d-1});
+        }
+    }
+}
+
+static void BM_wattsStrogatz2_singleCore(benchmark::State& state)
+{
+    for (auto _ : state) {
+        state.PauseTiming();
+        int feds = 2;
+        int degree = 1;
+        gmlc::concurrency::Barrier brr(feds);
+        auto wcore = helics::CoreFactory::create(
+            core_type::INPROC,
+            std::string(
+                "--autobroker --federates=2 --restrictive_time_policy --brokerinit=\"--restrictive_time_policy\""));
+
+        std::vector<WattsStrogatzFederate> links(feds);
+        for (int ii = 0; ii < feds; ++ii) {
+            std::string bmInit =
+                "--index=" + std::to_string(ii) + " --max_index=" + std::to_string(feds) + " --degree=" + std::to_string(degree);
+            links[ii].initialize(wcore->getIdentifier(), bmInit);
+        }
+
+        std::thread rthread([&](WattsStrogatzFederate& link) { link.run([&brr]() { brr.wait(); }); },
+                            std::ref(links[1]));
+
+        links[0].makeReady();
+        brr.wait();
+
+        state.ResumeTiming();
+        links[0].run();
+        state.PauseTiming();
+        rthread.join();
+
+        wcore.reset();
+        helics::cleanupHelicsLibrary();
+        state.ResumeTiming();
+    }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_wattsStrogatz2_singleCore)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->UseRealTime()
+    ->Iterations(3);
+
+static void BM_wattsStrogatz_multiCore(benchmark::State& state, core_type cType)
+{
+    for (auto _ : state) {
+        state.PauseTiming();
+
+        // Interested in the effect for varying degrees of connectedness
+        int feds = static_cast<int>(state.range(0));
+        int degree = static_cast<int>(state.range(1));
+
+        gmlc::concurrency::Barrier brr(feds);
+        auto broker =
+            helics::BrokerFactory::create(cType,
+                                          std::string("--restrictive_time_policy --federates=") +
+                                              std::to_string(feds));
+        broker->setLoggingLevel(0);
+
+        std::vector<WattsStrogatzFederate> links(feds);
+        std::vector<std::shared_ptr<helics::Core>> cores(feds);
+        for (int ii = 0; ii < feds; ++ii) {
+            cores[ii] = helics::CoreFactory::create(
+                cType,
+                std::string("--restrictive_time_policy --federates=1 --broker=" +
+                            broker->getIdentifier()));
+            cores[ii]->connect();
+            std::string bmInit =
+                "--index=" + std::to_string(ii) + " --max_index=" + std::to_string(feds) + " --degree=" + std::to_string(degree);
+            links[ii].initialize(cores[ii]->getIdentifier(), bmInit);
+        }
+        std::vector<std::thread> threadlist(feds - 1);
+        for (int ii = 0; ii < feds - 1; ++ii) {
+            threadlist[ii] =
+                std::thread([&](WattsStrogatzFederate& link) { link.run([&brr]() { brr.wait(); }); },
+                            std::ref(links[ii + 1]));
+        }
+
+        links[0].makeReady();
+        brr.wait();
+        state.ResumeTiming();
+        links[0].run();
+        state.PauseTiming();
+        for (auto& thrd : threadlist) {
+            thrd.join();
+        }
+
+        broker->disconnect();
+        broker.reset();
+        cores.clear();
+        helics::cleanupHelicsLibrary();
+        state.ResumeTiming();
+    }
+}
+
+// Register the test core benchmarks
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, inprocCore, core_type::INPROC)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+
+#ifdef ENABLE_ZMQ_CORE
+// Register the ZMQ benchmarks
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, zmqCore, core_type::ZMQ)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Iterations(1)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+
+// Register the ZMQ benchmarks
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, zmqssCore, core_type::ZMQ_SS)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Iterations(1)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+#endif
+
+#ifdef ENABLE_IPC_CORE
+// Register the IPC benchmarks
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, ipcCore, core_type::IPC)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+#endif
+
+#ifdef ENABLE_TCP_CORE
+// Register the TCP benchmarks
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, tcpCore, core_type::TCP)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Iterations(1)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+
+// Register the TCP SS benchmarks
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, tcpssCore, core_type::TCP_SS)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Iterations(1)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+#endif
+
+// Register the UDP benchmarks
+// The UDP benchmark starts hanging if too many messages are sent.
+#ifdef ENABLE_UDP_CORE
+BENCHMARK_CAPTURE(BM_wattsStrogatz_multiCore, udpCore, core_type::UDP)
+    ->Unit(benchmark::TimeUnit::kMillisecond)
+    ->Iterations(1)
+    ->Apply(WattsStrogatzArguments)
+    ->UseRealTime();
+#endif
+HELICS_BENCHMARK_MAIN(wattsStrogatzBenchmark);


### PR DESCRIPTION
### Summary
If merged this pull request will add a benchmark that implements a modified Watts-Strogatz network for communication. The key difference from the [Watts-Strogatz model described here](https://en.wikipedia.org/wiki/Watts%E2%80%93Strogatz_model) is that the links constructed by individual federates are directional.

From trying some different default parameters, increasing the initial message count created by each federate can make the benchmark hang when using the udp core as it gets near ~50 messages. Also, a large number of initial messages (100) resulted in the lower degrees of connectivity (1 link) being slower than higher degrees of connectivity (I think this is something that one of the message send benchmarks already exercises).

### Proposed changes
- add a modified Watts-Strogatz benchmark
- some clean-up in the PHOLD federate (remove todo and methods implemented in the base class)
