### PR TITLE
Fix names

### DIFF
--- a/interfaces/csharp/csharp_maps.i
+++ b/interfaces/csharp/csharp_maps.i
@@ -183,21 +183,21 @@
 //
 //
 //// typemap for raw data output function
-//%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+//%typemap(in, numinputs=0) (void *data, int maxDataLength, int *actualSize) {
 //  $3=&($2);
 //}
 //
-//%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+//%typemap(freearg) (void *data, int maxDataLength, int *actualSize) {
 //   if ($1) free($1);
 //}
 //
 //// Set argument to NULL before any conversion occurs
-//%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+//%typemap(check)(void *data, int maxDataLength, int *actualSize) {
 //    $2=helicsSubscriptionGetValueSize(arg1)+2;
 //    $1 =  malloc($2);
 //}
 //
-//%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+//%typemap(argout) (void *data, int maxDataLength, int *actualSize) {
 //  PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
 //  $result = SWIG_Python_AppendOutput($result, o2);
 //}

--- a/interfaces/java/java_maps.i
+++ b/interfaces/java/java_maps.i
@@ -21,20 +21,20 @@
 %apply (char *outputString, int maxLength) { (char *outputString, int maxStringLength) };
 
 ////typemap for large string output with a length return in C
-//%typemap(in, numinputs=0) (char *outputString, int maxStringLen, int *actualLength) {
+//%typemap(in, numinputs=0) (char *outputString, int maxStringLength, int *actualLength) {
 //  $3=&($2);
 //}
 //
-//%typemap(freearg) (char *outputString, int maxStringLen, int *actualLength) {
+//%typemap(freearg) (char *outputString, int maxStringLength, int *actualLength) {
 //   if ($1) free($1);
 //}
 //
-//%typemap(check)(char *outputString, int maxStringLen, int *actualLength) {
+//%typemap(check)(char *outputString, int maxStringLength, int *actualLength) {
 //    $2=helicsInputGetStringSize(arg1)+2;
 //    $1 = (char *) malloc($2);
 //}
 //
-//%typemap(argout) (char *outputString, int maxStringLen, int *actualLength) {
+//%typemap(argout) (char *outputString, int maxStringLength, int *actualLength) {
 //  PyObject *o2=PyString_FromString($1);
 //  $result = SWIG_Python_AppendOutput($result, o2);
 //}

--- a/interfaces/java/java_maps.i
+++ b/interfaces/java/java_maps.i
@@ -3,22 +3,22 @@
 
 %}
 
