### PR TITLE
move pendingMessages method to pendingMessagesCount

### DIFF
--- a/src/helics/application_api/Endpoints.cpp
+++ b/src/helics/application_api/Endpoints.cpp
@@ -158,9 +158,9 @@ bool Endpoint::hasMessage() const
 }
 
 /** check if there is a message available*/
-std::uint64_t Endpoint::pendingMessages() const
+std::uint64_t Endpoint::pendingMessagesCount() const
 {
-    return (fed != nullptr) ? fed->pendingMessages(*this) : 0;
+    return (fed != nullptr) ? fed->pendingMessagesCount(*this) : 0;
 }
 
 void Endpoint::setCallback(const std::function<void(const Endpoint&, Time)>& callback)

--- a/src/helics/application_api/Endpoints.hpp
+++ b/src/helics/application_api/Endpoints.hpp
@@ -160,8 +160,8 @@ class HELICS_CXX_EXPORT Endpoint: public Interface {
     std::unique_ptr<Message> getMessage() const;
     /** check if there is a message available*/
     bool hasMessage() const;
-    /** check if there is a message available*/
-    std::uint64_t pendingMessages() const;
+    /** Get the number of available messages*/
+    std::uint64_t pendingMessagesCount() const;
     /** register a callback for an update notification
     @details the callback is called in the just before the time request function returns
     @param callback a function with signature void(endpoint_id_t, Time)

--- a/src/helics/application_api/MessageFederate.cpp
+++ b/src/helics/application_api/MessageFederate.cpp
@@ -256,18 +256,18 @@ bool MessageFederate::hasMessage(const Endpoint& ept) const
     return false;
 }
 
-uint64_t MessageFederate::pendingMessages(const Endpoint& ept) const
+uint64_t MessageFederate::pendingMessagesCount(const Endpoint& ept) const
 {
     if (currentMode >= modes::initializing) {
-        return mfManager->pendingMessages(ept);
+        return mfManager->pendingMessagesCount(ept);
     }
     return 0;
 }
 
-uint64_t MessageFederate::pendingMessages() const
+uint64_t MessageFederate::pendingMessagesCount() const
 {
     if (currentMode >= modes::initializing) {
-        return mfManager->pendingMessages();
+        return mfManager->pendingMessagesCount();
     }
     return 0;
 }

--- a/src/helics/application_api/MessageFederate.hpp
+++ b/src/helics/application_api/MessageFederate.hpp
@@ -175,11 +175,11 @@ class HELICS_CXX_EXPORT MessageFederate:
     /**
      * Returns the number of pending receives for the specified destination endpoint.
      */
-    uint64_t pendingMessages(const Endpoint& ept) const;
+    uint64_t pendingMessagesCount(const Endpoint& ept) const;
     /**
      * Returns the number of pending receives for all endpoints.
      */
-    uint64_t pendingMessages() const;
+    uint64_t pendingMessagesCount() const;
     /** receive a packet from a particular endpoint
     @param ept the identifier for the endpoint
     @return a message object*/

--- a/src/helics/application_api/MessageFederateManager.cpp
+++ b/src/helics/application_api/MessageFederateManager.cpp
@@ -112,7 +112,7 @@ bool MessageFederateManager::hasMessage(const Endpoint& ept)
 /**
  * Returns the number of pending receives for the specified destination endpoint.
  */
-uint64_t MessageFederateManager::pendingMessages(const Endpoint& ept)
+uint64_t MessageFederateManager::pendingMessagesCount(const Endpoint& ept)
 {
     if (ept.dataReference != nullptr) {
         auto* eptDat = reinterpret_cast<EndpointData*>(ept.dataReference);
@@ -125,7 +125,7 @@ uint64_t MessageFederateManager::pendingMessages(const Endpoint& ept)
 @details this function is not preferred in multi-threaded contexts due to the required locking
 prefer to just use getMessage until it returns an invalid Message.
 */
-uint64_t MessageFederateManager::pendingMessages() const
+uint64_t MessageFederateManager::pendingMessagesCount() const
 {
     auto eptDat = eptData.lock_shared();
     uint64_t sz = 0;

--- a/src/helics/application_api/MessageFederateManager.hpp
+++ b/src/helics/application_api/MessageFederateManager.hpp
@@ -59,11 +59,11 @@ class MessageFederateManager {
     /**
      * Returns the number of pending receives for the specified destination endpoint.
      */
-    static uint64_t pendingMessages(const Endpoint& ept);
+    static uint64_t pendingMessagesCount(const Endpoint& ept);
     /**
      * Returns the number of pending receives for the specified destination endpoint.
      */
-    uint64_t pendingMessages() const;
+    uint64_t pendingMessagesCount() const;
     /** receive a packet from a particular endpoint
     @param ept the identifier for the endpoint
     @return a message object*/

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -230,7 +230,7 @@ class Endpoint {
     /** get the default destination for an endpoint*/
     const char* getDefaultDestination() const { return helicsEndpointGetDefaultDestination(ep); }
     /** Returns the number of pending receives for endpoint **/
-    uint64_t pendingMessages() const { return helicsEndpointPendingMessages(ep); }
+    uint64_t pendingMessagesCount() const { return helicsEndpointPendingMessagesCount(ep); }
 
     /** Get a packet from an endpoint **/
     Message getMessage() { return Message(helicsEndpointGetMessage(ep)); }

--- a/src/helics/cpp98/MessageFederate.hpp
+++ b/src/helics/cpp98/MessageFederate.hpp
@@ -94,7 +94,7 @@ class MessageFederate: public virtual Federate {
     }
 
     /** Returns the number of pending receives for all endpoints. **/
-    int pendingMessages() const { return helicsFederatePendingMessages(fed); }
+    int pendingMessagesCount() const { return helicsFederatePendingMessagesCount(fed); }
 
     /** Get a packet for any endpoints in the federate **/
     Message getMessage() { return Message(helicsFederateGetMessage(fed)); }

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -311,14 +311,14 @@ HELICS_EXPORT helics_bool helicsEndpointHasMessage(helics_endpoint endpoint);
  *
  * @param fed The federate to get the number of waiting messages from.
  */
-HELICS_EXPORT int helicsFederatePendingMessages(helics_federate fed);
+HELICS_EXPORT int helicsFederatePendingMessagesCount(helics_federate fed);
 
 /**
  * Returns the number of pending receives for all endpoints of a particular federate.
  *
  * @param endpoint The endpoint to query.
  */
-HELICS_EXPORT int helicsEndpointPendingMessages(helics_endpoint endpoint);
+HELICS_EXPORT int helicsEndpointPendingMessagesCount(helics_endpoint endpoint);
 
 /**
  * Receive a packet from a particular endpoint.

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -404,22 +404,22 @@ helics_bool helicsEndpointHasMessage(helics_endpoint endpoint)
     return (endObj->endPtr->hasMessage()) ? helics_true : helics_false;
 }
 
-int helicsFederatePendingMessages(helics_federate fed)
+int helicsFederatePendingMessagesCount(helics_federate fed)
 {
     auto* mFed = getMessageFed(fed, nullptr);
     if (mFed == nullptr) {
         return 0;
     }
-    return static_cast<int>(mFed->pendingMessages());
+    return static_cast<int>(mFed->pendingMessagesCount());
 }
 
-int helicsEndpointPendingMessages(helics_endpoint endpoint)
+int helicsEndpointPendingMessagesCount(helics_endpoint endpoint)
 {
     auto* endObj = verifyEndpoint(endpoint, nullptr);
     if (endObj == nullptr) {
         return 0;
     }
-    return static_cast<int>(endObj->endPtr->pendingMessages());
+    return static_cast<int>(endObj->endPtr->pendingMessagesCount());
 }
 static constexpr uint16_t messageKeyCode = 0xB3;
 

--- a/tests/helics/application_api/FilterTests.cpp
+++ b/tests/helics/application_api/FilterTests.cpp
@@ -1071,7 +1071,7 @@ TEST_F(filter_test, message_multi_clone_test)
     sFed2->requestTimeComplete();
     dcFed->requestTimeComplete();
 
-    auto mcnt = dFed->pendingMessages(p3);
+    auto mcnt = dFed->pendingMessagesCount(p3);
     EXPECT_EQ(mcnt, 2);
     auto res = dFed->hasMessage();
     EXPECT_TRUE(res);
@@ -1095,7 +1095,7 @@ TEST_F(filter_test, message_multi_clone_test)
     }
 
     // now check the message clone
-    mcnt = dcFed->pendingMessages(p4);
+    mcnt = dcFed->pendingMessagesCount(p4);
     EXPECT_EQ(mcnt, 2);
     res = dcFed->hasMessage();
     EXPECT_TRUE(res);

--- a/tests/helics/application_api/FilterTests.cpp
+++ b/tests/helics/application_api/FilterTests.cpp
@@ -451,7 +451,7 @@ static bool two_stage_filter_test(std::shared_ptr<helics::MessageFederate>& mFed
     }
     if (mFed->hasMessage(p2)) {
         auto m2 = mFed->getMessage(p2);
-        auto ept1Name = p1.getKey();
+        const auto& ept1Name = p1.getKey();
         if (ept1Name.size() > 1) {
             EXPECT_EQ(m2->source, p1.getKey());
             EXPECT_EQ(m2->original_source, p1.getKey());

--- a/tests/helics/application_api/MessageFederateAdditionalTests.cpp
+++ b/tests/helics/application_api/MessageFederateAdditionalTests.cpp
@@ -290,7 +290,7 @@ TEST_P(mfed_add_all_type_tests, send_receive_2fed_multisend_callback)
     EXPECT_TRUE(!mFed1->hasMessage());
 
     EXPECT_TRUE(!mFed1->hasMessage(epid));
-    auto cnt = mFed2->pendingMessages(epid2);
+    auto cnt = mFed2->pendingMessagesCount(epid2);
     EXPECT_EQ(cnt, 4);
 
     auto M1 = mFed2->getMessage(epid2);
@@ -299,13 +299,13 @@ TEST_P(mfed_add_all_type_tests, send_receive_2fed_multisend_callback)
 
     EXPECT_EQ(M1->data[245], data1[245]);
     // check the count decremented
-    cnt = mFed2->pendingMessages(epid2);
+    cnt = mFed2->pendingMessagesCount(epid2);
     EXPECT_EQ(cnt, 3);
     auto M2 = mFed2->getMessage();
     ASSERT_TRUE(M2);
     ASSERT_EQ(M2->data.size(), data2.size());
     EXPECT_EQ(M2->data[245], data2[245]);
-    cnt = mFed2->pendingMessages(epid2);
+    cnt = mFed2->pendingMessagesCount(epid2);
     EXPECT_EQ(cnt, 2);
 
     auto M3 = mFed2->getMessage();
@@ -578,13 +578,13 @@ TEST(messageFederate, constructor1)
     mf2 = std::move(mf1);
 
     EXPECT_FALSE(mf2.hasMessage());
-    EXPECT_EQ(mf2.pendingMessages(), 0);
+    EXPECT_EQ(mf2.pendingMessagesCount(), 0);
 
     EXPECT_FALSE(mf2.getMessage());
 
     auto ept1 = mf2.registerEndpoint();
     EXPECT_FALSE(mf2.hasMessage(ept1));
-    EXPECT_EQ(mf2.pendingMessages(ept1), 0);
+    EXPECT_EQ(mf2.pendingMessagesCount(ept1), 0);
     auto m1 = mf2.getMessage(ept1);
     EXPECT_FALSE(m1);
 

--- a/tests/helics/application_api/MessageFederateAdditionalTests.cpp
+++ b/tests/helics/application_api/MessageFederateAdditionalTests.cpp
@@ -258,9 +258,13 @@ TEST_P(mfed_add_all_type_tests, send_receive_2fed_multisend_callback)
     std::atomic<int> e1cnt{0};
     std::atomic<int> e2cnt{0};
     mFed1->setMessageNotificationCallback(epid,
-                                          [&](const helics::Endpoint&, helics::Time) { ++e1cnt; });
+                                          [&](const helics::Endpoint& /*unused*/,
+                                              helics::Time /*unused*/) { ++e1cnt; });
     mFed2->setMessageNotificationCallback(epid2,
-                                          [&](const helics::Endpoint&, helics::Time) { ++e2cnt; });
+                                          [&](const helics::Endpoint& /*unused*/,
+                                              helics::Time /*unused*/) {
+                                              ++e2cnt;
+                                          });
     // mFed1->getCorePointer()->setLoggingLevel(0, 5);
     mFed1->setProperty(helics_property_time_delta, 1.0);
     mFed2->setProperty(helics_property_time_delta, 1.0);
@@ -344,7 +348,6 @@ class PingPongFed {
   public:
     int pings{0};  //!< the number of pings received
     int pongs{0};  //!< the number of pongs received
-  public:
     PingPongFed(const std::string& fname, helics::Time tDelta, helics::core_type ctype):
         delta(tDelta), name(fname), coreType(ctype)
     {
@@ -370,7 +373,6 @@ class PingPongFed {
         ep = &mFed->registerEndpoint("port");
     }
 
-  private:
     void processMessages(helics::Time currentTime)
     {
         while (mFed->hasMessage(*ep)) {

--- a/tests/helics/application_api/MessageFederateAdditionalTests.cpp
+++ b/tests/helics/application_api/MessageFederateAdditionalTests.cpp
@@ -262,9 +262,7 @@ TEST_P(mfed_add_all_type_tests, send_receive_2fed_multisend_callback)
                                               helics::Time /*unused*/) { ++e1cnt; });
     mFed2->setMessageNotificationCallback(epid2,
                                           [&](const helics::Endpoint& /*unused*/,
-                                              helics::Time /*unused*/) {
-                                              ++e2cnt;
-                                          });
+                                              helics::Time /*unused*/) { ++e2cnt; });
     // mFed1->getCorePointer()->setLoggingLevel(0, 5);
     mFed1->setProperty(helics_property_time_delta, 1.0);
     mFed2->setProperty(helics_property_time_delta, 1.0);

--- a/tests/helics/application_api/MessageFederateKeyTests.cpp
+++ b/tests/helics/application_api/MessageFederateKeyTests.cpp
@@ -323,7 +323,7 @@ TEST_P(mfed_all_type_tests, send_receive_2fed_multisend)
     EXPECT_TRUE(!mFed1->hasMessage());
 
     EXPECT_TRUE(!mFed1->hasMessage(epid));
-    auto cnt = mFed2->pendingMessages(epid2);
+    auto cnt = mFed2->pendingMessagesCount(epid2);
     EXPECT_EQ(cnt, 4);
 
     EXPECT_EQ(epid.getDefaultDestination(), "ep2");
@@ -333,13 +333,13 @@ TEST_P(mfed_all_type_tests, send_receive_2fed_multisend)
 
     EXPECT_EQ(M1->data[245], data1[245]);
     // check the count decremented
-    cnt = mFed2->pendingMessages(epid2);
+    cnt = mFed2->pendingMessagesCount(epid2);
     EXPECT_EQ(cnt, 3);
     auto M2 = mFed2->getMessage();
     ASSERT_TRUE(M2);
     ASSERT_EQ(M2->data.size(), data2.size());
     EXPECT_EQ(M2->data[245], data2[245]);
-    cnt = mFed2->pendingMessages(epid2);
+    cnt = mFed2->pendingMessagesCount(epid2);
     EXPECT_EQ(cnt, 2);
 
     auto M3 = mFed2->getMessage();

--- a/tests/helics/apps/combo_tests.cpp
+++ b/tests/helics/apps/combo_tests.cpp
@@ -71,8 +71,8 @@ static void generateFiles(const ghc::filesystem::path& f1, const ghc::filesystem
     mfed.finalize();
     mfed2.finalize();
     fut.get();
-    EXPECT_EQ(rec1.messageCount(), 2u);
-    EXPECT_EQ(rec1.pointCount(), 3u);
+    EXPECT_EQ(rec1.messageCount(), 2U);
+    EXPECT_EQ(rec1.pointCount(), 3U);
 
     rec1.saveFile(f1.string());
 
@@ -94,10 +94,10 @@ static void useFile(const std::string& corename, const std::string& file)
     play1.loadFile(file);
 
     play1.initialize();
-    EXPECT_EQ(play1.pointCount(), 3u);
-    EXPECT_EQ(play1.publicationCount(), 1u);
-    EXPECT_EQ(play1.messageCount(), 2u);
-    EXPECT_EQ(play1.endpointCount(), 2u);
+    EXPECT_EQ(play1.pointCount(), 3U);
+    EXPECT_EQ(play1.publicationCount(), 1U);
+    EXPECT_EQ(play1.messageCount(), 2U);
+    EXPECT_EQ(play1.endpointCount(), 2U);
 
     play1.finalize();
     ghc::filesystem::remove(file);
@@ -170,8 +170,8 @@ static void generateFiles_binary(const ghc::filesystem::path& f1, const ghc::fil
     mfed.finalize();
     mfed2.finalize();
     fut.get();
-    EXPECT_EQ(rec1.messageCount(), 2u);
-    EXPECT_EQ(rec1.pointCount(), 3u);
+    EXPECT_EQ(rec1.messageCount(), 2U);
+    EXPECT_EQ(rec1.pointCount(), 3U);
 
     rec1.saveFile(f1.string());
 
@@ -194,10 +194,10 @@ static void useFileBinary(const std::string& corename, const std::string& file)
     play1.loadFile(file);
 
     play1.initialize();
-    EXPECT_EQ(play1.pointCount(), 3u);
-    EXPECT_EQ(play1.publicationCount(), 1u);
-    EXPECT_EQ(play1.messageCount(), 2u);
-    EXPECT_EQ(play1.endpointCount(), 2u);
+    EXPECT_EQ(play1.pointCount(), 3U);
+    EXPECT_EQ(play1.publicationCount(), 1U);
+    EXPECT_EQ(play1.messageCount(), 2U);
+    EXPECT_EQ(play1.endpointCount(), 2U);
 
     auto& b1 = play1.getMessage(0);
     helics::SmallBuffer n5(256);
@@ -262,10 +262,10 @@ TEST(combo_tests, check_combination_file_load)
             fed.getPublication(1).publish(1);
         }
     }
-    EXPECT_EQ(fed.pendingMessagesCount(), 3u);
+    EXPECT_EQ(fed.pendingMessagesCount(), 3U);
     fed.finalize();
     fut_play.get();
     fut_rec.get();
-    EXPECT_EQ(rec1.messageCount(), 2u);
-    EXPECT_EQ(rec1.pointCount(), 2u);
+    EXPECT_EQ(rec1.messageCount(), 2U);
+    EXPECT_EQ(rec1.pointCount(), 2U);
 }

--- a/tests/helics/apps/combo_tests.cpp
+++ b/tests/helics/apps/combo_tests.cpp
@@ -262,7 +262,7 @@ TEST(combo_tests, check_combination_file_load)
             fed.getPublication(1).publish(1);
         }
     }
