### PR TITLE
add a requested time field to the current_time query result 

### DIFF
--- a/docs/user-guide/queries.md
+++ b/docs/user-guide/queries.md
@@ -74,7 +74,7 @@ The following queries are defined for federates. Federates may specify a callbac
 +--------------------+------------------------------------------------------------+
 | ``dependents``     | list of dependent objects [sv]                             |
 +--------------------+------------------------------------------------------------+
-| ``current_time``   | the current time of the federate [JSON]                    |
+| ``current_time``   | the current time data for  the federate [JSON]             |
 +--------------------+------------------------------------------------------------+
 |``endpoint_filters``| data structure containing the filters on endpoints[JSON]   |
 +--------------------+------------------------------------------------------------+

--- a/docs/user-guide/queries.md
+++ b/docs/user-guide/queries.md
@@ -74,7 +74,7 @@ The following queries are defined for federates. Federates may specify a callbac
 +--------------------+------------------------------------------------------------+
 | ``dependents``     | list of dependent objects [sv]                             |
 +--------------------+------------------------------------------------------------+
-| ``current_time``   | the current time data for  the federate [JSON]             |
+| ``current_time``   | the current time data for the federate [JSON]             |
 +--------------------+------------------------------------------------------------+
 |``endpoint_filters``| data structure containing the filters on endpoints[JSON]   |
 +--------------------+------------------------------------------------------------+

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2605,7 +2605,7 @@ void CommonCore::processPriorityCommand(ActionMessage&& command)
 
         } break;
         case CMD_QUERY_REPLY:
-            if (command.dest_id == global_broker_id_local || command.dest_id==direct_core_id) {
+            if (command.dest_id == global_broker_id_local || command.dest_id == direct_core_id) {
                 processQueryResponse(command);
             } else {
                 transmit(getRoute(command.dest_id), command);

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2605,7 +2605,7 @@ void CommonCore::processPriorityCommand(ActionMessage&& command)
 
         } break;
         case CMD_QUERY_REPLY:
-            if (command.dest_id == global_broker_id_local) {
+            if (command.dest_id == global_broker_id_local || command.dest_id==direct_core_id) {
                 processQueryResponse(command);
             } else {
                 transmit(getRoute(command.dest_id), command);

--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -483,8 +483,9 @@ void TimeCoordinator::updateTimeGrant()
 std::string TimeCoordinator::printTimeStatus() const
 {
     return fmt::format(
-        R"raw({{"granted_time":{}, "exec":{}, "allow":{}, "value":{}, "message":{}, "minDe":{}, "minminDe":{}}})raw",
+        R"raw({{"granted_time":{},"requested_time":{}, "exec":{}, "allow":{}, "value":{}, "message":{}, "minDe":{}, "minminDe":{}}})raw",
         static_cast<double>(time_granted),
+        static_cast<double>(time_requested),
         static_cast<double>(time_exec),
         static_cast<double>(time_allow),
         static_cast<double>(time_value),

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -268,10 +268,20 @@ TEST_F(query, current_time)
     res = mFed1->query("current_time");
     auto val = loadJsonStr(res);
     EXPECT_EQ(val["granted_time"].asDouble(), 1.0);
+    EXPECT_EQ(val["requested_time"].asDouble(), 1.0);
+
+    mFed1->requestTimeAsync(3.0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    res = mFed1->query("current_time");
+    val = loadJsonStr(res);
+    EXPECT_EQ(val["granted_time"].asDouble(), 1.0);
+    EXPECT_EQ(val["requested_time"].asDouble(), 3.0);
+    mFed2->requestTime(3.0);
+    mFed1->requestTimeComplete();
 
     res = mFed1->query("broker", "current_time");
     val = loadJsonStr(res);
-    EXPECT_EQ(val["time_next"].asDouble(), 1.0);
+    EXPECT_EQ(val["time_next"].asDouble(), 3.0);
 
     res = mFed1->query("root", "current_time");
     EXPECT_EQ(res, "{}");


### PR DESCRIPTION
and fix a bug that could potentially cause deadlock if particular queries were made while a federate was using an async call.

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
- add requested_time field to `current_time` query
- fix potential block issue with the federate query making a query while processing an async call.

