### PR TITLE
Add workflow_dispatch trigger to test releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,6 +6,7 @@ on:
   # packages - a list of which packages to build (everything, archive, msvc, installer, sharedlib)
   # commit (optional) - the commit-ish to do a release build with
   repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
   release:


### PR DESCRIPTION

### Summary

If merged this pull request will add a workflow_dispatch trigger to the release build workflow in the master branch to enable manual test runs of the release build workflow from the GitHub Actions tab. With tests on a fork, the option to trigger workflow runs didn't show up until the change to the workflow made it to the default/main branch.

### Proposed changes

- Add `workflow_dispatch` as a trigger to the release builds workflow
