### PR TITLE
Setup CI jobs on Azure pipelines

### DIFF
--- a/.ci/azure-pipelines-daily.yml
+++ b/.ci/azure-pipelines-daily.yml
@@ -1,9 +1,9 @@
 schedules:
-- cron: "0 10 * * *"
-  displayName: Daily late night PST (GMT-8)
-  branches:
-    include:
-      - helics3
+  - cron: '0 10 * * *'
+    displayName: Daily late night PST (GMT-8)
+    branches:
+      include:
+        - helics3
 
 jobs:
   - job: Daily Linux
@@ -15,12 +15,12 @@ jobs:
         zmq-subproject:
           containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
           test_config: 'ci'
-          zmq_subproject: true        
+          zmq_subproject: true
     pool:
       vmImage: 'ubuntu-latest'
     container: $[ variables['containerImage'] ]
     timeoutInMinutes: 90
-    
+
     steps:
       - bash: |
           source scripts/setup-helics-ci-options.sh
@@ -33,7 +33,7 @@ jobs:
           ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
           ZMQ_FORCE_SUBPROJECT: $[variables['zmq_subproject']]
         displayName: 'Build HELICS'
-        
+
       - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
         env:
           TEST_CONFIG: $[variables['test_config']]

--- a/.ci/azure-pipelines-daily.yml
+++ b/.ci/azure-pipelines-daily.yml
@@ -1,0 +1,41 @@
+schedules:
+- cron: "0 10 * * *"
+  displayName: Daily late night PST (GMT-8)
+  branches:
+    include:
+      - helics3
+
+jobs:
+  - job: Daily Linux
+    strategy:
+      matrix:
+        all-tests:
+          containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
+          test_config: 'daily'
+        zmq-subproject:
+          containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
+          test_config: 'ci'
+          zmq_subproject: true        
+    pool:
+      vmImage: 'ubuntu-latest'
+    container: $[ variables['containerImage'] ]
+    timeoutInMinutes: 90
+    
+    steps:
+      - bash: |
+          source scripts/setup-helics-ci-options.sh
+          mkdir -p build && cd build
+          ../scripts/ci-build.sh
+        env:
+          MAKEFLAGS: '-j 4'
+          CMAKE_GENERATOR: 'Unix Makefiles'
+          USE_SWIG: 'true'
+          ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
+          ZMQ_FORCE_SUBPROJECT: $[variables['zmq_subproject']]
+        displayName: 'Build HELICS'
+        
+      - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
+        env:
+          TEST_CONFIG: $[variables['test_config']]
+        workingDirectory: 'build'
+        displayName: 'Test HELICS'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     exclude:
       - pre-commit/*
-      
+
 jobs:
   - job: Linux
     strategy:
@@ -19,12 +19,12 @@ jobs:
         clang5:
           containerImage: 'helics/buildenv:clang5-builder'
           test_config: 'ci'
-          
+
     pool:
       vmImage: 'ubuntu-latest'
     container: $[ variables['containerImage'] ]
     timeoutInMinutes: 90
-    
+
     steps:
       - bash: |
           source scripts/setup-helics-ci-options.sh
@@ -38,7 +38,7 @@ jobs:
           ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
           ZMQ_FORCE_SUBPROJECT: $[variables['zmq_subproject']]
         displayName: 'Build HELICS'
-        
+
       - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
         env:
           TEST_CONFIG: $[variables['test_config']]
@@ -58,7 +58,7 @@ jobs:
     pool:
       vmImage: $[ variables['vmImage'] ]
     timeoutInMinutes: 90
-    
+
     steps:
       - bash: sudo xcode-select --switch "${XCODE_PATH}/Contents/Developer"
         env:
@@ -76,7 +76,7 @@ jobs:
           CMAKE_GENERATOR: 'Unix Makefiles'
           USE_SWIG: 'true'
         displayName: 'Build HELICS'
-        
+
       - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
         env:
           TEST_CONFIG: $[variables['test_config']]

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -2,8 +2,87 @@ trigger:
   branches:
     exclude:
       - pre-commit/*
-
+      
 jobs:
+  - job: Linux
+    strategy:
+      matrix:
+        ubuntuDefault:
+          containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
+          test_config: 'ci'
+        gcc10:
+          containerImage: 'helics/buildenv:gcc10-builder'
+          test_config: 'ci'
+        clang10:
+          containerImage: 'helics/buildenv:clang10-builder'
+          test_config: 'ci'
+        clang5:
+          containerImage: 'helics/buildenv:clang5-builder'
+          test_config: 'ci'
+          
+    pool:
+      vmImage: 'ubuntu-latest'
+    container: $[ variables['containerImage'] ]
+    timeoutInMinutes: 90
+    
+    steps:
+      - bash: |
+          source scripts/setup-helics-ci-options.sh
+          mkdir -p build && cd build
+          ../scripts/ci-build.sh
+        env:
+          MAKEFLAGS: '-j 4'
+          CMAKE_GENERATOR: 'Unix Makefiles'
+          USE_SWIG: 'true'
+          USE_MPI: 'true'
+          ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
+          ZMQ_FORCE_SUBPROJECT: $[variables['zmq_subproject']]
+        displayName: 'Build HELICS'
+        
+      - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
+        env:
+          TEST_CONFIG: $[variables['test_config']]
+        workingDirectory: 'build'
+        displayName: 'Test HELICS'
+
+  - job: macOS
+    strategy:
+      matrix:
+        XCode-latest:
+          test_config: 'ci'
+          vmImage: 'macOS-latest'
+        XCode-oldest:
+          test_config: 'ci'
+          vmImage: 'macOS-10.14'
+          xcode_path: '/Applications/Xcode_10.1.app'
+    pool:
+      vmImage: $[ variables['vmImage'] ]
+    timeoutInMinutes: 90
+    
+    steps:
+      - bash: sudo xcode-select --switch "${XCODE_PATH}/Contents/Developer"
+        env:
+          XCODE_PATH: $[variables['xcode_path']]
+        displayName: 'Set XCode Path'
+        condition: ne(variables['xcode_path'],'')
+      - bash: brew install swig zeromq boost
+        displayName: 'Install dependencies'
+      - bash: |
+          source scripts/setup-helics-ci-options.sh
+          mkdir -p build && cd build
+          ../scripts/ci-build.sh
+        env:
+          MAKEFLAGS: '-j 4'
+          CMAKE_GENERATOR: 'Unix Makefiles'
+          USE_SWIG: 'true'
+        displayName: 'Build HELICS'
+        
+      - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
+        env:
+          TEST_CONFIG: $[variables['test_config']]
+        workingDirectory: 'build'
+        displayName: 'Test HELICS'
+
   - job: Windows
     strategy:
       matrix:

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -32,7 +32,16 @@ if [[ "${DISABLE_INTERFACES}" != *"Java"* ]]; then
     OPTION_FLAGS_ARR+=("-DBUILD_JAVA_INTERFACE=ON")
 fi
 if [[ "${DISABLE_INTERFACES}" != *"Python"* ]]; then
-    OPTION_FLAGS_ARR+=("-DBUILD_PYTHON_INTERFACE=ON" "-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}" "-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH} -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
+    OPTION_FLAGS_ARR+=("-DBUILD_PYTHON_INTERFACE=ON")
+    if [[ "$PYTHON_LIB_PATH" ]]; then
+        OPTION_FLAGS_ARR+=("-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}")
+    fi
+    if [[ "$PYTHON_INCLUDE_PATH" ]]; then
+        OPTION_FLAGS_ARR+=("-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH}")
+    fi
+    if [[ "$PYTHON_EXECUTABLE" ]]; then
+        OPTION_FLAGS_ARR+=("-DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
+    fi
 fi
 if [[ "$USE_SWIG" == 'true' ]]; then
     OPTION_FLAGS_ARR+=("-DHELICS_ENABLE_SWIG=ON")
@@ -67,9 +76,9 @@ fi
 # MPI options
 if [[ "$USE_MPI" ]]; then
     OPTION_FLAGS_ARR+=("-DENABLE_MPI_CORE=ON")
-    CC=${CI_DEPENDENCY_DIR}/mpi/bin/mpicc
+    CC=mpicc
     export CC
-    CXX=${CI_DEPENDENCY_DIR}/mpi/bin/mpic++
+    CXX=mpic++
     export CXX
 fi
 


### PR DESCRIPTION

### Summary

Setup commit and some daily jobs on Azure Pipelines

If merged this pull request will add Linux and macOS jobs to runs on Azure Pipelines, and some scheduled daily jobs for checking (possibly less common) variants.

### Proposed changes

- Add Linux and macOS jobs to Azure Pipelines
- Make some aspects of the CI build/test scripts use-able on services other than Travis CI
