### PR TITLE
Benchmark build workflow

### DIFF
--- a/.github/actions/benchmark-build/benchmark-Linux.sh
+++ b/.github/actions/benchmark-build/benchmark-Linux.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This uses bash variable substitution in a few places
+# 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+
+#wget --quiet -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && chmod +x cmake-install.sh
+#sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
+#rm cmake-install.sh
+
+mkdir build && cd build || exit
+cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
+cmake --build . --config Release
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+"${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
+cd ../artifact || exit
+rm -rf _CPack_Packages

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This uses bash variable substitution in a few places
+# 1. replacing x86 with Win32 (setting the Python version uses x86)
+# 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+
+echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
+choco install -y swig
+BOOST_ROOT="${BOOST_ROOT_1_72_0}"
+export BOOST_ROOT
+mkdir build && cd build || exit
+cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
+cmake --build . --config Release
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+"${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
+cd ../artifact || exit
+rm -rf _CPack_Packages

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -4,7 +4,6 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
-choco install -y swig
 BOOST_ROOT="${BOOST_ROOT_1_72_0}"
 export BOOST_ROOT
 mkdir build && cd build || exit

--- a/.github/actions/benchmark-build/benchmark-macOS.sh
+++ b/.github/actions/benchmark-build/benchmark-macOS.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This uses bash variable substitution in a few places
+# 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
+
+brew install swig boost
+mkdir build && cd build || exit
+cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
+cmake --build . --config Release
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+"${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
+cd ../artifact || exit
+rm -rf _CPack_Packages

--- a/.github/actions/benchmark-build/benchmark-macOS.sh
+++ b/.github/actions/benchmark-build/benchmark-macOS.sh
@@ -2,7 +2,7 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
-brew install swig boost
+brew install boost
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release

--- a/.github/workflows/benchmark-package.yml
+++ b/.github/workflows/benchmark-package.yml
@@ -8,7 +8,6 @@ on:
               required: false
   schedule:
     - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
-  push:
 
 jobs:
 #####################################

--- a/.github/workflows/benchmark-package.yml
+++ b/.github/workflows/benchmark-package.yml
@@ -1,0 +1,95 @@
+name: Build benchmarks
+
+on:
+  workflow_dispatch:
+      inputs:
+          webhook:
+              description: 'Webhook to call with the completed workflow run id'
+              required: false
+  schedule:
+    - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
+
+jobs:
+#####################################
+# Build benchmarks
+#####################################
+  build-benchmarks:
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Benchmarks
+    strategy:
+      matrix:
+        id: [windows-x64, macos-x64, linux-x64]
+        include:
+          - id: windows-x64
+            os: windows-latest
+            arch: x64
+            cpack_gen: ZIP
+            cmake_gen: 'Visual Studio 16 2019'
+            msvc_ver: 'msvc2019'
+          - id: macos-x64
+            os: macos-latest
+            arch: x64
+            cpack_gen: ZIP
+            macos_target_ver: '10.9'
+          - id: linux-x64
+            os: ubuntu-latest
+            arch: x64
+            cpack_gen: TGZ
+
+    steps:
+    - name: Checkout event ref
+      uses: actions/checkout@v2
+      if: github.event_name != 'schedule'
+    
+    - name: Checkout develop branch
+      uses: actions/checkout@v2
+      with:
+        ref: develop
+      if: github.event_name == 'schedule'
+      
+    # Setup a copy of the macOS SDK
+    - name: Setup macOS SDK
+      if: runner.os == 'macOS'
+      run: ./.github/actions/setup-macos-10.9-sdk.sh
+        
+    # Compile HELICS and create the benchmark package
+    - name: Build benchmarks
+      if: runner.os != 'Linux'
+      env:
+        BUILD_ARCH: ${{ matrix.arch }}
+        BUILD_GEN: ${{ matrix.cmake_gen }}
+        MSVC_VER: ${{ matrix.msvc_ver }}
+        MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_target_ver }}
+        CPACK_GEN: ${{ matrix.cpack_gen }}
+      shell: bash
+      run: ./.github/actions/benchmark-build/benchmark-${{ runner.os }}.sh
+ 
+    - name: Build benchmarks (container)
+      if: runner.os == 'Linux'
+      uses: ./.github/actions/linux-release-builder
+      with:
+        script: ./.github/actions/benchmark-build/benchmark-${{ runner.os }}.sh
+       
+    # GitHub Actions combines artifacts uploaded with the same name
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ runner.os }}-benchmarks
+        path: artifact
+      
+
+#####################################
+# Call webhook for finished build 
+#####################################
+  benchmark-build-complete-webhook:
+    name: Call webhook to notify of the finished benchmark build
+    needs: [build-benchmarks]
+    runs-on: ubuntu-latest
+    if: github.event.inputs.webhook
+    steps:
+      - name: Call webhook
+        run: |
+          curl -X POST --header 'authorization: Bearer ${{ secrets.BM_BUILD_SECRET }}' \
+               --url ${{ github.event.inputs.webhook }} \
+               --header 'content-type: application/json' \
+               --data "{\"id\":\"${{ github.run_id }}\"}"

--- a/.github/workflows/benchmark-package.yml
+++ b/.github/workflows/benchmark-package.yml
@@ -7,7 +7,7 @@ on:
               description: 'Webhook to call with the completed workflow run id'
               required: false
   schedule:
-    - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
+    - cron: '15 09 * * */2' # Run at in the early hours of the morning every other day of the week (UTC)
 
 jobs:
 #####################################

--- a/.github/workflows/benchmark-package.yml
+++ b/.github/workflows/benchmark-package.yml
@@ -8,6 +8,7 @@ on:
               required: false
   schedule:
     - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
+  push:
 
 jobs:
 #####################################


### PR DESCRIPTION
### Summary

If merged this pull request will add a workflow to build a package with the benchmarks for Windows/macOS/Linux that can be triggered by an API call (or manually once the workflow is in the master branch). Once it makes its way into master it will also run every 2nd day of the week (3/4 times/week, something like Sunday, Tuesday, Thursday, Saturday or Monday, Wednesday, Friday).

### Proposed changes

- Add a workflow for building packages with the benchmark binaries
