### PR TITLE
add a message clear operation for Message to the C++/C/C++98 APi's

### DIFF
--- a/src/helics/core/core-data.hpp
+++ b/src/helics/core/core-data.hpp
@@ -180,7 +180,8 @@ class Message {
     /** get the payload as a string*/
     const std::string& to_string() const { return data.to_string(); }
     /** clear all data from the message*/
-    void clear() {
+    void clear()
+    {
         time = timeZero;
         flags = 0;
         messageID = 0;

--- a/src/helics/core/core-data.hpp
+++ b/src/helics/core/core-data.hpp
@@ -179,6 +179,18 @@ class Message {
     }
     /** get the payload as a string*/
     const std::string& to_string() const { return data.to_string(); }
+    /** clear all data from the message*/
+    void clear() {
+        time = timeZero;
+        flags = 0;
+        messageID = 0;
+        data.resize(0);
+        dest.clear();
+        source.clear();
+        original_source.clear();
+        original_dest.clear();
+        counter = 0;
+    }
 };
 
 /**

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -182,6 +182,7 @@ class Message {
         mo = HELICS_NULL_POINTER;
         return mreturn;
     }
+    void clear() { helicsMessageClear(mo, HELICS_IGNORE_ERROR);}
     /** generate a new message in a federate*/
     Message& newMessageObject(const Federate& fed);
 

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -182,7 +182,7 @@ class Message {
         mo = HELICS_NULL_POINTER;
         return mreturn;
     }
-    void clear() { helicsMessageClear(mo, HELICS_IGNORE_ERROR);}
+    void clear() { helicsMessageClear(mo, HELICS_IGNORE_ERROR); }
     /** generate a new message in a federate*/
     Message& newMessageObject(const Federate& fed);
 

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -717,7 +717,7 @@ HELICS_EXPORT helics_message_object helicsMessageClone(helics_message_object mes
 HELICS_EXPORT void helicsMessageFree(helics_message_object message);
 
 /**
- * reset a message to empty state
+ * Reset a message to empty state
  * @param message The message object to copy from.
  * @details The message after this function will be empty, with no source or destination
  * @forcpponly

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -709,11 +709,22 @@ HELICS_EXPORT helics_message_object helicsMessageClone(helics_message_object mes
 
 /**
  * Free a message object from memory
+ * @param message The message object to copy from.
  * @details memory for message is managed so not using this function does not create memory leaks, this is an indication
  * to the system that the memory for this message is done being used and can be reused for a new message.
  * helicsFederateClearMessages() can also be used to clear up all stored messages at once
  */
 HELICS_EXPORT void helicsMessageFree(helics_message_object message);
+
+/**
+ * reset a message to empty state
+ * @param message The message object to copy from.
+ * @details The message after this function will be empty, with no source or destination
+ * @forcpponly
+ * @param[in,out] err An error object to fill out in case of an error.
+ * @endforcpponly
+ */
+HELICS_EXPORT void helicsMessageClear(helics_message_object message, helics_error* err);
 
 /**@}*/
 #ifdef __cplusplus

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -990,6 +990,15 @@ void helicsMessageAppendData(helics_message_object message, const void* data, in
     mess->data.append(static_cast<const char*>(data), inputDataLength);
 }
 
+void helicsMessageClear(helics_message_object message, helics_error* err)
+{
+    auto* mess = getMessageObj(message, err);
+    if (mess == nullptr) {
+        return;
+    }
+    mess->clear();
+}
+
 void helicsMessageCopy(helics_message_object source_message, helics_message_object dest_message, helics_error* err)
 {
     auto* mess_src = getMessageObj(source_message, err);

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -508,6 +508,14 @@ TEST(message_object, copy)
 
     EXPECT_EQ(helicsMessageCheckFlag(m2, 4), helics_true);
 
+    helicsMessageClear(m2, &err);
+
+    EXPECT_EQ(helicsMessageIsValid(m2), helics_false);
+
+    EXPECT_EQ(helicsMessageCheckFlag(m2, 4), helics_false);
+
+    EXPECT_EQ(helicsMessageGetRawDataSize(m2), 0);
+
     helicsFederateEnterExecutingMode(fed, nullptr);
     helicsFederateFinalize(fed, nullptr);
     helicsBrokerDisconnect(brk, nullptr);


### PR DESCRIPTION

partially Address Issues #1596 

Need to verify this actually does drop the message seamlessly yet but not in this PR.

add helicsMessageClear to C api

add clear method to C++ interfaces