-    EXPECT_EQ(fed.pendingMessages(), 3u);
+    EXPECT_EQ(fed.pendingMessagesCount(), 3u);
     fed.finalize();
     fut_play.get();
     fut_rec.get();

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -967,7 +967,7 @@ TEST_F(filter_tests, multi_clone_test)
     CE(helicsFederateRequestTimeComplete(sFed2, &err));
     CE(helicsFederateRequestTimeComplete(dcFed, &err));
 
-    auto mcnt = helicsEndpointPendingMessages(p3);
+    auto mcnt = helicsEndpointPendingMessagesCount(p3);
     EXPECT_EQ(mcnt, 2);
     auto res = helicsFederateHasMessage(dFed);
     EXPECT_EQ(res, helics_true);
@@ -991,7 +991,7 @@ TEST_F(filter_tests, multi_clone_test)
     }
 
     // now check the message clone
-    mcnt = helicsEndpointPendingMessages(p4);
+    mcnt = helicsEndpointPendingMessagesCount(p4);
     EXPECT_EQ(mcnt, 2);
     res = helicsFederateHasMessage(dcFed);
     EXPECT_EQ(res, helics_true);

--- a/tests/helics/shared_library/badInputTests.cpp
+++ b/tests/helics/shared_library/badInputTests.cpp
@@ -412,7 +412,7 @@ TEST_F(function_tests, typePub)
     EXPECT_EQ(str[0], '2');
     EXPECT_EQ(str[1], '7');
 
