### PR TITLE
Create mechanics for some queries of the broker to reset on changes

### DIFF
--- a/docs/user-guide/queries.md
+++ b/docs/user-guide/queries.md
@@ -166,6 +166,8 @@ The following queries will be answered by a core.
 +----------------------+-------------------------------------------------------------------------------------+
 | ``version``          | the version string for the helics library [string]                                  |
 +----------------------+-------------------------------------------------------------------------------------+
+| ``counter``          | A single number with a code, changes indicate core changes [string]                 |
++----------------------+-------------------------------------------------------------------------------------+
 ```
 
 The last two are valid but are not usually queried directly, but instead the same query is used on a broker and this query in the core is used as a building block.
@@ -224,9 +226,11 @@ The Following queries will be answered by a broker.
 +----------------------+-------------------------------------------------------------------------------------+
 | ``version``          | the version string for the helics library [string]                                  |
 +----------------------+-------------------------------------------------------------------------------------+
+| ``counter``          | A single number with a code, changes indicate federation changes [string]           |
++----------------------+-------------------------------------------------------------------------------------+
 ```
 
-`federate_map`, `dependency_graph`, `global_time`, and `data_flow_graph` when called with the root broker as a target will generate a JSON string containing the entire structure of the federation. This can take some time to assemble since all members must be queried.
+`federate_map`, `dependency_graph`, `global_time`,`global_state`, and `data_flow_graph` when called with the root broker as a target will generate a JSON string containing the entire structure of the federation. This can take some time to assemble since all members must be queried.
 
 ## Usage Notes
 

--- a/src/helics/common/JsonBuilder.hpp
+++ b/src/helics/common/JsonBuilder.hpp
@@ -49,7 +49,7 @@ class JsonMapBuilder {
     void reset();
     /** set the counter code value*/
     void setCounterCode(int code) { counterCode = code; }
-    int getCounterCode() const { return counterCode; };
+    int getCounterCode() const { return counterCode; }
 };
 
 /** class to help with the generation of JSON*/

