### PR TITLE
Add option to install benchmark executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,6 +980,7 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
         java
         octave
         csharp
+        benchmarks
         cereal
     )
     if(WIN32)
@@ -994,6 +995,7 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_LIBS_DISPLAY_NAME "Libraries")
     set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Headers")
     set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Runtime Libraries")
+    set(CPACK_COMPONENT_BENCHMARKS_DISPLAY_NAME "Benchmarks")
     set(CPACK_COMPONENT_SWIG_DISPLAY_NAME "SWIG")
     set(CPACK_COMPONENT_JAVA_DISPLAY_NAME "Java")
     set(CPACK_COMPONENT_PYTHON_DISPLAY_NAME "Python")
@@ -1021,6 +1023,7 @@ if(HELICS_ENABLE_PACKAGE_BUILD)
     set(CPACK_COMPONENT_LIBS_DESCRIPTION "Libraries for compiling and linking with HELICS")
     set(CPACK_COMPONENT_HEADERS_DESCRIPTION "Headers for linking and compiling with HELICS")
     set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Runtime libraries for HELICS")
+    set(CPACK_COMPONENT_BENCHMARKS_DESCRIPTION "Benchmark applications for HELICS")
     set(CPACK_COMPONENT_CEREAL_DESCRIPTION
         "cereal C++11 serialization library [no support for other language interfaces]"
     )

--- a/benchmarks/helics/CMakeLists.txt
+++ b/benchmarks/helics/CMakeLists.txt
@@ -89,7 +89,8 @@ if(NOT HELICS_DISABLE_C_SHARED_LIB)
         echoBenchmarks_c PRIVATE ${HELICS_BINARY_DIR}/helics_generated_includes/
     )
     install(TARGETS echoBenchmarks_c ${HELICS_EXPORT_COMMAND} DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT benchmarks)
+            COMPONENT benchmarks
+    )
 endif()
 
 string(TIMESTAMP current_date "%Y-%m-%d")

--- a/benchmarks/helics/CMakeLists.txt
+++ b/benchmarks/helics/CMakeLists.txt
@@ -62,14 +62,18 @@ foreach(T ${HELICS_BENCHMARKS})
     target_compile_definitions(
         ${T} PRIVATE "HELICS_BENCHMARK_SHIFT_FACTOR=(${HELICS_BENCHMARK_SHIFT_FACTOR})"
     )
+    install(TARGETS ${T} ${HELICS_EXPORT_COMMAND} DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT benchmarks)
 endforeach()
 
 add_executable(helics_benchmarks BenchmarkMain.cpp BenchmarkFederate.hpp)
 target_link_libraries(helics_benchmarks PUBLIC helics_application_api)
 set_target_properties(helics_benchmarks PROPERTIES FOLDER benchmarks_multimachine)
 foreach(T ${HELICS_MULTINODE_BENCHMARKS})
-    target_sources(helics_benchmarks PUBLIC ${T}.hpp)
+    target_sources(helics_benchmarks PRIVATE ${T}.hpp)
 endforeach()
+install(TARGETS helics_benchmarks ${HELICS_EXPORT_COMMAND} DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT benchmarks)
 
 if(NOT HELICS_DISABLE_C_SHARED_LIB)
     add_executable(echoBenchmarks_c echoBenchmarks_c.cpp)

--- a/benchmarks/helics/CMakeLists.txt
+++ b/benchmarks/helics/CMakeLists.txt
@@ -84,8 +84,10 @@ if(NOT HELICS_DISABLE_C_SHARED_LIB)
         echoBenchmarks_c PRIVATE "HELICS_BENCHMARK_SHIFT_FACTOR=(${HELICS_BENCHMARK_SHIFT_FACTOR})"
     )
     target_include_directories(
-        echoBenchmarks_c PUBLIC ${HELICS_BINARY_DIR}/helics_generated_includes/
+        echoBenchmarks_c PRIVATE ${HELICS_BINARY_DIR}/helics_generated_includes/
     )
+    install(TARGETS echoBenchmarks_c ${HELICS_EXPORT_COMMAND} DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT benchmarks)
 endif()
 
 string(TIMESTAMP current_date "%Y-%m-%d")


### PR DESCRIPTION
### Summary

If merged this pull request will add an option for installing the benchmark binaries. Tested the change with spack and it provides a potentially easy way to get the HELICS benchmarks built on any systems that support spack.

### Proposed changes

- Install HELICS benchmark binaries when they are built
- Include benchmarks component in installers when built with the benchmarks enabled