-//typemap for short maxlen strings
-%typemap(in) (char *outputString, int maxlen) {
+//typemap for short maxLength strings
+%typemap(in) (char *outputString, int maxLength) {
   $1 = (char*)JCALL2(GetByteArrayElements, jenv, $input, 0);
   $2 = (int)JCALL1(GetArrayLength, jenv, $input);
 }
 
-%typemap(argout) (char *outputString, int maxlen) {
+%typemap(argout) (char *outputString, int maxLength) {
   JCALL3(ReleaseByteArrayElements, jenv, $input, (jbyte*)$1, 0);
 }
 
-%typemap(jni) (char *outputString, int maxlen) "jbyteArray"
-%typemap(jtype) (char *outputString, int maxlen) "byte[]"
-%typemap(jstype) (char *outputString, int maxlen) "byte[]"
-%typemap(javain) (char *outputString, int maxlen) "$javainput"
+%typemap(jni) (char *outputString, int maxLength) "jbyteArray"
+%typemap(jtype) (char *outputString, int maxLength) "byte[]"
+%typemap(jstype) (char *outputString, int maxLength) "byte[]"
+%typemap(javain) (char *outputString, int maxLength) "$javainput"
 
-%apply (char *outputString, int maxlen) { (char *outputString, int maxStringLen) };
+%apply (char *outputString, int maxLength) { (char *outputString, int maxStringLength) };
 
 ////typemap for large string output with a length return in C
 //%typemap(in, numinputs=0) (char *outputString, int maxStringLen, int *actualLength) {

--- a/interfaces/java/java_maps.i
+++ b/interfaces/java/java_maps.i
@@ -188,21 +188,21 @@
 //
 //
 //// typemap for raw data output function
-//%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+//%typemap(in, numinputs=0) (void *data, int maxDataLength, int *actualSize) {
 //  $3=&($2);
 //}
 //
-//%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+//%typemap(freearg) (void *data, int maxDataLength, int *actualSize) {
 //   if ($1) free($1);
 //}
 //
 //// Set argument to NULL before any conversion occurs
-//%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+//%typemap(check)(void *data, int maxDataLength, int *actualSize) {
 //    $2=helicsSubscriptionGetValueSize(arg1)+2;
 //    $1 =  malloc($2);
 //}
 //
-//%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+//%typemap(argout) (void *data, int maxDataLength, int *actualSize) {
 //  PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
 //  $result = SWIG_Python_AppendOutput($result, o2);
 //}

--- a/interfaces/matlab/matlab_maps.i
+++ b/interfaces/matlab/matlab_maps.i
@@ -242,39 +242,39 @@ static void throwHelicsMatlabError(helics_error *err) {
 
 
 // typemap for raw data output function
-%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxDataLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+%typemap(freearg) (void *data, int maxDataLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+%typemap(check)(void *data, int maxDataLength, int *actualSize) {
     $2 = helicsInputGetRawValueSize(arg1) + 2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+%typemap(argout) (void *data, int maxDataLength, int *actualSize) {
  if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize((char*)$1,*$3);
 }
 
 // typemap for raw message data functions
-%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxMessageLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(freearg) (void *data, int maxMessageLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+%typemap(check)(void *data, int maxMessageLength, int *actualSize) {
     $2=helicsMessageGetRawDataSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(argout) (void *data, int maxMessageLength, int *actualSize) {
  if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize((char*)$1,*$3);
 }

--- a/interfaces/matlab/matlab_maps.i
+++ b/interfaces/matlab/matlab_maps.i
@@ -61,20 +61,20 @@ static void throwHelicsMatlabError(helics_error *err) {
 }
 
 //typemap for large string output with a length return in C
-%typemap(in, numinputs=0) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(in, numinputs=0) (char *outputString, int maxStringLength, int *actualLength) {
   $3=&($2);
 }
 
-%typemap(freearg) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(freearg) (char *outputString, int maxStringLength, int *actualLength) {
    if ($1) free($1);
 }
 
-%typemap(check)(char *outputString, int maxStringLen, int *actualLength) {
+%typemap(check)(char *outputString, int maxStringLength, int *actualLength) {
     $2=helicsInputGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 
-%typemap(argout) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(argout) (char *outputString, int maxStringLength, int *actualLength) {
 
   if (--resc>=0) *resv++ = SWIG_FromCharPtrAndSize($1,*$3-1);
 }

--- a/interfaces/octave/octave_maps.i
+++ b/interfaces/octave/octave_maps.i
@@ -59,20 +59,20 @@ static octave_value throwHelicsOctaveError(helics_error *err) {
 }
 
 //typemap for large string output with a length return in C
-%typemap(in, numinputs=0) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(in, numinputs=0) (char *outputString, int maxStringLength, int *actualLength) {
   $3=&($2);
 }
 
-%typemap(freearg) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(freearg) (char *outputString, int maxStringLength, int *actualLength) {
    if ($1) free($1);
 }
 
-%typemap(check)(char *outputString, int maxStringLen, int *actualLength) {
+%typemap(check)(char *outputString, int maxStringLength, int *actualLength) {
     $2=helicsInputGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 
-%typemap(argout) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(argout) (char *outputString, int maxStringLength, int *actualLength) {
     _outv = SWIG_FromCharPtrAndSize($1,*$3-1);
   if (_outv.is_defined()) _outp = SWIG_Octave_AppendOutput(_outp, _outv);
 }

--- a/interfaces/octave/octave_maps.i
+++ b/interfaces/octave/octave_maps.i
@@ -200,41 +200,41 @@ static octave_value throwHelicsOctaveError(helics_error *err) {
 
 
 // typemap for raw data output function
-%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxDataLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+%typemap(freearg) (void *data, int maxDataLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+%typemap(check)(void *data, int maxDataLength, int *actualSize) {
     $2=helicsInputGetRawValueSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+%typemap(argout) (void *data, int maxDataLength, int *actualSize) {
  _outv = SWIG_FromCharPtrAndSize(static_cast<char *>($1),*$3);
   if (_outv.is_defined()) _outp = SWIG_Octave_AppendOutput(_outp, _outv);
 }
 
 // typemap for raw data message functions
-%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxMessageLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(freearg) (void *data, int maxMessageLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+%typemap(check)(void *data, int maxMessageLength, int *actualSize) {
     $2=helicsMessageGetRawDataSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(argout) (void *data, int maxMessageLength, int *actualSize) {
 _outv = SWIG_FromCharPtrAndSize(static_cast<char *>($1),*$3);
   if (_outv.is_defined()) _outp = SWIG_Octave_AppendOutput(_outp, _outv);
 }

--- a/interfaces/python/python_maps2.i
+++ b/interfaces/python/python_maps2.i
@@ -90,20 +90,20 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
 }
 
 //typemap for large string output with a length return in C
-%typemap(in, numinputs=0) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(in, numinputs=0) (char *outputString, int maxStringLength, int *actualLength) {
   $3=&($2);
 }
 
-%typemap(freearg) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(freearg) (char *outputString, int maxStringLength, int *actualLength) {
    if ($1) free($1);
 }
 
-%typemap(check)(char *outputString, int maxStringLen, int *actualLength) {
+%typemap(check)(char *outputString, int maxStringLength, int *actualLength) {
     $2=helicsInputGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 
-%typemap(argout) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(argout) (char *outputString, int maxStringLength, int *actualLength) {
   PyObject *o2=PyString_FromString($1);
   $result = SWIG_Python_AppendOutput($result, o2);
 }
@@ -172,25 +172,25 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
 
 // typemap for vector output functions
 
-%typemap(arginit) (double data[], int maxlen, int *actualSize) {
+%typemap(arginit) (double data[], int maxLength, int *actualSize) {
   $1=(double *)(NULL);
 }
 
-%typemap(in, numinputs=0) (double data[], int maxlen, int *actualSize) {
+%typemap(in, numinputs=0) (double data[], int maxLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (double data[], int maxlen, int *actualSize) {
+%typemap(freearg) (double data[], int maxLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(double data[], int maxlen, int *actualSize) {
+%typemap(check)(double data[], int maxLength, int *actualSize) {
     $2=helicsInputGetVectorSize(arg1);
     $1 = (double *) malloc($2*sizeof(double));
 }
 
-%typemap(argout) (double data[], int maxlen, int *actualSize) {
+%typemap(argout) (double data[], int maxLength, int *actualSize) {
   int i;
   PyObject *o2=PyList_New(*$3);
   for (i = 0; i < *$3; i++) {
@@ -204,42 +204,42 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
 
 
 // typemap for raw data output function
-%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxDataLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+%typemap(freearg) (void *data, int maxDataLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+%typemap(check)(void *data, int maxDataLength, int *actualSize) {
     $2=helicsInputGetRawValueSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+%typemap(argout) (void *data, int maxDataLength, int *actualSize) {
   PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
   $result = SWIG_Python_AppendOutput($result, o2);
 }
 
 
 // typemap for raw message data output
-%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxMessageLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(freearg) (void *data, int maxMessageLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+%typemap(check)(void *data, int maxMessageLength, int *actualSize) {
     $2=helicsMessageGetRawDataSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(argout) (void *data, int maxMessageLength, int *actualSize) {
   PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
   $result = SWIG_Python_AppendOutput($result, o2);
 }

--- a/interfaces/python/python_maps3.i
+++ b/interfaces/python/python_maps3.i
@@ -178,25 +178,25 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
 
 // typemap for vector output functions
 
-%typemap(arginit) (double data[], int maxlen, int *actualSize) {
+%typemap(arginit) (double data[], int maxLength, int *actualSize) {
   $1=(double *)(NULL);
 }
 
-%typemap(in, numinputs=0) (double data[], int maxlen, int *actualSize) {
+%typemap(in, numinputs=0) (double data[], int maxLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (double data[], int maxlen, int *actualSize) {
+%typemap(freearg) (double data[], int maxLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(double data[], int maxlen, int *actualSize) {
+%typemap(check)(double data[], int maxLength, int *actualSize) {
     $2=helicsInputGetVectorSize(arg1);
     $1 = (double *) malloc($2*sizeof(double));
 }
 
-%typemap(argout) (double data[], int maxlen, int *actualSize) {
+%typemap(argout) (double data[], int maxLength, int *actualSize) {
   int i;
   PyObject *o2=PyList_New(*$3);
   for (i = 0; i < *$3; i++) {
@@ -245,42 +245,42 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
 
 
 // typemap for raw data output function
-%typemap(in, numinputs=0) (void *data, int maxDatalen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxDataLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxDatalen, int *actualSize) {
+%typemap(freearg) (void *data, int maxDataLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxDatalen, int *actualSize) {
+%typemap(check)(void *data, int maxDataLength, int *actualSize) {
     $2=helicsInputGetRawValueSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxDatalen, int *actualSize) {
+%typemap(argout) (void *data, int maxDataLength, int *actualSize) {
   PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
   $result = SWIG_Python_AppendOutput($result, o2);
 }
 
 
 // typemap for raw message data output
-%typemap(in, numinputs=0) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(in, numinputs=0) (void *data, int maxMessageLength, int *actualSize) {
   $3=&($2);
 }
 
-%typemap(freearg) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(freearg) (void *data, int maxMessageLength, int *actualSize) {
    if ($1) free($1);
 }
 
 // Set argument to NULL before any conversion occurs
-%typemap(check)(void *data, int maxMessagelen, int *actualSize) {
+%typemap(check)(void *data, int maxMessageLength, int *actualSize) {
     $2=helicsMessageGetRawDataSize(arg1)+2;
     $1 =  malloc($2);
 }
 
-%typemap(argout) (void *data, int maxMessagelen, int *actualSize) {
+%typemap(argout) (void *data, int maxMessageLength, int *actualSize) {
   PyObject *o2=PyBytes_FromStringAndSize($1,*$3);
   $result = SWIG_Python_AppendOutput($result, o2);
 }

--- a/interfaces/python/python_maps3.i
+++ b/interfaces/python/python_maps3.i
@@ -96,20 +96,20 @@ PyModule_AddObject(m, "HelicsException", pHelicsException);
 
 
 //typemap for large string output with a length return in C
-%typemap(in, numinputs=0) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(in, numinputs=0) (char *outputString, int maxStringLength, int *actualLength) {
   $3=&($2);
 }
 
-%typemap(freearg) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(freearg) (char *outputString, int maxStringLength, int *actualLength) {
    if ($1) free($1);
 }
 
-%typemap(check)(char *outputString, int maxStringLen, int *actualLength) {
+%typemap(check)(char *outputString, int maxStringLength, int *actualLength) {
     $2=helicsInputGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 
-%typemap(argout) (char *outputString, int maxStringLen, int *actualLength) {
+%typemap(argout) (char *outputString, int maxStringLength, int *actualLength) {
   PyObject *o2=PyString_FromString($1);
   $result = SWIG_Python_AppendOutput($result, o2);
 }

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -507,7 +507,7 @@ HELICS_EXPORT int helicsMessageGetRawDataSize(helics_message_object message);
  * @param message A message object to get the data for.
  * @forcpponly
  * @param[out] data The memory location of the data.
- * @param maxMessagelen The maximum size of information that data can hold.
+ * @param maxMessageLength The maximum size of information that data can hold.
  * @param[out] actualSize The actual length of data copied to data.
  * @param[in,out] err A pointer to an error object for catching errors.
  * @endforcpponly
@@ -517,7 +517,7 @@ HELICS_EXPORT int helicsMessageGetRawDataSize(helics_message_object message);
  * @endPythonOnly
  */
 HELICS_EXPORT void
-    helicsMessageGetRawData(helics_message_object message, void* data, int maxMessagelen, int* actualSize, helics_error* err);
+    helicsMessageGetRawData(helics_message_object message, void* data, int maxMessageLength, int* actualSize, helics_error* err);
 
 /**
  * Get a pointer to the raw data of a message.

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -110,12 +110,12 @@ HELICS_EXPORT helics_bool helicsEndpointIsValid(helics_endpoint endpoint);
  * Set the default destination for an endpoint if no other endpoint is given.
  *
  * @param endpoint The endpoint to set the destination for.
- * @param dest A string naming the desired default endpoint.
+ * @param dst A string naming the desired default endpoint.
  * @forcpponly
  * @param[in,out] err A pointer to an error object for catching errors.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsEndpointSetDefaultDestination(helics_endpoint endpoint, const char* dest, helics_error* err);
+HELICS_EXPORT void helicsEndpointSetDefaultDestination(helics_endpoint endpoint, const char* dst, helics_error* err);
 
 /**
  * Get the default destination for an endpoint.
@@ -130,7 +130,7 @@ HELICS_EXPORT const char* helicsEndpointGetDefaultDestination(helics_endpoint en
  * Send a message to the specified destination.
  *
  * @param endpoint The endpoint to send the data from.
- * @param dest The target destination.
+ * @param dst The target destination.
  * @forcpponly
  *             nullptr to use the default destination.
  * @endforcpponly
@@ -144,13 +144,13 @@ HELICS_EXPORT const char* helicsEndpointGetDefaultDestination(helics_endpoint en
  * @endforcpponly
  */
 HELICS_EXPORT void
-    helicsEndpointSendMessageRaw(helics_endpoint endpoint, const char* dest, const void* data, int inputDataLength, helics_error* err);
+    helicsEndpointSendMessageRaw(helics_endpoint endpoint, const char* dst, const void* data, int inputDataLength, helics_error* err);
 
 /**
  * Send a message at a specific time to the specified destination.
  *
  * @param endpoint The endpoint to send the data from.
- * @param dest The target destination.
+ * @param dst The target destination.
  * @forcpponly
  *             nullptr to use the default destination.
  * @endforcpponly
@@ -167,7 +167,7 @@ HELICS_EXPORT void
  * @endforcpponly
  */
 HELICS_EXPORT void helicsEndpointSendEventRaw(helics_endpoint endpoint,
-                                              const char* dest,
+                                              const char* dst,
                                               const void* data,
                                               int inputDataLength,
                                               helics_time time,
@@ -552,12 +552,12 @@ HELICS_EXPORT void helicsMessageSetSource(helics_message_object message, const c
  * Set the destination of a message.
  *
  * @param message The message object in question.
- * @param dest A string containing the new destination.
+ * @param dst A string containing the new destination.
  * @forcpponly
  * @param[in,out] err An error object to fill out in case of an error.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsMessageSetDestination(helics_message_object message, const char* dest, helics_error* err);
+HELICS_EXPORT void helicsMessageSetDestination(helics_message_object message, const char* dst, helics_error* err);
 
 /**
  * Set the original source of a message.
@@ -574,12 +574,12 @@ HELICS_EXPORT void helicsMessageSetOriginalSource(helics_message_object message,
  * Set the original destination of a message.
  *
  * @param message The message object in question.
- * @param dest A string containing the new original source.
+ * @param dst A string containing the new original source.
  * @forcpponly
  * @param[in,out] err An error object to fill out in case of an error.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsMessageSetOriginalDestination(helics_message_object message, const char* dest, helics_error* err);
+HELICS_EXPORT void helicsMessageSetOriginalDestination(helics_message_object message, const char* dst, helics_error* err);
 
 /**
  * Set the delivery time for a message.
@@ -689,13 +689,13 @@ HELICS_EXPORT void helicsMessageAppendData(helics_message_object message, const 
 /**
  * Copy a message object.
  *
- * @param source_message The message object to copy from.
- * @param dest_message The message object to copy to.
+ * @param src_message The message object to copy from.
+ * @param dst_message The message object to copy to.
  * @forcpponly
  * @param[in,out] err An error object to fill out in case of an error.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsMessageCopy(helics_message_object source_message, helics_message_object dest_message, helics_error* err);
+HELICS_EXPORT void helicsMessageCopy(helics_message_object src_message, helics_message_object dst_message, helics_error* err);
 
 /**
  * Clone a message object.

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -390,7 +390,7 @@ HELICS_EXPORT const char* helicsEndpointGetInfo(helics_endpoint end);
  * @param[in,out] err An error object to fill out in case of an error.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsEndpointSetInfo(helics_endpoint end, const char* info, helics_error* err);
+HELICS_EXPORT void helicsEndpointSetInfo(helics_endpoint endpoint, const char* info, helics_error* err);
 
 /**
  * Set a handle option on an endpoint.
@@ -402,7 +402,7 @@ HELICS_EXPORT void helicsEndpointSetInfo(helics_endpoint end, const char* info, 
  * @param[in,out] err An error object to fill out in case of an error.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsEndpointSetOption(helics_endpoint end, int option, int value, helics_error* err);
+HELICS_EXPORT void helicsEndpointSetOption(helics_endpoint endpoint, int option, int value, helics_error* err);
 
 /**
  * Set a handle option on an endpoint.
@@ -411,7 +411,7 @@ HELICS_EXPORT void helicsEndpointSetOption(helics_endpoint end, int option, int 
  * @param option Integer code for the option to set /ref helics_handle_options.
  * @return the value of the option, for boolean options will be 0 or 1
  */
-HELICS_EXPORT int helicsEndpointGetOption(helics_endpoint end, int option);
+HELICS_EXPORT int helicsEndpointGetOption(helics_endpoint endpoint, int option);
 
 /**
  * \defgroup Message operation functions

--- a/src/helics/shared_api_library/MessageFilters.h
+++ b/src/helics/shared_api_library/MessageFilters.h
@@ -203,12 +203,12 @@ HELICS_EXPORT void helicsFilterSetString(helics_filter filt, const char* prop, c
  *
  * @details All messages going to a destination are copied to the delivery address(es).
  * @param filt The given filter to add a destination target to.
- * @param dest The name of the endpoint to add as a destination target.
+ * @param dst The name of the endpoint to add as a destination target.
  * @forcpponly
  * @param[in,out] err A pointer to an error object for catching errors.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsFilterAddDestinationTarget(helics_filter filt, const char* dest, helics_error* err);
+HELICS_EXPORT void helicsFilterAddDestinationTarget(helics_filter filt, const char* dst, helics_error* err);
 
 /**
  * Add a source target to a filter.

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -483,7 +483,7 @@ HELICS_EXPORT int helicsInputGetRawValueSize(helics_input ipt);
  * @param ipt The input to get the data for.
  * @forcpponly
  * @param[out] data The memory location of the data
- * @param maxDatalen The maximum size of information that data can hold.
+ * @param maxDataLength The maximum size of information that data can hold.
  * @param[out] actualSize The actual length of data copied to data.
  * @param[in,out] err A pointer to an error object for catching errors.
  * @endforcpponly
@@ -492,7 +492,7 @@ HELICS_EXPORT int helicsInputGetRawValueSize(helics_input ipt);
  * @return Raw string data.
  * @endPythonOnly
  */
-HELICS_EXPORT void helicsInputGetRawValue(helics_input ipt, void* data, int maxDatalen, int* actualSize, helics_error* err);
+HELICS_EXPORT void helicsInputGetRawValue(helics_input ipt, void* data, int maxDataLength, int* actualSize, helics_error* err);
 
 /**
  * Get the size of a value for subscription assuming return as a string.
@@ -507,7 +507,7 @@ HELICS_EXPORT int helicsInputGetStringSize(helics_input ipt);
  * @param ipt The input to get the data for.
  * @forcpponly
  * @param[out] outputString Storage for copying a null terminated string.
- * @param maxStringLen The maximum size of information that str can hold.
+ * @param maxStringLength The maximum size of information that str can hold.
  * @param[out] actualLength The actual length of the string.
  * @param[in,out] err Error term for capturing errors.
  * @endforcpponly
@@ -516,7 +516,7 @@ HELICS_EXPORT int helicsInputGetStringSize(helics_input ipt);
  * @return A string data
  * @endPythonOnly
  */
-HELICS_EXPORT void helicsInputGetString(helics_input ipt, char* outputString, int maxStringLen, int* actualLength, helics_error* err);
+HELICS_EXPORT void helicsInputGetString(helics_input ipt, char* outputString, int maxStringLength, int* actualLength, helics_error* err);
 
 /**
  * Get an integer value from a subscription.
@@ -624,7 +624,7 @@ HELICS_EXPORT int helicsInputGetVectorSize(helics_input ipt);
  * @param ipt The input to get the result for.
  * @forcpponly
  * @param[out] data The location to store the data.
- * @param maxlen The maximum size of the vector.
+ * @param maxLength The maximum size of the vector.
  * @param[out] actualSize Location to place the actual length of the resulting vector.
  * @param[in,out] err An error object that will contain an error code and string if any error occurred during the execution of the function.
  * @endforcpponly
@@ -633,7 +633,7 @@ HELICS_EXPORT int helicsInputGetVectorSize(helics_input ipt);
  * @return a list of floating point values
  * @endPythonOnly
  */
-HELICS_EXPORT void helicsInputGetVector(helics_input ipt, double data[], int maxlen, int* actualSize, helics_error* err);
+HELICS_EXPORT void helicsInputGetVector(helics_input ipt, double data[], int maxLength, int* actualSize, helics_error* err);
 
 /**
  * Get a named point from a subscription.
@@ -641,7 +641,7 @@ HELICS_EXPORT void helicsInputGetVector(helics_input ipt, double data[], int max
  * @param ipt The input to get the result for.
  * @forcpponly
  * @param[out] outputString Storage for copying a null terminated string.
- * @param maxStringLen The maximum size of information that str can hold.
+ * @param maxStringLength The maximum size of information that str can hold.
  * @param[out] actualLength The actual length of the string
  * @param[out] val The double value for the named point.
  * @param[in,out] err An error object that will contain an error code and string if any error occurred during the execution of the function.
@@ -652,7 +652,7 @@ HELICS_EXPORT void helicsInputGetVector(helics_input ipt, double data[], int max
  * @endPythonOnly
  */
 HELICS_EXPORT void
-    helicsInputGetNamedPoint(helics_input ipt, char* outputString, int maxStringLen, int* actualLength, double* val, helics_error* err);
+    helicsInputGetNamedPoint(helics_input ipt, char* outputString, int maxStringLength, int* actualLength, double* val, helics_error* err);
 
 /**@}*/
 


### PR DESCRIPTION
### Summary

If merged this pull request will update names in the function arguments in the C API.


- Make `src` and `dst` names consistent. Alternatively, we can use `source` and `destination` spelled out explicitly.
- Change `end` to `endpoint`
- Make some names proper `camelCase` and spelled out to be consistent with other names.