--- a/src/helics/common/JsonBuilder.hpp
+++ b/src/helics/common/JsonBuilder.hpp
@@ -21,7 +21,7 @@ class JsonMapBuilder {
   private:
     std::unique_ptr<Json::Value> jMap;
     std::map<int, std::pair<std::string, int32_t>> missing_components;
-
+    int counterCode{0};  // a code for the user to include for various purposes
   public:
     JsonMapBuilder() noexcept;
     ~JsonMapBuilder();
@@ -47,6 +47,9 @@ class JsonMapBuilder {
     std::string generate();
     /** reset the builder*/
     void reset();
+    /** set the counter code value*/
+    void setCounterCode(int code) { counterCode = code; }
+    int getCounterCode() const { return counterCode; };
 };
 
 /** class to help with the generation of JSON*/

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -3985,7 +3985,7 @@ bool CommonCore::checkAndProcessDisconnect()
 int CommonCore::generateMapObjectCounter() const
 {
     int result = static_cast<int>(brokerState.load());
-    for (auto& fed : loopFederates) {
+    for (const auto& fed : loopFederates) {
         result += static_cast<int>(fed.state);
     }
     result += static_cast<int>(loopHandles.size());

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2284,7 +2284,7 @@ std::string CommonCore::coreQuery(const std::string& queryStr) const
             if (builder.isCompleted()) {
                 auto center = generateMapObjectCounter();
                 if (center == builder.getCounterCode()) {
-                    return std::get<0>(mapBuilders[index]).generate();
+                    return builder.generate();
                 }
                 builder.reset();
             }

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2282,8 +2282,8 @@ std::string CommonCore::coreQuery(const std::string& queryStr) const
         if (isValidIndex(index, mapBuilders) && !mi->second.second) {
             auto& builder = std::get<0>(mapBuilders[index]);
             if (builder.isCompleted()) {
-                auto cnter = generateMapObjectCounter();
-                if (cnter == builder.getCounterCode()) {
+                auto center = generateMapObjectCounter();
+                if (center == builder.getCounterCode()) {
                     return std::get<0>(mapBuilders[index]).generate();
                 }
                 builder.reset();
@@ -2296,8 +2296,8 @@ std::string CommonCore::coreQuery(const std::string& queryStr) const
         initializeMapBuilder(queryStr, index, mi->second.second);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
             if (!mi->second.second) {
-                auto cnter = generateMapObjectCounter();
-                std::get<0>(mapBuilders[index]).setCounterCode(cnter);
+                auto center = generateMapObjectCounter();
+                std::get<0>(mapBuilders[index]).setCounterCode(center);
             }
             return std::get<0>(mapBuilders[index]).generate();
         }

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -482,7 +482,8 @@ class CommonCore: public Core, public BrokerBase {
     void sendDisconnect();
     /** broadcast a message to all federates*/
     void broadcastToFederates(ActionMessage& cmd);
-
+    /** generate a counter for when to reset object*/
+    int generateMapObjectCounter() const;
     friend class TimeoutMonitor;
 };
 

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -657,6 +657,19 @@ void CoreBroker::generateTimeBarrier(ActionMessage& m)
     broadcast(m);
 }
 
+int CoreBroker::generateMapObjectCounter() const
+{
+    int result = static_cast<int>(brokerState.load());
+    for (const auto& brk : _brokers) {
+        result += static_cast<int>(brk.state);
+    }
+    for (const auto& fed : _federates) {
+        result += static_cast<int>(fed.state);
+    }
+    result += static_cast<int>(handles.size());
+    return result;
+}
+
 void CoreBroker::transmitDelayedMessages()
 {
     auto msg = delayTransmitQueue.pop();
@@ -2502,7 +2515,7 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
     }
     if ((request == "queries") || (request == "available_queries")) {
         return "[isinit;isconnected;name;identifier;address;queries;address;counts;summary;federates;brokers;inputs;endpoints;"
-               "publications;filters;federate_map;dependency_graph;data_flow_graph;dependencies;dependson;dependents;"
+               "publications;filters;federate_map;dependency_graph;counter;data_flow_graph;dependencies;dependson;dependents;"
                "current_time;current_state;global_state;status;global_time;version;version_all;exists]";
     }
     if (request == "address") {
@@ -2510,6 +2523,9 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
     }
     if (request == "version") {
         return versionString;
+    }
+    if (request == "counter") {
+        return fmt::format("{}", generateMapObjectCounter());
     }
     if (request == "status") {
         Json::Value base;
@@ -2590,17 +2606,27 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
     if (mi != mapIndex.end()) {
         auto index = mi->second.first;
         if (isValidIndex(index, mapBuilders) && !mi->second.second) {
-            if (std::get<0>(mapBuilders[index]).isCompleted()) {
-                return std::get<0>(mapBuilders[index]).generate();
+            auto& builder = std::get<0>(mapBuilders[index]);
+            if (builder.isCompleted()) {
+                auto cnter = generateMapObjectCounter();
+                if (cnter == builder.getCounterCode()) {
+                    return std::get<0>(mapBuilders[index]).generate();
+                }
+                builder.reset();
             }
-            if (std::get<0>(mapBuilders[index]).isActive()) {
+            if (builder.isActive()) {
                 return "#wait";
             }
         }
 
         initializeMapBuilder(request, index, mi->second.second);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
+            if (!mi->second.second) {
+                auto cnter = generateMapObjectCounter();
+                std::get<0>(mapBuilders[index]).setCounterCode(cnter);
+            }
             return std::get<0>(mapBuilders[index]).generate();
+                
         }
         return "#wait";
     }
@@ -2966,6 +2992,8 @@ void CoreBroker::processQueryResponse(const ActionMessage& m)
             requestors.clear();
             if (std::get<2>(mapBuilders[m.counter])) {
                 builder.reset();
+            } else {
+                builder.setCounterCode(generateMapObjectCounter());
             }
         }
     }

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2608,8 +2608,8 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
         if (isValidIndex(index, mapBuilders) && !mi->second.second) {
             auto& builder = std::get<0>(mapBuilders[index]);
             if (builder.isCompleted()) {
-                auto cnter = generateMapObjectCounter();
-                if (cnter == builder.getCounterCode()) {
+                auto center = generateMapObjectCounter();
+                if (center == builder.getCounterCode()) {
                     return std::get<0>(mapBuilders[index]).generate();
                 }
                 builder.reset();
@@ -2622,11 +2622,10 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
         initializeMapBuilder(request, index, mi->second.second);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
             if (!mi->second.second) {
-                auto cnter = generateMapObjectCounter();
-                std::get<0>(mapBuilders[index]).setCounterCode(cnter);
+                auto center = generateMapObjectCounter();
+                std::get<0>(mapBuilders[index]).setCounterCode(center);
             }
             return std::get<0>(mapBuilders[index]).generate();
-                
         }
         return "#wait";
     }

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2610,7 +2610,7 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
             if (builder.isCompleted()) {
                 auto center = generateMapObjectCounter();
                 if (center == builder.getCounterCode()) {
-                    return std::get<0>(mapBuilders[index]).generate();
+                    return builder.generate();
                 }
                 builder.reset();
             }

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -361,6 +361,7 @@ class CoreBroker: public Broker, public BrokerBase {
 
     /** generate a time barrier request*/
     void generateTimeBarrier(ActionMessage& m);
+    int generateMapObjectCounter() const;
     friend class TimeoutMonitor;
 };
 

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -204,6 +204,25 @@ TEST_F(query, dependency_graph)
     helics::cleanupHelicsLibrary();
 }
 
+TEST_F(query, dependency_graph_reset)
+{
+    SetupTest<helics::ValueFederate>("test", 2);
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
+    vFed1->registerGlobalPublication<double>("test1");
+    auto core = vFed1->getCorePointer();
+    auto res1 = core->query("root", "dependency_graph");
+    vFed2->registerSubscription("test1");
+    vFed1->enterInitializingModeAsync();
+    vFed2->enterInitializingMode();
+    vFed1->enterInitializingModeComplete();
+    auto res2 = core->query("root", "dependency_graph");
+    EXPECT_NE(res1, res2);
+    vFed1->finalize();
+    vFed2->finalize();
+    helics::cleanupHelicsLibrary();
+}
+
 TEST_F(query, global_time)
 {
     SetupTest<helics::ValueFederate>("test_3", 2);


### PR DESCRIPTION


<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will add a reset counter to some of the broker queries, dependecy_graph, data_flow_graph,and some others.  

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
- add reset counter to detect changes in the federation
- add a query for the counter to cores and brokers