### PR TITLE
make the vector/complex number conversions to fit JSON standard.

### DIFF
--- a/ThirdParty/frozen/bits/pmh.h
+++ b/ThirdParty/frozen/bits/pmh.h
@@ -96,13 +96,15 @@ pmh_buckets<M> constexpr make_pmh_buckets(const carray<Item, N> & items,
   result_t result{};
   // Continue until all items are placed without exceeding bucket_max
   while (1) {
-    for (auto & b : result.buckets) {
-      b.clear();
-    }
     result.seed = prg();
     for (std::size_t i = 0; i < N; ++i) {
       auto & bucket = result.buckets[hash(key(items[i]), static_cast<size_t>(result.seed)) % M];
-      if (bucket.size() >= result_t::bucket_max) { continue; }
+      if (bucket.size() >= result_t::bucket_max) {
+        continue;
+        for (auto & b : result.buckets) {
+          b.clear();
+        }
+      }
       bucket.push_back(i);
     }
     return result;

--- a/ThirdParty/frozen/string.h
+++ b/ThirdParty/frozen/string.h
@@ -81,11 +81,14 @@ template <> struct elsa<string> {
       d = d * 33 + value[i];
     return d;
   }
+
+  // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+  // With the lowest bits removed, based on experimental setup.
   constexpr std::size_t operator()(string value, std::size_t seed) const {
-    std::size_t d = seed;
+    std::size_t d =  (0x811c9dc5 ^ seed) * 0x01000193;
     for (std::size_t i = 0; i < value.size(); ++i)
-      d = (d * 0x01000193) ^ value[i];
-    return d;
+      d = (d ^ value[i]) * 0x01000193;
+    return d >> 8 ;
   }
 };
 

--- a/src/helics/application_api/ValueFederateManager.cpp
+++ b/src/helics/application_api/ValueFederateManager.cpp
@@ -52,9 +52,10 @@ int getTypeSize(const std::string& type)
 }
 
 Publication& ValueFederateManager::registerPublication(const std::string& key,
-                                                       const std::string& type,
+                                                       std::string type,
                                                        const std::string& units)
 {
+    type=getCleanedTypeName(type);
     auto coreID = coreObject->registerPublication(fedID, key, type, units);
 
     auto pubHandle = publications.lock();
@@ -72,9 +73,10 @@ Publication& ValueFederateManager::registerPublication(const std::string& key,
 }
 
 Input& ValueFederateManager::registerInput(const std::string& key,
-                                           const std::string& type,
+                                           std::string type,
                                            const std::string& units)
 {
+    type=getCleanedTypeName(type);
     auto coreID = coreObject->registerInput(fedID, key, type, units);
     auto inpHandle = inputs.lock();
     decltype(inpHandle->insert(key, coreID, fed, coreID, key, units)) active;

--- a/src/helics/application_api/ValueFederateManager.cpp
+++ b/src/helics/application_api/ValueFederateManager.cpp
@@ -55,7 +55,7 @@ Publication& ValueFederateManager::registerPublication(const std::string& key,
                                                        std::string type,
                                                        const std::string& units)
 {
-    type=getCleanedTypeName(type);
+    type = getCleanedTypeName(type);
     auto coreID = coreObject->registerPublication(fedID, key, type, units);
 
     auto pubHandle = publications.lock();
@@ -76,7 +76,7 @@ Input& ValueFederateManager::registerInput(const std::string& key,
                                            std::string type,
                                            const std::string& units)
 {
-    type=getCleanedTypeName(type);
+    type = getCleanedTypeName(type);
     auto coreID = coreObject->registerInput(fedID, key, type, units);
     auto inpHandle = inputs.lock();
     decltype(inpHandle->insert(key, coreID, fed, coreID, key, units)) active;

--- a/src/helics/application_api/ValueFederateManager.hpp
+++ b/src/helics/application_api/ValueFederateManager.hpp
@@ -69,12 +69,12 @@ class ValueFederateManager {
     ~ValueFederateManager();
 
     Publication& registerPublication(const std::string& key,
-                                     const std::string& type,
+                                     std::string type,
                                      const std::string& units);
     /** register a subscription
     @details call is only valid in startup mode
     */
-    Input& registerInput(const std::string& key, const std::string& type, const std::string& units);
+    Input& registerInput(const std::string& key, std::string type, const std::string& units);
 
     /** add a shortcut for locating a subscription
     @details primarily for use in looking up an id from a different location

--- a/src/helics/application_api/ValueFederateManager.hpp
+++ b/src/helics/application_api/ValueFederateManager.hpp
@@ -68,9 +68,8 @@ class ValueFederateManager {
     ValueFederateManager(Core* coreOb, ValueFederate* vfed, local_federate_id id);
     ~ValueFederateManager();
 
-    Publication& registerPublication(const std::string& key,
-                                     std::string type,
-                                     const std::string& units);
+    Publication&
+        registerPublication(const std::string& key, std::string type, const std::string& units);
     /** register a subscription
     @details call is only valid in startup mode
     */

--- a/src/helics/application_api/helicsTypes.cpp
+++ b/src/helics/application_api/helicsTypes.cpp
@@ -104,7 +104,7 @@ std::string helicsComplexString(std::complex<double> val)
     return helicsComplexString(val.real(), val.imag());
 }
 /** map of an assortment of type string that can be converted to a known type*/
-static constexpr frozen::unordered_map<frozen::string, data_type, 55> typeMap{
+static constexpr frozen::unordered_map<frozen::string, data_type, 56> typeMap{
     {"double", data_type::helics_double},
     {"string", data_type::helics_string},
     {"binary", data_type::helics_bool},
@@ -136,13 +136,15 @@ static constexpr frozen::unordered_map<frozen::string, data_type, 55> typeMap{
     {"byte", data_type::helics_int},
     {"int8", data_type::helics_int},
     {"uint8", data_type::helics_int},
+    {"char8_t", data_type::helics_string},
     {"complex_vector", data_type::helics_complex_vector},
     {"complex vector", data_type::helics_complex_vector},
     {"d", data_type::helics_double},
     {"s", data_type::helics_string},
     {"f", data_type::helics_double},
     {"v", data_type::helics_vector},
-    {"c", data_type::helics_complex},
+    // typeid(char).name sometimes is produced from char
+    {"c", data_type::helics_string},
     {"t", data_type::helics_time},
     {"i", data_type::helics_int},
     {"i64", data_type::helics_int},

--- a/src/helics/application_api/helicsTypes.cpp
+++ b/src/helics/application_api/helicsTypes.cpp
@@ -226,6 +226,32 @@ data_type getTypeFromString(std::string_view typeName)
     return data_type::helics_custom;
 }
 
+std::string_view getCleanedTypeName(std::string_view typeName)
+{
+    if (!typeName.empty() && typeName.front() == '[') {
+        return typeName;
+    }
+    const auto* res = typeMap.find(frozen::string(typeName.data(), typeName.size()));
+    if (res != typeMap.end()) {
+        return typeName;
+    }
+    std::string strName(typeName);
+    auto dres = demangle_names.find(strName);
+    if (dres != demangle_names.end()) {
+        return typeNameStringRef(dres->second);
+    }
+    makeLowerCase(strName);
+    res = typeMap.find(frozen::string(strName.data(), strName.size()));
+    if (res != typeMap.end()) {
+        return typeName;
+    }
+    dres = demangle_names.find(strName);
+    if (dres != demangle_names.end()) {
+        return typeNameStringRef(dres->second);
+    }
+    return typeName;
+}
+
 // regular expression to handle complex numbers of various formats
 const std::regex creg(
     R"(([+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?)\s*([+-]\s*(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?)[ji]*)");

--- a/src/helics/application_api/helicsTypes.cpp
+++ b/src/helics/application_api/helicsTypes.cpp
@@ -7,12 +7,12 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "helicsTypes.hpp"
 
-#include "ValueConverter.hpp"
 #include "../common/JsonGeneration.hpp"
 #include "../common/JsonProcessingFunctions.hpp"
-#include "frozen/unordered_map.h"
-#include "frozen/string.h"
+#include "ValueConverter.hpp"
 #include "fmt/format.h"
+#include "frozen/string.h"
+#include "frozen/unordered_map.h"
 #include "gmlc/utilities/demangle.hpp"
 #include "gmlc/utilities/stringConversion.h"
 #include "gmlc/utilities/stringOps.h"
@@ -28,25 +28,17 @@ SPDX-License-Identifier: BSD-3-Clause
 
 using namespace gmlc::utilities;  // NOLINT
 
-
-
 template<>
 struct fmt::formatter<std::complex<double>> {
     // Formats the point p using the parsed format specification (presentation)
     // stored in this formatter.
-    static constexpr auto parse(format_parse_context& ctx)
-    {
-        return ctx.end();
-    }
+    static constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
 
     template<typename FormatContext>
     auto format(const std::complex<double>& p, FormatContext& ctx)
     {
         // ctx.out() is an output iterator to write to.
-        return format_to(ctx.out(),
-                         "[{:.9g},{:.9g}]",
-                         p.real(),
-                         p.imag());
+        return format_to(ctx.out(), "[{:.9g},{:.9g}]", p.real(), p.imag());
     }
 };
 
@@ -112,7 +104,7 @@ std::string helicsComplexString(std::complex<double> val)
     return helicsComplexString(val.real(), val.imag());
 }
 /** map of an assortment of type string that can be converted to a known type*/
-static constexpr frozen::unordered_map<frozen::string, data_type,55> typeMap{
+static constexpr frozen::unordered_map<frozen::string, data_type, 55> typeMap{
     {"double", data_type::helics_double},
     {"string", data_type::helics_string},
     {"binary", data_type::helics_bool},
@@ -204,33 +196,32 @@ static const std::unordered_map<std::string, data_type> demangle_names{
     {typeid(std::string).name(), data_type::helics_string},
     {typeid(char*).name(), data_type::helics_string},
     {typeid(const char*).name(), data_type::helics_string},
-    {typeid(Time).name(), data_type::helics_time}
-};
+    {typeid(Time).name(), data_type::helics_time}};
 
 data_type getTypeFromString(std::string_view typeName)
 {
     if (!typeName.empty() && typeName.front() == '[') {
         return data_type::helics_multi;
     }
-    const auto* res = typeMap.find(frozen::string(typeName.data(),typeName.size()));
-    if (res!=typeMap.end()) {
+    const auto* res = typeMap.find(frozen::string(typeName.data(), typeName.size()));
+    if (res != typeMap.end()) {
         return res->second;
     }
-        std::string strName(typeName);
-        auto dres = demangle_names.find(strName);
-        if (dres!=demangle_names.end()) {
-            return dres->second;
-        }
-        makeLowerCase(strName);
-        res = typeMap.find(frozen::string(strName.data(), strName.size()));
-        if (res != typeMap.end()) {
-            return res->second;
-        }
-        dres = demangle_names.find(strName);
-        if (dres != demangle_names.end()) {
-            return dres->second;
-        }
-        return data_type::helics_custom;
+    std::string strName(typeName);
+    auto dres = demangle_names.find(strName);
+    if (dres != demangle_names.end()) {
+        return dres->second;
+    }
+    makeLowerCase(strName);
+    res = typeMap.find(frozen::string(strName.data(), strName.size()));
+    if (res != typeMap.end()) {
+        return res->second;
+    }
+    dres = demangle_names.find(strName);
+    if (dres != demangle_names.end()) {
+        return dres->second;
+    }
+    return data_type::helics_custom;
 }
 
 // regular expression to handle complex numbers of various formats
@@ -244,18 +235,17 @@ std::complex<double> helicsGetComplex(std::string_view val)
     }
     double re{invalidValue<double>()};
     double im{0.0};
-    if (val.front() =='[') {
-        
+    if (val.front() == '[') {
         auto sep = val.find_first_of(',');
-        if (sep==std::string_view::npos) {
+        if (sep == std::string_view::npos) {
             val.remove_prefix(1);
             val.remove_suffix(1);
             re = numConv<double>(val);
             return {re, im};
         }
-        if (val.find_first_of(',',sep+1)!=std::string_view::npos) {
+        if (val.find_first_of(',', sep + 1) != std::string_view::npos) {
             auto V = helicsGetVector(val);
-            if (V.size()>=2) {
+            if (V.size() >= 2) {
                 return {V[0], V[1]};
             }
             return invalidValue<std::complex<double>>();
@@ -266,7 +256,7 @@ std::complex<double> helicsGetComplex(std::string_view val)
         return {re, im};
     }
     std::smatch m;
-   
+
     auto temp = std::string(val);
     std::regex_search(temp, m, creg);
     try {
@@ -322,7 +312,7 @@ std::string helicsNamedPointString(std::string_view pointName, double val)
     NP["value"] = val;
     if (pointName.empty()) {
     } else {
-        NP["name"] = Json::Value(pointName.data(), pointName.data()+pointName.size());
+        NP["name"] = Json::Value(pointName.data(), pointName.data() + pointName.size());
     }
     return generateJsonString(NP);
 }
@@ -516,7 +506,7 @@ void helicsGetComplexVector(std::string_view val, std::vector<std::complex<doubl
             fb = nc;
         }
     } else {
-        if (val.find_first_of("ji")!=std::string_view::npos) {
+        if (val.find_first_of("ji") != std::string_view::npos) {
             auto V = helicsGetComplex(val);
             data.resize(0);
             data.push_back(V);
@@ -530,10 +520,10 @@ void helicsGetComplexVector(std::string_view val, std::vector<std::complex<doubl
                     data.resize(0);
                     data.emplace_back(JV.asDouble(), 0.0);
                     break;
-                case Json::ValueType::arrayValue: 
+                case Json::ValueType::arrayValue:
                     for (auto& av : JV) {
                         if (av.isNumeric()) {
-                            if (cnt==0) {
+                            if (cnt == 0) {
                                 data.emplace_back(av.asDouble(), 0.0);
                                 cnt = 1;
                             } else {
@@ -548,7 +538,7 @@ void helicsGetComplexVector(std::string_view val, std::vector<std::complex<doubl
                                 }
                             } else if (av.size() == 1) {
                                 if (av[0].isNumeric()) {
-                                    data.emplace_back(av[0].asDouble(),0.0);
+                                    data.emplace_back(av[0].asDouble(), 0.0);
                                 }
                             } else {
                                 data.push_back(invalidValue<std::complex<double>>());
@@ -560,19 +550,18 @@ void helicsGetComplexVector(std::string_view val, std::vector<std::complex<doubl
                     break;
             }
         }
-        
     }
 }
 
 bool helicsBoolValue(std::string_view val)
 {
-    static constexpr const frozen::unordered_map<frozen::string, bool,35> knownStrings{
+    static constexpr const frozen::unordered_map<frozen::string, bool, 35> knownStrings{
 
         {"0", false},
         {"00", false},
-        {frozen::string("\0",1), false},
+        {frozen::string("\0", 1), false},
         {"0000", false},
-        {frozen::string("\0\0\0\0\0\0\0\0",8), false},
+        {frozen::string("\0\0\0\0\0\0\0\0", 8), false},
         {"1", true},
         {"false", false},
         {"true", true},
@@ -602,11 +591,10 @@ bool helicsBoolValue(std::string_view val)
         {"enable", true},
         {"disabled", false},
         {"enabled", true},
-        {"", false}
-    };
+        {"", false}};
     // all known false strings are captured in known strings so if it isn't in there it evaluates to
     // true
-    const auto * res = knownStrings.find(frozen::string(val.data(),val.size()));
+    const auto* res = knownStrings.find(frozen::string(val.data(), val.size()));
     if (res != knownStrings.end()) {
         return res->second;
     }

--- a/src/helics/application_api/helicsTypes.cpp
+++ b/src/helics/application_api/helicsTypes.cpp
@@ -8,6 +8,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helicsTypes.hpp"
 
 #include "ValueConverter.hpp"
+#include "../common/JsonGeneration.hpp"
+#include "../common/JsonProcessingFunctions.hpp"
+#include "frozen/unordered_map.h"
+#include "frozen/string.h"
 #include "fmt/format.h"
 #include "gmlc/utilities/demangle.hpp"
 #include "gmlc/utilities/stringConversion.h"
@@ -23,6 +27,28 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <unordered_map>
 
 using namespace gmlc::utilities;  // NOLINT
+
+
+
+template<>
+struct fmt::formatter<std::complex<double>> {
+    // Formats the point p using the parsed format specification (presentation)
+    // stored in this formatter.
+    static constexpr auto parse(format_parse_context& ctx)
+    {
+        return ctx.end();
+    }
+
+    template<typename FormatContext>
+    auto format(const std::complex<double>& p, FormatContext& ctx)
+    {
+        // ctx.out() is an output iterator to write to.
+        return format_to(ctx.out(),
+                         "[{:.9g},{:.9g}]",
+                         p.real(),
+                         p.imag());
+    }
+};
 
 namespace helics {
 
@@ -77,7 +103,7 @@ double vectorNorm(const std::vector<std::complex<double>>& vec)
 
 std::string helicsComplexString(double real, double imag)
 {
-    return (imag != 0.0) ? fmt::format(FMT_STRING("{:.9g}{:<+.9g}j"), real, imag) :
+    return (imag != 0.0) ? fmt::format(FMT_STRING("[{:.9g},{:.9g}]"), real, imag) :
                            fmt::format(FMT_STRING("{:.9g}"), real);
 }
 
@@ -86,7 +112,7 @@ std::string helicsComplexString(std::complex<double> val)
     return helicsComplexString(val.real(), val.imag());
 }
 /** map of an assortment of type string that can be converted to a known type*/
-static const std::unordered_map<std::string, data_type> typeMap{
+static constexpr frozen::unordered_map<frozen::string, data_type,55> typeMap{
     {"double", data_type::helics_double},
     {"string", data_type::helics_string},
     {"binary", data_type::helics_bool},
@@ -97,13 +123,61 @@ static const std::unordered_map<std::string, data_type> typeMap{
     {"vector", data_type::helics_vector},
     {"double_vector", data_type::helics_vector},
     {"double vector", data_type::helics_vector},
-    {typeid(std::vector<double>).name(), data_type::helics_vector},
-    {gmlc::demangle(typeid(std::vector<double>).name()), data_type::helics_vector},
-    {typeid(double*).name(), data_type::helics_vector},
     {"complex", data_type::helics_complex},
     {"pair", data_type::helics_complex},
     {"int", data_type::helics_int},
     {"int64", data_type::helics_int},
+    {"long long", data_type::helics_int},
+    {"integer", data_type::helics_int},
+    {"int32", data_type::helics_int},
+    {"uint32", data_type::helics_int},
+    {"uint64", data_type::helics_int},
+    {"int16", data_type::helics_int},
+    {"uint16", data_type::helics_int},
+    {"short", data_type::helics_int},
+    {"unsigned short", data_type::helics_int},
+    {"long", data_type::helics_int},
+    {"unsigned long", data_type::helics_int},
+    {"char", data_type::helics_string},
+    {"uchar", data_type::helics_int},
+    {"unsigned char", data_type::helics_int},
+    {"byte", data_type::helics_int},
+    {"int8", data_type::helics_int},
+    {"uint8", data_type::helics_int},
+    {"complex_vector", data_type::helics_complex_vector},
+    {"complex vector", data_type::helics_complex_vector},
+    {"d", data_type::helics_double},
+    {"s", data_type::helics_string},
+    {"f", data_type::helics_double},
+    {"v", data_type::helics_vector},
+    {"c", data_type::helics_complex},
+    {"t", data_type::helics_time},
+    {"i", data_type::helics_int},
+    {"i64", data_type::helics_int},
+    {"cv", data_type::helics_complex_vector},
+    {"np", data_type::helics_named_point},
+    {"point", data_type::helics_named_point},
+    {"pt", data_type::helics_named_point},
+    {"named_point", data_type::helics_named_point},
+    {"default", data_type::helics_any},
+    {"time", data_type::helics_time},
+    {"tm", data_type::helics_time},
+    {"multi", data_type::helics_multi},
+    {"many", data_type::helics_multi},
+    {"def", data_type::helics_any},
+    {"any", data_type::helics_any},
+    {"", data_type::helics_any},
+    {"all", data_type::helics_any}};
+
+static const std::unordered_map<std::string, data_type> demangle_names{
+    {gmlc::demangle(typeid(Time).name()), data_type::helics_time},
+    {gmlc::demangle(typeid(std::string).name()), data_type::helics_string},
+    {gmlc::demangle(typeid(std::complex<double>).name()), data_type::helics_complex},
+    {gmlc::demangle(typeid(std::vector<double>).name()), data_type::helics_vector},
+    {gmlc::demangle(typeid(std::vector<std::complex<double>>).name()),
+     data_type::helics_complex_vector},
+    {typeid(std::vector<double>).name(), data_type::helics_vector},
+    {typeid(double*).name(), data_type::helics_vector},
     {typeid(double).name(), data_type::helics_double},
     {typeid(float).name(), data_type::helics_double},
     {typeid(char).name(), data_type::helics_string},
@@ -125,73 +199,38 @@ static const std::unordered_map<std::string, data_type> typeMap{
     {typeid(int8_t).name(), data_type::helics_int},
     {typeid(uint8_t).name(), data_type::helics_int},
     {typeid(bool).name(), data_type::helics_bool},
-    {"long long", data_type::helics_int},
-    {"integer", data_type::helics_int},
-    {"int32", data_type::helics_int},
-    {"uint32", data_type::helics_int},
-    {"uint64", data_type::helics_int},
-    {"int16", data_type::helics_int},
-    {"uint16", data_type::helics_int},
-    {"short", data_type::helics_int},
-    {"unsigned short", data_type::helics_int},
-    {"long", data_type::helics_int},
-    {"unsigned long", data_type::helics_int},
-    {"char", data_type::helics_string},
-    {"uchar", data_type::helics_int},
-    {"unsigned char", data_type::helics_int},
-    {"byte", data_type::helics_int},
-    {"int8", data_type::helics_int},
-    {"uint8", data_type::helics_int},
-    {"complex_vector", data_type::helics_complex_vector},
-    {"complex vector", data_type::helics_complex_vector},
     {typeid(std::vector<std::complex<double>>).name(), data_type::helics_complex_vector},
-    {gmlc::demangle(typeid(std::vector<std::complex<double>>).name()),
-     data_type::helics_complex_vector},
-    {"d", data_type::helics_double},
-    {"s", data_type::helics_string},
-    {"f", data_type::helics_double},
-    {"v", data_type::helics_vector},
-    {"c", data_type::helics_complex},
     {typeid(std::complex<double>).name(), data_type::helics_complex},
-    {gmlc::demangle(typeid(std::complex<double>).name()), data_type::helics_complex},
-    {"t", data_type::helics_time},
-    {"i", data_type::helics_int},
-    {"i64", data_type::helics_int},
-    {"cv", data_type::helics_complex_vector},
-    {"np", data_type::helics_named_point},
-    {"point", data_type::helics_named_point},
-    {"pt", data_type::helics_named_point},
-    {"named_point", data_type::helics_named_point},
     {typeid(std::string).name(), data_type::helics_string},
-    {gmlc::demangle(typeid(std::string).name()), data_type::helics_string},
     {typeid(char*).name(), data_type::helics_string},
     {typeid(const char*).name(), data_type::helics_string},
-    {"default", data_type::helics_any},
-    {"time", data_type::helics_time},
-    {typeid(Time).name(), data_type::helics_time},
-    {gmlc::demangle(typeid(Time).name()), data_type::helics_time},
-    {"tm", data_type::helics_time},
-    {"multi", data_type::helics_multi},
-    {"many", data_type::helics_multi},
-    {"def", data_type::helics_any},
-    {"any", data_type::helics_any},
-    {"", data_type::helics_any},
-    {"all", data_type::helics_any}};
+    {typeid(Time).name(), data_type::helics_time}
+};
 
-data_type getTypeFromString(const std::string& typeName)
+data_type getTypeFromString(std::string_view typeName)
 {
     if (!typeName.empty() && typeName.front() == '[') {
         return data_type::helics_multi;
     }
-    auto res = typeMap.find(typeName);
-    if (res == typeMap.end()) {
-        auto lcStr = convertToLowerCase(typeName);
-        res = typeMap.find(lcStr);
-        if (res == typeMap.end()) {
-            return data_type::helics_custom;
-        }
+    const auto* res = typeMap.find(frozen::string(typeName.data(),typeName.size()));
+    if (res!=typeMap.end()) {
+        return res->second;
     }
-    return res->second;
+        std::string strName(typeName);
+        auto dres = demangle_names.find(strName);
+        if (dres!=demangle_names.end()) {
+            return dres->second;
+        }
+        makeLowerCase(strName);
+        res = typeMap.find(frozen::string(strName.data(), strName.size()));
+        if (res != typeMap.end()) {
+            return res->second;
+        }
+        dres = demangle_names.find(strName);
+        if (dres != demangle_names.end()) {
+            return dres->second;
+        }
+        return data_type::helics_custom;
 }
 
 // regular expression to handle complex numbers of various formats
@@ -203,9 +242,31 @@ std::complex<double> helicsGetComplex(std::string_view val)
     if (val.empty()) {
         return invalidValue<std::complex<double>>();
     }
-    std::smatch m;
     double re{invalidValue<double>()};
     double im{0.0};
+    if (val.front() =='[') {
+        
+        auto sep = val.find_first_of(',');
+        if (sep==std::string_view::npos) {
+            val.remove_prefix(1);
+            val.remove_suffix(1);
+            re = numConv<double>(val);
+            return {re, im};
+        }
+        if (val.find_first_of(',',sep+1)!=std::string_view::npos) {
+            auto V = helicsGetVector(val);
+            if (V.size()>=2) {
+                return {V[0], V[1]};
+            }
+            return invalidValue<std::complex<double>>();
+        }
+        re = numConv<double>(val.substr(1, sep));
+        val.remove_suffix(1);
+        im = numConv<double>(val.substr(sep + 1));
+        return {re, im};
+    }
+    std::smatch m;
+   
     auto temp = std::string(val);
     std::regex_search(temp, m, creg);
     try {
@@ -238,58 +299,17 @@ std::complex<double> helicsGetComplex(std::string_view val)
 
 std::string helicsVectorString(const std::vector<double>& val)
 {
-    std::string vString("v");
-    vString.append(std::to_string(val.size()));
-    vString.push_back('[');
-    for (const auto& v : val) {
-        vString.append(std::to_string(v));
-        vString.push_back(';');
-        vString.push_back(' ');
-    }
-    if (vString.size() > 3)  // 3 for v0[ which would be for an empty vector
-    {
-        vString.pop_back();
-        vString.pop_back();
-    }
-    vString.push_back(']');
-    return vString;
+    return fmt::format("[{:g}]", fmt::join(val, ","));
 }
 
 std::string helicsVectorString(const double* vals, size_t size)
 {
-    std::string vString("v");
-    vString.append(std::to_string(size));
-    vString.push_back('[');
-    for (size_t ii = 0; ii < size; ++ii) {
-        vString.append(std::to_string(vals[ii]));
-        vString.push_back(';');
-        vString.push_back(' ');
-    }
-    if (vString.size() > 3)  // 3 for c0[ which would be for an empty vector
-    {
-        vString.pop_back();
-        vString.pop_back();
-    }
-    vString.push_back(']');
-    return vString;
+    return fmt::format("[{:g}]", fmt::join(vals, vals + size, ","));
 }
 
 std::string helicsComplexVectorString(const std::vector<std::complex<double>>& val)
 {
-    std::string vString("c");
-    vString.append(std::to_string(val.size()));
-    vString.push_back('[');
-    for (const auto& v : val) {
-        vString.append(helicsComplexString(v.real(), v.imag()));
-        vString.push_back(';');
-        vString.push_back(' ');
-    }
-    if (vString.size() > 3) {
-        vString.pop_back();
-        vString.pop_back();
-    }
-    vString.push_back(']');
-    return vString;
+    return fmt::format("[{}]", fmt::join(val, ","));
 }
 
 std::string helicsNamedPointString(const NamedPoint& point)
@@ -298,17 +318,13 @@ std::string helicsNamedPointString(const NamedPoint& point)
 }
 std::string helicsNamedPointString(std::string_view pointName, double val)
 {
-    std::string retStr = "{\"";
-    if (!pointName.empty()) {
-        retStr.append(pointName);
+    Json::Value NP;
+    NP["value"] = val;
+    if (pointName.empty()) {
     } else {
-        retStr.append("value");
+        NP["name"] = Json::Value(pointName.data(), pointName.data()+pointName.size());
     }
-    retStr.push_back('"');
-    retStr.push_back(':');
-    retStr.append(std::to_string(val));
-    retStr.push_back('}');
-    return retStr;
+    return generateJsonString(NP);
 }
 
 std::vector<double> helicsGetVector(std::string_view val)
@@ -327,33 +343,36 @@ std::vector<std::complex<double>> helicsGetComplexVector(std::string_view val)
 
 NamedPoint helicsGetNamedPoint(std::string_view val)
 {
-    auto loc = val.find_first_of('{');
-    if (loc == std::string::npos) {
-        auto fb = val.find_first_of('[');
-        if (fb != std::string::npos) {
-            return {val, std::nan("0")};
+    NamedPoint p;
+    try {
+        auto jv = loadJsonStr(val);
+        switch (jv.type()) {
+            case Json::ValueType::realValue:
+                p.value = jv.asDouble();
+                p.name = "value";
+                break;
+            case Json::ValueType::stringValue:
+                p.name = jv.asString();
+                break;
+            case Json::ValueType::arrayValue:
+                break;
+            case Json::ValueType::intValue:
+            case Json::ValueType::uintValue:
+                p.value = static_cast<double>(jv.asInt());
+                p.name = "value";
+                break;
+            case Json::ValueType::objectValue:
+                replaceIfMember(jv, "value", p.value);
+                replaceIfMember(jv, "name", p.name);
+                break;
+            default:
+                break;
         }
-        auto V = helicsGetComplex(val);
-        if (V.real() <= invalidDouble) {
-            return {val, std::nan("0")};
-        }
-        if (V.imag() == 0) {
-            return {"value", std::abs(V)};
-        }
-        return {val, V.real()};
     }
-    auto locsep = val.find_last_of(':');
-    auto locend = val.find_last_of('}');
-    auto str1 = val.substr(loc + 1, locsep - loc);
-    string_viewOps::trimString(str1);
-    str1.remove_suffix(1);
-
-    NamedPoint point;
-    point.name = string_viewOps::removeQuotes(str1);
-    auto vstr = val.substr(locsep + 1, locend - locsep - 1);
-    string_viewOps::trimString(vstr);
-    point.value = numConv<double>(vstr);
-    return point;
+    catch (...) {
+        p.name = val;
+    }
+    return p;
 }
 
 static int readSize(std::string_view val)
@@ -497,21 +516,63 @@ void helicsGetComplexVector(std::string_view val, std::vector<std::complex<doubl
             fb = nc;
         }
     } else {
-        auto V = helicsGetComplex(val);
-        data.resize(0);
-        data.push_back(V);
+        if (val.find_first_of("ji")!=std::string_view::npos) {
+            auto V = helicsGetComplex(val);
+            data.resize(0);
+            data.push_back(V);
+        } else {
+            auto JV = loadJsonStr(val);
+            int cnt = 0;
+            switch (JV.type()) {
+                case Json::ValueType::realValue:
+                case Json::ValueType::intValue:
+                case Json::ValueType::uintValue:
+                    data.resize(0);
+                    data.emplace_back(JV.asDouble(), 0.0);
+                    break;
+                case Json::ValueType::arrayValue: 
+                    for (auto& av : JV) {
+                        if (av.isNumeric()) {
+                            if (cnt==0) {
+                                data.emplace_back(av.asDouble(), 0.0);
+                                cnt = 1;
+                            } else {
+                                data.back() += std::complex<double>{0.0, av.asDouble()};
+                                cnt = 0;
+                            }
+                        } else if (av.isArray()) {
+                            cnt = 0;
+                            if (av.size() >= 2) {
+                                if (av[0].isNumeric()) {
+                                    data.emplace_back(av[0].asDouble(), av[1].asDouble());
+                                }
+                            } else if (av.size() == 1) {
+                                if (av[0].isNumeric()) {
+                                    data.emplace_back(av[0].asDouble(),0.0);
+                                }
+                            } else {
+                                data.push_back(invalidValue<std::complex<double>>());
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        
     }
 }
 
 bool helicsBoolValue(std::string_view val)
 {
-    static const std::unordered_map<std::string, bool> knownStrings{
+    static constexpr const frozen::unordered_map<frozen::string, bool,35> knownStrings{
 
         {"0", false},
         {"00", false},
-        {"\0", false},
+        {frozen::string("\0",1), false},
         {"0000", false},
-        {std::string(8, '\0'), false},
+        {frozen::string("\0\0\0\0\0\0\0\0",8), false},
         {"1", true},
         {"false", false},
         {"true", true},
@@ -541,11 +602,11 @@ bool helicsBoolValue(std::string_view val)
         {"enable", true},
         {"disabled", false},
         {"enabled", true},
-        {std::string{}, false},
+        {"", false}
     };
     // all known false strings are captured in known strings so if it isn't in there it evaluates to
     // true
-    auto res = knownStrings.find(std::string(val));
+    const auto * res = knownStrings.find(frozen::string(val.data(),val.size()));
     if (res != knownStrings.end()) {
         return res->second;
     }
@@ -575,7 +636,7 @@ data_block emptyBlock(data_type outputType, data_type inputType = data_type::hel
                 case data_type::helics_complex_vector:
                     return helicsComplexVectorString(std::vector<std::complex<double>>());
                 case data_type::helics_named_point:
-                    return "{\"\":0}";
+                    return "0";
             }
         case data_type::helics_complex_vector: {
             return ValueConverter<std::vector<std::complex<double>>>::convert(

--- a/src/helics/application_api/helicsTypes.hpp
+++ b/src/helics/application_api/helicsTypes.hpp
@@ -299,7 +299,7 @@ inline constexpr bool isRawType(data_type type)
 HELICS_CXX_EXPORT const std::string& typeNameStringRef(data_type type);
 
 /** convert a string to a type*/
-HELICS_CXX_EXPORT data_type getTypeFromString(const std::string& typeName);
+HELICS_CXX_EXPORT data_type getTypeFromString(std::string_view typeName);
 
 /** generate a string representation of a complex number from separate real and imaginary parts*/
 HELICS_CXX_EXPORT std::string helicsComplexString(double real, double imag);

--- a/src/helics/application_api/helicsTypes.hpp
+++ b/src/helics/application_api/helicsTypes.hpp
@@ -301,6 +301,10 @@ HELICS_CXX_EXPORT const std::string& typeNameStringRef(data_type type);
 /** convert a string to a type*/
 HELICS_CXX_EXPORT data_type getTypeFromString(std::string_view typeName);
 
+/** convert to a string and also get a cleaned view of the string if it were a specific typeid
+@details returns the input if not changed*/
+HELICS_CXX_EXPORT std::string_view getCleanedTypeName(std::string_view typeName);
+
 /** generate a string representation of a complex number from separate real and imaginary parts*/
 HELICS_CXX_EXPORT std::string helicsComplexString(double real, double imag);
 /** generate a string representation of a complex number */

--- a/src/helics/common/JsonProcessingFunctions.cpp
+++ b/src/helics/common/JsonProcessingFunctions.cpp
@@ -52,7 +52,7 @@ Json::Value loadJsonStr(std::string_view jsonString)
     Json::Value doc;
     Json::CharReaderBuilder rbuilder;
     std::string errs;
-    auto* reader = rbuilder.newCharReader();
+    auto reader = std::unique_ptr<Json::CharReader>(rbuilder.newCharReader());
     bool ok = reader->parse(jsonString.data(), jsonString.data() + jsonString.size(), &doc, &errs);
     if (!ok) {
         throw(std::invalid_argument(errs.c_str()));

--- a/src/helics/common/JsonProcessingFunctions.cpp
+++ b/src/helics/common/JsonProcessingFunctions.cpp
@@ -47,13 +47,13 @@ Json::Value loadJson(const std::string& jsonString)
     return loadJsonStr(jsonString);
 }
 
-Json::Value loadJsonStr(const std::string& jsonString)
+Json::Value loadJsonStr( std::string_view jsonString)
 {
     Json::Value doc;
     Json::CharReaderBuilder rbuilder;
     std::string errs;
-    std::istringstream jstring(jsonString);
-    bool ok = Json::parseFromStream(rbuilder, jstring, &doc, &errs);
+    auto* reader = rbuilder.newCharReader();
+    bool ok = reader->parse(jsonString.data(),jsonString.data()+jsonString.size(), &doc, &errs);
     if (!ok) {
         throw(std::invalid_argument(errs.c_str()));
     }

--- a/src/helics/common/JsonProcessingFunctions.cpp
+++ b/src/helics/common/JsonProcessingFunctions.cpp
@@ -47,13 +47,13 @@ Json::Value loadJson(const std::string& jsonString)
     return loadJsonStr(jsonString);
 }
 
-Json::Value loadJsonStr( std::string_view jsonString)
+Json::Value loadJsonStr(std::string_view jsonString)
 {
     Json::Value doc;
     Json::CharReaderBuilder rbuilder;
     std::string errs;
     auto* reader = rbuilder.newCharReader();
-    bool ok = reader->parse(jsonString.data(),jsonString.data()+jsonString.size(), &doc, &errs);
+    bool ok = reader->parse(jsonString.data(), jsonString.data() + jsonString.size(), &doc, &errs);
     if (!ok) {
         throw(std::invalid_argument(errs.c_str()));
     }

--- a/src/helics/common/JsonProcessingFunctions.hpp
+++ b/src/helics/common/JsonProcessingFunctions.hpp
@@ -26,7 +26,7 @@ Json::Value loadJson(const std::string& jsonString);
 
 /** load a JSON object in a string
  */
-Json::Value loadJsonStr(const std::string& jsonString);
+Json::Value loadJsonStr(std::string_view jsonString);
 
 /** read a time from a JSON value element*/
 helics::Time loadJsonTime(const Json::Value& timeElement,
@@ -131,5 +131,12 @@ inline void replaceIfMember(const Json::Value& element, const std::string& key, 
 {
     if (element.isMember(key)) {
         sval = element[key].asInt();
+    }
+}
+
+inline void replaceIfMember(const Json::Value& element, const std::string& key, double& sval)
+{
+    if (element.isMember(key)) {
+        sval = element[key].asDouble();
     }
 }

--- a/tests/helics/application_api/PrimaryTypeConversionTests.cpp
+++ b/tests/helics/application_api/PrimaryTypeConversionTests.cpp
@@ -126,9 +126,6 @@ TEST(type_conversion_tests, namedType_tests)
     EXPECT_TRUE(getTypeFromString(typeid(bool).name()) == data_type::helics_bool);
     EXPECT_TRUE(getTypeFromString(typeid(int64_t).name()) == data_type::helics_int);
     EXPECT_TRUE(getTypeFromString(typeid(char).name()) == data_type::helics_string);
-    printf("typeid(char)=%s produces %d\n",
-           typeid(char).name(),
-           static_cast<int>(getTypeFromString(typeid(char).name())));
     EXPECT_TRUE(getTypeFromString(typeid(std::complex<double>).name()) ==
                 data_type::helics_complex);
     EXPECT_TRUE(getTypeFromString("COMPLEX") == data_type::helics_complex);

--- a/tests/helics/application_api/PrimaryTypeConversionTests.cpp
+++ b/tests/helics/application_api/PrimaryTypeConversionTests.cpp
@@ -5,11 +5,12 @@ Energy, LLC.  See the top-level NOTICE for additional details. All rights reserv
 SPDX-License-Identifier: BSD-3-Clause
 */
 
+#include "helics/common/JsonProcessingFunctions.hpp"
+
 #include <complex>
 #include <gtest/gtest.h>
 #include <list>
 #include <set>
-#include "helics/common/JsonProcessingFunctions.hpp"
 
 /** these test cases test out the value converters
  */

--- a/tests/helics/application_api/PrimaryTypeConversionTests.cpp
+++ b/tests/helics/application_api/PrimaryTypeConversionTests.cpp
@@ -126,6 +126,9 @@ TEST(type_conversion_tests, namedType_tests)
     EXPECT_TRUE(getTypeFromString(typeid(bool).name()) == data_type::helics_bool);
     EXPECT_TRUE(getTypeFromString(typeid(int64_t).name()) == data_type::helics_int);
     EXPECT_TRUE(getTypeFromString(typeid(char).name()) == data_type::helics_string);
+    printf("typeid(char)=%s produces %d\n",
+           typeid(char).name(),
+           static_cast<int>(getTypeFromString(typeid(char).name())));
     EXPECT_TRUE(getTypeFromString(typeid(std::complex<double>).name()) ==
                 data_type::helics_complex);
     EXPECT_TRUE(getTypeFromString("COMPLEX") == data_type::helics_complex);

--- a/tests/helics/application_api/PrimaryTypeConversionTests.cpp
+++ b/tests/helics/application_api/PrimaryTypeConversionTests.cpp
@@ -9,6 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <gtest/gtest.h>
 #include <list>
 #include <set>
+#include "helics/common/JsonProcessingFunctions.hpp"
 
 /** these test cases test out the value converters
  */
@@ -23,10 +24,7 @@ bool checkTypeConversion1(const T1& val1, const T2& exp)
     defV val = val1;
     T2 v2{};
     valueExtract(val, v2);
-    if (v2 != exp) {
-        return false;
-    }
-    return true;
+    return (v2 == exp);
 }
 
 TEST(type_conversion_tests, vectorNorm_tests)
@@ -177,7 +175,10 @@ TEST(type_conversion_tests, namedpoint_conversion_tests)
         checkTypeConversion1(vp,
                              std::vector<std::complex<double>>{std::complex<double>(val, 0.0)}));
     EXPECT_TRUE(checkTypeConversion1(vp, true));
-    EXPECT_TRUE(checkTypeConversion1(vp, std::string("{\"point\":" + std::to_string(val) + "}")));
+    Json::Value v1;
+    v1["name"] = "point";
+    v1["value"] = val;
+    EXPECT_TRUE(checkTypeConversion1(vp, generateJsonString(v1)));
 
     NamedPoint vp2{"v2[3.0,-4.0]", std::nan("0")};
     double v2 = 5.0;

--- a/tests/helics/application_api/helicsTypeTests.cpp
+++ b/tests/helics/application_api/helicsTypeTests.cpp
@@ -81,6 +81,14 @@ TEST(helics_types, vector_string)
     EXPECT_TRUE(v.empty());
 }
 
+TEST(helics_types, vector_to_string)
+{
+    std::vector<double> V1{10.0, 3.5, 5.6};
+    auto v = helicsVectorString(V1);
+    EXPECT_FALSE(v.empty());
+    EXPECT_EQ(v, "[10,3.5,5.6]");
+}
+
 TEST(helics_types, cvector_string)
 {
     auto v = helicsGetComplexVector(std::string{});
@@ -88,4 +96,16 @@ TEST(helics_types, cvector_string)
     v = helicsGetComplexVector("c[1+4j,2-3j,invalid]");
     ASSERT_EQ(v.size(), 3U);
     EXPECT_EQ(v[2], invalidValue<std::complex<double>>());
+}
+
+
+TEST(helics_types, cvector_to_string)
+{
+    std::vector<std::complex<double>> V1{{1, 4}, {2, -3}};
+    auto v = helicsComplexVectorString(V1);
+    EXPECT_FALSE(v.empty());
+    EXPECT_EQ(v, "[[1,4],[2,-3]]");
+
+    auto V2 = helicsGetComplexVector(v);
+    EXPECT_EQ(V1, V2);
 }

--- a/tests/helics/application_api/helicsTypeTests.cpp
+++ b/tests/helics/application_api/helicsTypeTests.cpp
@@ -98,7 +98,6 @@ TEST(helics_types, cvector_string)
     EXPECT_EQ(v[2], invalidValue<std::complex<double>>());
 }
 
-
 TEST(helics_types, cvector_to_string)
 {
     std::vector<std::complex<double>> V1{{1, 4}, {2, -3}};

--- a/tests/helics/shared_library/test-value-federate1.cpp
+++ b/tests/helics/shared_library/test-value-federate1.cpp
@@ -726,7 +726,7 @@ void runFederateTestVectorD(const char* core,
     buf.resize(static_cast<size_t>(actualLen) + 2);
     CE(helicsInputGetString(subid, &(buf[0]), static_cast<int>(buf.size()), &actualLen, &err));
     buf.resize(static_cast<size_t>(actualLen) - 1);
-    EXPECT_EQ(buf[0], 'v');
+    EXPECT_EQ(buf[0], '[');
     EXPECT_EQ(buf.back(), ']');
 
     // publish a second vector

--- a/tests/helics/system_tests/updateTests.cpp
+++ b/tests/helics/system_tests/updateTests.cpp
@@ -168,7 +168,7 @@ TEST_F(update_tests, test_single_update_vector)
     sub.getValue(val);
     EXPECT_TRUE(!sub.isUpdated());
     // make sure the string is what we expect
-    EXPECT_EQ(val, "v1[4.790000]");
+    EXPECT_EQ(val, "[4.79]");
     sub.getValue(val);
     EXPECT_TRUE(!sub.isUpdated());
     pub.publish(testValue2);
@@ -181,7 +181,7 @@ TEST_F(update_tests, test_single_update_vector)
     sub.getValue(val);
     EXPECT_TRUE(!sub.isUpdated());
     // make sure the string is what we expect
-    EXPECT_EQ(val, "v1[9.340000]");
+    EXPECT_EQ(val, "[9.34]");
     sub.getValue(val);
     EXPECT_TRUE(!sub.isUpdated());
     double v2{0};
@@ -233,7 +233,7 @@ TEST_F(update_tests, test_single_update_vector_char_ptr)
     sub.getValue(val.data(), 50);
     EXPECT_TRUE(!sub.isUpdated());
     // make sure the string is what we expect
-    EXPECT_EQ(std::string(val.data()), "v1[4.790000]");
+    EXPECT_EQ(std::string(val.data()), "[4.79]");
     sub.getValue(val.data(), 50);
     EXPECT_TRUE(!sub.isUpdated());
     pub.publish(testValue2);
@@ -246,7 +246,7 @@ TEST_F(update_tests, test_single_update_vector_char_ptr)
     sub.getValue(val.data(), 50);
     EXPECT_TRUE(!sub.isUpdated());
     // make sure the string is what we expect
-    EXPECT_EQ(std::string(val.data()), "v1[9.340000]");
+    EXPECT_EQ(std::string(val.data()), "[9.34]");
     sub.getValue(val.data(), 50);
     EXPECT_TRUE(!sub.isUpdated());
     double v2{0};


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will use JSON strings as the vector and complex vector conversion operations.  

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
- update vector to string operations
- update complex vector to string operations
- update named point to string operations
- update complex number to string operation now `[real, imag]` instead of using the i/j notation, though the ability to read that notation remains in place.  