-    auto messages = helicsFederatePendingMessages(vFed1);
+    auto messages = helicsFederatePendingMessagesCount(vFed1);
     EXPECT_EQ(messages, 0);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -884,7 +884,7 @@ TEST_F(function_tests, messageFed)
 
     helicsFederateRequestNextStep(mFed1, nullptr);
     // make sure the message got through
-    auto cnt = helicsEndpointPendingMessages(ept1);
+    auto cnt = helicsEndpointPendingMessagesCount(ept1);
     EXPECT_EQ(cnt, 2);
 
     // message Federates do not have publications so should be 0
@@ -918,7 +918,7 @@ TEST_F(function_tests, messageFed_event)
     char data[5] = "test";
     helicsEndpointSendAt(ept1, data, 4, 0.0, &err);
     helicsFederateRequestNextStep(mFed1, nullptr);
-    auto cnt = helicsEndpointPendingMessages(ept1);
+    auto cnt = helicsEndpointPendingMessagesCount(ept1);
     EXPECT_EQ(cnt, 3);
 
     helicsFederateFinalize(mFed1, nullptr);
@@ -972,7 +972,7 @@ TEST_F(function_tests, messageFed_messageObject)
     helicsEndpointSendMessageZeroCopy(ept1, mess1, &err);
 
     helicsFederateRequestNextStep(mFed1, nullptr);
