### PR TITLE
Set no_delay on TCP sockets

### DIFF
--- a/src/helics/network/tcp/TcpHelperClasses.cpp
+++ b/src/helics/network/tcp/TcpHelperClasses.cpp
@@ -238,6 +238,7 @@ namespace tcp {
     {
         if (!error) {
             connected.activate();
+            socket_.set_option(asio::ip::tcp::no_delay(true));
         } else {
             std::cerr << "connection error " << error.message() << ": code =" << error.value()
                       << '\n';
@@ -661,6 +662,7 @@ namespace tcp {
         /*setting linger to 1 second*/
         asio::socket_base::linger optionLinger(true, 0);
         new_connection->socket().set_option(optionLinger);
+        new_connection->socket().set_option(asio::ip::tcp::no_delay(true));
         // Set options here
         if (halted.load()) {
             new_connection->close();


### PR DESCRIPTION
### Summary


If merged this pull request will set no_delay on TCP sockets to disable Nagle's algorithm. This significantly improves the performance of the tcpss core when running on multiple machines.

From some limited test runs with various combinations of the broker and federates with no_delay enabled using the MessageExchange benchmark:
| broker no_delay | bm fed no_delay | Benchmark Time |
| --- | --- | --- |
| no | no | > .2 sec |
| no | yes | > .2 sec |
| yes | no | .006 - .06 sec |
| yes | yes | .002 - .02 sec |

Nagle's algorithm is why the tcpss benchmark is consistently slow. The worst case is with the broker using Nagle's algorithm. Setting no_delay on the broker results in the benchmark speed improving by at least an order of magnitude (typical times with it set on the broker but not on the benchmark federates is .015 seconds). Setting no_delay on the sockets for both the broker and federates bring the typical times down to around .0035 seconds. The higher end of the time range is with the larger message size or more packets getting sent, so it's seeing an upward curve similar to the other comm types.

### Proposed changes

- Set no_delay on TCP sockets
