### PR TITLE
Update macOS deployment target to 10.14

### DIFF
--- a/.github/actions/setup-macos-10.9-sdk.sh
+++ b/.github/actions/setup-macos-10.9-sdk.sh
@@ -3,7 +3,7 @@
 XCODE_MACOS_PLATFORM_PATH="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform"
 XCODE_MACOS_SDK_PATH="${XCODE_MACOS_PLATFORM_PATH}/Developer/SDKs"
 
-SDK_VER=10.9
+SDK_VER=10.14
 
 # Download macOS SDK
 wget "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX${SDK_VER}.sdk.tar.xz"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -136,7 +136,7 @@ jobs:
             os: macos-latest
             arch: x64
             cpack_gen: ZIP
-            macos_target_ver: '10.9'
+            macos_target_ver: '10.14'
           - id: linux-x64
             os: ubuntu-latest
             arch: x64
@@ -224,7 +224,7 @@ jobs:
           - id: macos-x64
             os: macos-latest
             arch: x64
-            macos_target_ver: '10.9'
+            macos_target_ver: '10.14'
           - id: ubuntu-x64
             os: ubuntu-latest
             arch: x64

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -19,20 +19,20 @@ jobs:
   create-all-submodule-archive:
     name: Create all submodule archive
     runs-on: ubuntu-latest
-    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'everything'))) || github.event.action == 'workflow_dispatch'
+    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'everything'))) || github.event_name == 'workflow_dispatch'
     steps:
     - name: Checkout event ref
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
       
     - name: Create archive
       if: github.event.action != 'helics-release-build'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")" && mkdir artifact && mv "Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}")-source.tar.gz" artifact/
     - name: Create archive (no version)
-      if: github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
+      if: github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh && mkdir artifact && mv "Helics-source.tar.gz" artifact/
      
@@ -54,7 +54,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'everything')) || github.event.action == 'workflow_dispatch'
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'everything')) || github.event == 'workflow_dispatch'
     strategy:
       matrix:
         os: [windows-2016, windows-latest]
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -115,7 +115,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'everything')) || github.event.action == 'workflow_dispatch'
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'everything')) || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -147,7 +147,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'everything')) || github.event.action == 'workflow_dispatch'
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'everything')) || github.event_name == 'workflow_dispatch'
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:
@@ -234,7 +234,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,6 +6,7 @@ on:
   # packages - a list of which packages to build (everything, archive, msvc, installer, sharedlib)
   # commit (optional) - the commit-ish to do a release build with
   repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
   release:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -19,20 +19,20 @@ jobs:
   create-all-submodule-archive:
     name: Create all submodule archive
     runs-on: ubuntu-latest
-    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'everything')))
+    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'everything'))) || github.event.action == 'workflow_dispatch'
     steps:
     - name: Checkout event ref
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
       
     - name: Create archive
       if: github.event.action != 'helics-release-build'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")" && mkdir artifact && mv "Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}")-source.tar.gz" artifact/
     - name: Create archive (no version)
-      if: github.event.action == 'helics-release-build'
+      if: github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh && mkdir artifact && mv "Helics-source.tar.gz" artifact/
      
@@ -54,7 +54,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'everything'))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'everything')) || github.event.action == 'workflow_dispatch'
     strategy:
       matrix:
         os: [windows-2016, windows-latest]
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -115,7 +115,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'everything'))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'everything')) || github.event.action == 'workflow_dispatch'
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -147,7 +147,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'everything'))
+    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'everything')) || github.event.action == 'workflow_dispatch'
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:
@@ -234,7 +234,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event.action == 'workflow_dispatch'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,13 @@ if(HELICS_BUILD_CONFIGURATION STREQUAL "PI")
 endif()
 
 # -------------------------------------------------------------
+# Things to keep builds on macOS < 10.12 working for now
+# -------------------------------------------------------------
+if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.12")
+    add_definitions(-DLIBGUARDED_NO_DEFAULT)
+endif()
+
+# -------------------------------------------------------------
 # finding MPI
 # -------------------------------------------------------------
 


### PR DESCRIPTION
### Summary

Install macOS 10.14 SDK and set macOS 10.14 as the deployment target for release builds.

If merged this pull request will set `LIBGUARDED_NO_DEFAULT` when the macOS deployment target is < 10.12, so if someone wants to try to mess with the default macOS stdlib to build on older versions of macOS < 10.14 they can try.

### Proposed changes

- Install macOS 10.14 SDK for release builds
- Update macOS deployment target version to 10.14 for release builds
- Set `LIBGUARDED_NO_DEFAULT` when building for macOS SDKs < 10.12
- Sets some workflow_dispatch things for testing
