### PR TITLE
CMake error if user sets the install prefix to the build folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND CMAKE_PROJECT_NAME STREQUAL P
     endif(WIN32)
 endif()
 
-# Check to make sure the install prefix isn't the build folder, if it is, build errors will
-# happen
+# Check to make sure the install prefix isn't the build folder, if it is, build errors will happen
 get_filename_component(tmp_install_prefix ${CMAKE_INSTALL_PREFIX} REALPATH)
 get_filename_component(tmp_proj_bindir ${PROJECT_BINARY_DIR} REALPATH)
 # Windows paths are case insensitive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,19 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND CMAKE_PROJECT_NAME STREQUAL P
     endif(WIN32)
 endif()
 
+# Check to make sure the install prefix isn't the build folder
+# If they match, build errors will happen
+get_filename_component(tmp_install_prefix ${CMAKE_INSTALL_PREFIX} REALPATH)
+get_filename_component(tmp_proj_bindir ${PROJECT_BINARY_DIR} REALPATH)
+# Windows paths are case insensitive
+if(WIN32)
+    string(TOLOWER "${tmp_install_prefix}" tmp_install_prefix)
+    string(TOLOWER "${tmp_proj_bindir}" tmp_proj_bindir)
+endif()
+if(tmp_install_prefix STREQUAL tmp_proj_bindir)
+    message(FATAL_ERROR "CMAKE_INSTALL_PREFIX must not be set to the build folder")
+endif()
+
 if(MSYS
    OR CYGWIN
    OR UNIX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,8 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND CMAKE_PROJECT_NAME STREQUAL P
     endif(WIN32)
 endif()
 
-# Check to make sure the install prefix isn't the build folder
-# If they match, build errors will happen
+# Check to make sure the install prefix isn't the build folder, if it is, build errors will
+# happen
 get_filename_component(tmp_install_prefix ${CMAKE_INSTALL_PREFIX} REALPATH)
 get_filename_component(tmp_proj_bindir ${PROJECT_BINARY_DIR} REALPATH)
 # Windows paths are case insensitive


### PR DESCRIPTION

### Summary

If merged this pull request will make CMake exit with an error if the install prefix is set to the build folder. Setting install prefix to the build folder is the likely cause of #1445, due to build files conflicting with install files when the install path is set to the build folder.

### Proposed changes

- Exit CMake configure with an error if a user sets the install prefix to the build folder