-    auto cnt = helicsEndpointPendingMessages(ept1);
+    auto cnt = helicsEndpointPendingMessagesCount(ept1);
     EXPECT_EQ(cnt, 4);
 
     helicsFederateFinalize(mFed1, nullptr);
@@ -1012,7 +1012,7 @@ TEST_F(function_tests, messageFed_message_object)
     helicsEndpointSendMessage(ept1, mess1, &err);
 
     helicsFederateRequestNextStep(mFed1, nullptr);
-    auto cnt = helicsEndpointPendingMessages(ept1);
+    auto cnt = helicsEndpointPendingMessagesCount(ept1);
     EXPECT_EQ(cnt, 1);
 
     auto m3 = helicsFederateGetMessage(mFed1);

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -3206,14 +3206,14 @@ TEST(evil_message_fed_test, helicsFederateHasMessage)
     EXPECT_EQ(res2, helics_false);
 }
 
-TEST(evil_message_fed_test, helicsFederatePendingMessages)
+TEST(evil_message_fed_test, helicsFederatePendingMessagesCount)
 {
     // int helicsFederatePendingMessages(helics_federate fed);
     char rdata[256];
     auto evil_federate = reinterpret_cast<helics_federate>(rdata);
-    auto res1 = helicsFederatePendingMessages(nullptr);
+    auto res1 = helicsFederatePendingMessagesCount(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsFederatePendingMessages(evil_federate);
+    auto res2 = helicsFederatePendingMessagesCount(evil_federate);
     EXPECT_EQ(res2, 0);
 }
 
@@ -3756,9 +3756,9 @@ TEST(evil_endpoint_test, helicsEndpointPendingMessages)
     // int helicsEndpointPendingMessages(helics_endpoint endpoint);
     char rdata[256];
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
-    auto res1 = helicsEndpointPendingMessages(nullptr);
+    auto res1 = helicsEndpointPendingMessagesCount(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsEndpointPendingMessages(evil_ept);
+    auto res2 = helicsEndpointPendingMessagesCount(evil_ept);
     EXPECT_EQ(res2, 0);
 }
 

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -342,10 +342,10 @@ TEST_P(mfed_type_tests, send_receive_2fed_multisend)
     EXPECT_EQ(gtime, 1.0);
     EXPECT_EQ(time, 1.0);
 
-    auto res = helicsEndpointPendingMessages(epid2);
+    auto res = helicsEndpointPendingMessagesCount(epid2);
     EXPECT_EQ(res, 3);
 
-    res = helicsFederatePendingMessages(mFed2);
+    res = helicsFederatePendingMessagesCount(mFed2);
     EXPECT_EQ(res, 3);
 
     EXPECT_STREQ(helicsEndpointGetDefaultDestination(epid), "ep2");

--- a/tests/helics/shared_library/test-message-federate_cpp.cpp
+++ b/tests/helics/shared_library/test-message-federate_cpp.cpp
@@ -127,7 +127,7 @@ TEST_F(mfed_tests, Message)
 
     EXPECT_EQ(time, 1.0);
 
-    auto cnt = epid2.pendingMessages();
+    auto cnt = epid2.pendingMessagesCount();
     EXPECT_EQ(cnt, 2U);
 
     auto M1 = epid2.getMessage();
@@ -143,7 +143,7 @@ TEST_F(mfed_tests, Message)
 
     time = mFed1->requestTimeComplete();
     EXPECT_DOUBLE_EQ(time, 1.0);
-    EXPECT_EQ(epid.pendingMessages(), 1U);
+    EXPECT_EQ(epid.pendingMessagesCount(), 1U);
     auto M3 = epid.getMessage();
     EXPECT_EQ(M3.messageID(), 45);
 

--- a/tests/java/JavaHelicsApiTests.java
+++ b/tests/java/JavaHelicsApiTests.java
@@ -420,7 +420,7 @@ public class JavaHelicsApiTests {
             if (returnTime != 1.0) {
                 javaHelicsApiTests.helicsAssert("returnTime[0] != 1.0");
             }
-            int ep2MsgCount = helics.helicsEndpointPendingMessages(ep2);
+            int ep2MsgCount = helics.helicsEndpointPendingMessagesCount(ep2);
             if (ep2MsgCount != 2) {
                 javaHelicsApiTests.helicsAssert("ep2MsgCount != 2");
             }
@@ -460,7 +460,7 @@ public class JavaHelicsApiTests {
             if (!"Ep2".equals(msg2OriginalDestination)) {
                 javaHelicsApiTests.helicsAssert("!msg2OriginalDestination.equals(\"Ep2\")");
             }
-            int fed1MsgCount = helics.helicsFederatePendingMessages(fed1);
+            int fed1MsgCount = helics.helicsFederatePendingMessagesCount(fed1);
             if (fed1MsgCount != 1) {
                 javaHelicsApiTests.helicsAssert("fed1MsgCount != 1");
             }


### PR DESCRIPTION
 as per recommendation in Issue #1654

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will rename all methods helicsPendingMessages to helicsPendingMessageCount to better clarify what the function does.

Fix Issue #1654
