### PR TITLE
remove a redundant raw from some of the method names

### DIFF
--- a/docs/user-guide/simulator_integration.md
+++ b/docs/user-guide/simulator_integration.md
@@ -211,7 +211,7 @@ h.helicsPublicationPublishChar(pub, string_value)
 For sending a message through an endpoint, that once again looks a little bit different, in this case because - unlike with a publication - a message requires a destination. If a default destination was set when the endpoint was registered (either through the config file or through calling `h.helicsEndpointSetDefaultDestination()`), then an empty string can be passed. Otherwise, the destination must be provided as shown in API call below where dest is the destination and msg is the message to be sent.
 
 ```python
-h.helicsEndpointSendMessageRaw(end, dest, msg)
+h.helicsEndpointSendTo(end, msg, dest)
 ```
 
 #### Request the Next Time Step
@@ -346,7 +346,7 @@ while t < end_time:
         # Now loop through all endpoints. For this example, we'll assume that a default destination
         # was provided in the config file.
         for end in ends:
-            h.helicsEndpointSendMessageRaw(eid, '', "string")
+            h.helicsEndpointSendTo(eid, "string", '')
             # And once again, you can pull some metadata about the endpoint.
             name = h.helicsEndpointGetName(eid)
             info = h.helicsEndpointGetInfo(eid)

--- a/interfaces/octave/octave_maps.i
+++ b/interfaces/octave/octave_maps.i
@@ -210,7 +210,7 @@ static octave_value throwHelicsOctaveError(helics_error *err) {
 
 // Set argument to NULL before any conversion occurs
 %typemap(check)(void *data, int maxDataLength, int *actualSize) {
-    $2=helicsInputGetRawValueSize(arg1)+2;
+    $2=helicsInputGetByteCount(arg1)+2;
     $1 =  malloc($2);
 }
 
@@ -230,7 +230,7 @@ static octave_value throwHelicsOctaveError(helics_error *err) {
 
 // Set argument to NULL before any conversion occurs
 %typemap(check)(void *data, int maxMessageLength, int *actualSize) {
-    $2=helicsMessageGetRawDataSize(arg1)+2;
+    $2=helicsMessageGetByteCount(arg1)+2;
     $1 =  malloc($2);
 }
 

--- a/src/helics/application_api/Inputs.cpp
+++ b/src/helics/application_api/Inputs.cpp
@@ -67,7 +67,7 @@ Input::Input(interface_visibility locality,
     }
 }
 
-void Input::setDefaultRaw(data_view val)
+void Input::setDefaultBytes(data_view val)
 {
     fed->setDefaultValue(*this, val);
 }
@@ -516,7 +516,7 @@ bool Input::checkUpdate(bool assumeUpdate)
 {
     if (changeDetectionEnabled) {
         if (assumeUpdate || fed->isUpdated(*this)) {
-            auto dv = fed->getValueRaw(*this);
+            auto dv = fed->getBytes(*this);
             if (injectionType == data_type::helics_unknown) {
                 loadSourceInformation();
             }
@@ -615,10 +615,10 @@ void Input::registerCallback()
         handleCallback(time);
     });
 }
-size_t Input::getRawSize()
+size_t Input::getBytesSize()
 {
     isUpdated();
-    auto dv = fed->getValueRaw(*this);
+    auto dv = fed->getBytes(*this);
     if (dv.empty()) {
         const auto& out = getValueRef<std::string>();
         return out.size();
@@ -634,10 +634,10 @@ void Input::addTarget(const std::string& target)
     fed->addTarget(*this, target);
 }
 
-data_view Input::getRawValue()
+data_view Input::getBytes()
 {
     hasUpdate = false;
-    return fed->getValueRaw(*this);
+    return fed->getBytes(*this);
 }
 
 size_t Input::getStringSize()
@@ -782,7 +782,7 @@ void integerExtractAndConvert(defV& store,
 
 data_view Input::checkAndGetFedUpdate()
 {
-    return (fed->isUpdated(*this) || allowDirectFederateUpdate()) ? (fed->getValueRaw(*this)) :
+    return (fed->isUpdated(*this) || allowDirectFederateUpdate()) ? (fed->getBytes(*this)) :
                                                                     data_view{};
 }
 

--- a/src/helics/application_api/Inputs.cpp
+++ b/src/helics/application_api/Inputs.cpp
@@ -615,7 +615,7 @@ void Input::registerCallback()
         handleCallback(time);
     });
 }
-size_t Input::getBytesSize()
+size_t Input::getByteCount()
 {
     isUpdated();
     auto dv = fed->getBytes(*this);

--- a/src/helics/application_api/Inputs.hpp
+++ b/src/helics/application_api/Inputs.hpp
@@ -257,7 +257,7 @@ class HELICS_CXX_EXPORT Input: public Interface {
     {
         auto res = ValueConverter<remove_cv_ref<X>>::convert(std::forward<X>(val));
         lastValue = std::string(res.to_string());
-        setDefaultRaw(res);
+        setDefaultBytes(res);
     }
 
     /** setup the callback for value callback into the federate*/
@@ -272,7 +272,7 @@ class HELICS_CXX_EXPORT Input: public Interface {
         setDefault_impl<X>(typeCategory<X>(), std::forward<X>(val));
     }
 
-    void setDefaultRaw(data_view val);
+    void setDefaultBytes(data_view val);
     /** set the minimum delta for change detection
     @param deltaV a double with the change in a value in order to register a different value
     */
@@ -325,7 +325,7 @@ class HELICS_CXX_EXPORT Input: public Interface {
     template<class X>
     void getValue_impl(std::integral_constant<int, nonConvertibleType> /*V*/, X& out)
     {
-        ValueConverter<X>::interpret(getRawValue(), out);
+        ValueConverter<X>::interpret(getBytes(), out);
     }
 
     template<class X>
@@ -350,7 +350,7 @@ class HELICS_CXX_EXPORT Input: public Interface {
     template<class X>
     X getValue_impl(std::integral_constant<int, nonConvertibleType> /*V*/)
     {
-        return ValueConverter<X>::interpret(getRawValue());
+        return ValueConverter<X>::interpret(getBytes());
     }
 
   public:
@@ -382,9 +382,9 @@ class HELICS_CXX_EXPORT Input: public Interface {
     const std::string& getString() { return getValueRef<std::string>(); }
 
     /** get the raw binary data*/
-    data_view getRawValue();
+    data_view getBytes();
     /** get the size of the raw data*/
-    size_t getRawSize();
+    size_t getBytesSize();
     /** get the size of the data if it were a string*/
     size_t getStringSize();
     /** get the number of elements in the data if it were a vector*/

--- a/src/helics/application_api/Inputs.hpp
+++ b/src/helics/application_api/Inputs.hpp
@@ -384,7 +384,7 @@ class HELICS_CXX_EXPORT Input: public Interface {
     /** get the raw binary data*/
     data_view getBytes();
     /** get the size of the raw data*/
-    size_t getBytesSize();
+    size_t getByteCount();
     /** get the size of the data if it were a string*/
     size_t getStringSize();
     /** get the number of elements in the data if it were a vector*/

--- a/src/helics/application_api/Publications.cpp
+++ b/src/helics/application_api/Publications.cpp
@@ -80,7 +80,7 @@ void Publication::publish(double val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -96,7 +96,7 @@ void Publication::publishInt(int64_t val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -127,7 +127,7 @@ void Publication::publish(Time val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val.getBaseTimeCode());
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -144,7 +144,7 @@ void Publication::publish(bool val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, bstring);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -160,7 +160,7 @@ void Publication::publishString(std::string_view val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -177,7 +177,7 @@ void Publication::publish(const std::vector<std::string>& val)
         }
     }
     if (doPublish) {
-        fed->publishRaw(*this, buffer);
+        fed->publishBytes(*this, buffer);
     }
 }
 
@@ -193,7 +193,7 @@ void Publication::publish(const std::vector<double>& val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -209,7 +209,7 @@ void Publication::publish(const std::vector<std::complex<double>>& val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -225,7 +225,7 @@ void Publication::publish(const double* vals, int size)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, vals, size);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -241,7 +241,7 @@ void Publication::publish(std::complex<double> val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -257,7 +257,7 @@ void Publication::publish(const NamedPoint& np)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, np);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -274,7 +274,7 @@ void Publication::publish(std::string_view field, double val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, field, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 
@@ -332,7 +332,7 @@ void Publication::publishDefV(const defV& val)
     }
     if (doPublish) {
         auto db = typeConvert(pubType, val);
-        fed->publishRaw(*this, db);
+        fed->publishBytes(*this, db);
     }
 }
 }  // namespace helics

--- a/src/helics/application_api/ValueFederate.cpp
+++ b/src/helics/application_api/ValueFederate.cpp
@@ -364,12 +364,12 @@ void ValueFederate::registerValueInterfacesToml(const std::string& tomlString)
     }
 }
 
-data_view ValueFederate::getValueRaw(const Input& inp)
+data_view ValueFederate::getBytes(const Input& inp)
 {
     return vfManager->getValue(inp);
 }
 
-void ValueFederate::publishRaw(const Publication& pub, data_view block)  // NOLINT
+void ValueFederate::publishBytes(const Publication& pub, data_view block)  // NOLINT
 {
     if ((currentMode == modes::executing) || (currentMode == modes::initializing)) {
         vfManager->publish(pub, block);

--- a/src/helics/application_api/ValueFederate.hpp
+++ b/src/helics/application_api/ValueFederate.hpp
@@ -328,14 +328,14 @@ class HELICS_CXX_EXPORT ValueFederate:
     @return a constant data block
     @throw std::invalid_argument if id is invalid
     */
-    data_view getValueRaw(const Input& inp);
+    data_view getBytes(const Input& inp);
 
     /** publish a value
     @param pub the publication identifier
     @param block a data block containing the data
     @throw invalid_argument if the publication id is invalid
     */
-    void publishRaw(const Publication& pub, data_view block);
+    void publishBytes(const Publication& pub, data_view block);
 
     /** publish data
   @param pub the publication identifier
@@ -343,9 +343,9 @@ class HELICS_CXX_EXPORT ValueFederate:
   @param data_size the length of the data
   @throw invalid_argument if the publication id is invalid
   */
-    void publishRaw(const Publication& pub, const char* data, size_t data_size)
+    void publishBytes(const Publication& pub, const char* data, size_t data_size)
     {
-        publishRaw(pub, data_view{data, data_size});
+        publishBytes(pub, data_view{data, data_size});
     }
 
     /** register a set of publications based on a publication JSON

--- a/src/helics/application_api/helicsTypes.hpp
+++ b/src/helics/application_api/helicsTypes.hpp
@@ -291,7 +291,7 @@ enum class data_type : int {
 
 };
 
-inline constexpr bool isRawType(data_type type)
+inline constexpr bool isBytesType(data_type type)
 {
     return (type == data_type::helics_any) || (type == data_type::helics_custom);
 }

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -110,14 +110,14 @@ class Message {
         return *this;
     }
     /** get the size of the message data field*/
-    int size() const { return helicsMessageGetDataSize(mo); }
+    int size() const { return helicsMessageGetBytesSize(mo); }
     /** set the size of the message data field*/
     void resize(int newSize) { helicsMessageResize(mo, newSize, hThrowOnError()); }
     /** reserve a certain amount of size in the message data field which is useful for the append
      * operation*/
     void reserve(int newSize) { helicsMessageReserve(mo, newSize, hThrowOnError()); }
     /** get a pointer to the data field*/
-    void* data() const { return helicsMessageGetDataPointer(mo); }
+    void* data() const { return helicsMessageGetBytesPointer(mo); }
     /** set the message data from a pointer and size*/
     Message& data(const void* ptr, int size)
     {

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -245,7 +245,7 @@ class Endpoint {
     */
     void send(const void* data, size_t data_size)
     {
-        helicsEndpointSend(ep, data, static_cast<int>(data_size), hThrowOnError());
+        helicsEndpointSendBytes(ep, data, static_cast<int>(data_size), hThrowOnError());
     }
 
     /** send a data block and length
@@ -255,7 +255,7 @@ class Endpoint {
     */
     void sendTo(const void* data, size_t data_size, const std::string& dest)
     {
-        helicsEndpointSendTo(ep, data, static_cast<int>(data_size), dest.c_str(), hThrowOnError());
+        helicsEndpointSendBytesTo(ep, data, static_cast<int>(data_size), dest.c_str(), hThrowOnError());
     }
     /** send a data block and length
    @param data pointer to data location
@@ -264,7 +264,7 @@ class Endpoint {
    */
     void sendAt(const char* data, size_t data_size, helics_time time)
     {
-        helicsEndpointSendAt(ep, data, static_cast<int>(data_size), time, hThrowOnError());
+        helicsEndpointSendBytesAt(ep, data, static_cast<int>(data_size), time, hThrowOnError());
     }
     /** send a data block and length
     @param data pointer to data location
@@ -274,7 +274,7 @@ class Endpoint {
     */
     void sendToAt(const void* data, size_t data_size, const std::string& dest, helics_time time)
     {
-        helicsEndpointSendToAt(
+        helicsEndpointSendBytesToAt(
             ep, data, static_cast<int>(data_size), dest.c_str(), time, hThrowOnError());
     }
     /** send a string to the target destination
@@ -282,7 +282,7 @@ class Endpoint {
     */
     void send(const std::string& data)
     {
-        helicsEndpointSend(ep, &(data[0]), static_cast<int>(data.size()), hThrowOnError());
+        helicsEndpointSendBytes(ep, &(data[0]), static_cast<int>(data.size()), hThrowOnError());
     }
 
     /** send a string to a particular destination
@@ -291,7 +291,7 @@ class Endpoint {
    */
     void sendTo(const std::string& data, const std::string& dest)
     {
-        helicsEndpointSendTo(
+        helicsEndpointSendBytesTo(
             ep, &(data[0]), static_cast<int>(data.size()), dest.c_str(), hThrowOnError());
     }
     /** send a string at a particular time
@@ -300,7 +300,7 @@ class Endpoint {
    */
     void sendAt(const std::string& data, helics_time time)
     {
-        helicsEndpointSendAt(ep, &(data[0]), static_cast<int>(data.size()), time, hThrowOnError());
+        helicsEndpointSendBytesAt(ep, &(data[0]), static_cast<int>(data.size()), time, hThrowOnError());
     }
     /** send a string to a particular destination at a particular time
      @param data the information to send
@@ -309,7 +309,7 @@ class Endpoint {
    */
     void sendToAt(const std::string& data, const std::string& dest, helics_time time)
     {
-        helicsEndpointSendToAt(
+        helicsEndpointSendBytesToAt(
             ep, &(data[0]), static_cast<int>(data.size()), dest.c_str(), time, hThrowOnError());
     }
 
@@ -318,7 +318,7 @@ class Endpoint {
    */
     void send(const std::vector<char>& data)
     {
-        helicsEndpointSend(ep, data.data(), static_cast<int>(data.size()), hThrowOnError());
+        helicsEndpointSendBytes(ep, data.data(), static_cast<int>(data.size()), hThrowOnError());
     }
 
     /** send a vector of data to a particular destination
@@ -327,7 +327,7 @@ class Endpoint {
    */
     void sendTo(const std::vector<char>& data, const std::string& dest)
     {
-        helicsEndpointSendTo(
+        helicsEndpointSendBytesTo(
             ep, data.data(), static_cast<int>(data.size()), dest.c_str(), hThrowOnError());
     }
     /** send a vector of data to the target destination at a particular time
@@ -336,7 +336,7 @@ class Endpoint {
    */
     void sendAt(const std::vector<char>& data, helics_time time)
     {
-        helicsEndpointSendAt(ep, data.data(), static_cast<int>(data.size()), time, hThrowOnError());
+        helicsEndpointSendBytesAt(ep, data.data(), static_cast<int>(data.size()), time, hThrowOnError());
     }
     /** send a vector of data to a particular destination at a particular time
      @param dest the target endpoint to send the data to
@@ -345,7 +345,7 @@ class Endpoint {
    */
     void sendToAt(const std::vector<char>& data, const std::string& dest, helics_time time)
     {
-        helicsEndpointSendToAt(
+        helicsEndpointSendBytesToAt(
             ep, data.data(), static_cast<int>(data.size()), dest.c_str(), time, hThrowOnError());
     }
 

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -110,7 +110,7 @@ class Message {
         return *this;
     }
     /** get the size of the message data field*/
-    int size() const { return helicsMessageGetBytesSize(mo); }
+    int size() const { return helicsMessageGetByteCount(mo); }
     /** set the size of the message data field*/
     void resize(int newSize) { helicsMessageResize(mo, newSize, hThrowOnError()); }
     /** reserve a certain amount of size in the message data field which is useful for the append

--- a/src/helics/cpp98/Endpoint.hpp
+++ b/src/helics/cpp98/Endpoint.hpp
@@ -110,18 +110,18 @@ class Message {
         return *this;
     }
     /** get the size of the message data field*/
-    int size() const { return helicsMessageGetRawDataSize(mo); }
+    int size() const { return helicsMessageGetDataSize(mo); }
     /** set the size of the message data field*/
     void resize(int newSize) { helicsMessageResize(mo, newSize, hThrowOnError()); }
     /** reserve a certain amount of size in the message data field which is useful for the append
      * operation*/
     void reserve(int newSize) { helicsMessageReserve(mo, newSize, hThrowOnError()); }
-    /** get a pointer to the raw data field*/
-    void* data() const { return helicsMessageGetRawDataPointer(mo); }
-    /** set the message data from a raw pointer and size*/
-    Message& data(const void* raw, int size)
+    /** get a pointer to the data field*/
+    void* data() const { return helicsMessageGetDataPointer(mo); }
+    /** set the message data from a pointer and size*/
+    Message& data(const void* ptr, int size)
     {
-        helicsMessageSetData(mo, raw, size, hThrowOnError());
+        helicsMessageSetData(mo, ptr, size, hThrowOnError());
         return *this;
     }
     /** set the data from a string*/
@@ -137,9 +137,9 @@ class Message {
         return *this;
     }
     /** append data to the message data field*/
-    Message& append(const void* raw, int size)
+    Message& append(const void* ptr, int size)
     {
-        helicsMessageAppendData(mo, raw, size, hThrowOnError());
+        helicsMessageAppendData(mo, ptr, size, hThrowOnError());
         return *this;
     }
     /** append a string to a message data field*/

--- a/src/helics/cpp98/Input.hpp
+++ b/src/helics/cpp98/Input.hpp
@@ -79,14 +79,14 @@ class Input {
     /** get a raw value as a character vector*/
     int getBytes(std::vector<char>& data)
     {
-        int size = helicsInputGetBytesSize(inp);
+        int size = helicsInputGetByteCount(inp);
         data.resize(size);
         helicsInputGetBytes(
             inp, data.data(), static_cast<int>(data.size()), &size, HELICS_IGNORE_ERROR);
         return size;
     }
     /** get the size of the raw value */
-    int getBytesSize() { return helicsInputGetBytesSize(inp); }
+    int getByteCount() { return helicsInputGetByteCount(inp); }
 
     /** get the size of the value as a string */
     int getStringSize()

--- a/src/helics/cpp98/Input.hpp
+++ b/src/helics/cpp98/Input.hpp
@@ -45,7 +45,7 @@ class Input {
     /** set the default value as a raw data with length*/
     void setDefault(const char* data, int len)
     {
-        helicsInputSetDefaultRaw(inp, data, len, HELICS_IGNORE_ERROR);
+        helicsInputSetDefaultBytes(inp, data, len, HELICS_IGNORE_ERROR);
     }
     /** set the default value as a string*/
     void setDefault(const std::string& str)
@@ -77,16 +77,16 @@ class Input {
 
     /** Methods to get subscription values **/
     /** get a raw value as a character vector*/
-    int getRawValue(std::vector<char>& data)
+    int getBytes(std::vector<char>& data)
     {
-        int size = helicsInputGetRawValueSize(inp);
+        int size = helicsInputGetBytesSize(inp);
         data.resize(size);
-        helicsInputGetRawValue(
+        helicsInputGetBytes(
             inp, data.data(), static_cast<int>(data.size()), &size, HELICS_IGNORE_ERROR);
         return size;
     }
     /** get the size of the raw value */
-    int getRawValueSize() { return helicsInputGetRawValueSize(inp); }
+    int getBytesSize() { return helicsInputGetBytesSize(inp); }
 
     /** get the size of the value as a string */
     int getStringSize()

--- a/src/helics/cpp98/Publication.hpp
+++ b/src/helics/cpp98/Publication.hpp
@@ -46,7 +46,7 @@ class Publication {
     void publish(const char* data, int len)
     {
         // returns helics_status
-        helicsPublicationPublishRaw(pub, data, len, HELICS_IGNORE_ERROR);
+        helicsPublicationPublishBytes(pub, data, len, HELICS_IGNORE_ERROR);
     }
     /** publish a string from a char * */
     void publish(const char* str) { helicsPublicationPublishString(pub, str, HELICS_IGNORE_ERROR); }

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -586,7 +586,7 @@ HELICS_EXPORT helics_bool helicsMessageGetFlagOption(helics_message message, int
  *
  * @return The size of the data payload.
  */
-HELICS_EXPORT int helicsMessageGetRawDataSize(helics_message message);
+HELICS_EXPORT int helicsMessageGetDataSize(helics_message message);
 
 /**
  * Get the raw data for a message object.
@@ -603,7 +603,7 @@ HELICS_EXPORT int helicsMessageGetRawDataSize(helics_message message);
  * @return Raw string data.
  * @endPythonOnly
  */
-HELICS_EXPORT void helicsMessageGetRawData(helics_message message, void* data, int maxMessageLength, int* actualSize, helics_error* err);
+HELICS_EXPORT void helicsMessageGetData(helics_message message, void* data, int maxMessageLength, int* actualSize, helics_error* err);
 
 /**
  * Get a pointer to the raw data of a message.
@@ -612,7 +612,7 @@ HELICS_EXPORT void helicsMessageGetRawData(helics_message message, void* data, i
  *
  * @return A pointer to the raw data in memory, the pointer may be NULL if the message is not a valid message.
  */
-HELICS_EXPORT void* helicsMessageGetRawDataPointer(helics_message message);
+HELICS_EXPORT void* helicsMessageGetDataPointer(helics_message message);
 
 /**
  * A check if the message contains a valid payload.

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -586,7 +586,7 @@ HELICS_EXPORT helics_bool helicsMessageGetFlagOption(helics_message message, int
  *
  * @return The size of the data payload.
  */
-HELICS_EXPORT int helicsMessageGetBytesSize(helics_message message);
+HELICS_EXPORT int helicsMessageGetByteCount(helics_message message);
 
 /**
  * Get the raw data for a message object.

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -185,7 +185,7 @@ HELICS_EXPORT const char* helicsEndpointGetDefaultDestination(helics_endpoint en
  * @param[in,out] err A pointer to an error object for catching errors.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsEndpointSend(helics_endpoint endpoint, const void* data, int inputDataLength, helics_error* err);
+HELICS_EXPORT void helicsEndpointSendBytes(helics_endpoint endpoint, const void* data, int inputDataLength, helics_error* err);
 
 /**
  * Send a message to the specified destination.
@@ -206,7 +206,7 @@ HELICS_EXPORT void helicsEndpointSend(helics_endpoint endpoint, const void* data
  * @endforcpponly
  */
 HELICS_EXPORT void
-    helicsEndpointSendTo(helics_endpoint endpoint, const void* data, int inputDataLength, const char* dst, helics_error* err);
+    helicsEndpointSendBytesTo(helics_endpoint endpoint, const void* data, int inputDataLength, const char* dst, helics_error* err);
 
 /**
  * Send a message to the specified destination at a specific time.
@@ -229,7 +229,7 @@ HELICS_EXPORT void
  * @endforcpponly
  */
 
-HELICS_EXPORT void helicsEndpointSendToAt(helics_endpoint endpoint,
+HELICS_EXPORT void helicsEndpointSendBytesToAt(helics_endpoint endpoint,
                                           const void* data,
                                           int inputDataLength,
                                           const char* dst,
@@ -252,7 +252,7 @@ HELICS_EXPORT void helicsEndpointSendToAt(helics_endpoint endpoint,
  */
 
 HELICS_EXPORT void
-    helicsEndpointSendAt(helics_endpoint endpoint, const void* data, int inputDataLength, helics_time time, helics_error* err);
+    helicsEndpointSendBytesAt(helics_endpoint endpoint, const void* data, int inputDataLength, helics_time time, helics_error* err);
 
 /**
  * Send a message object from a specific endpoint.

--- a/src/helics/shared_api_library/MessageFederate.h
+++ b/src/helics/shared_api_library/MessageFederate.h
@@ -586,7 +586,7 @@ HELICS_EXPORT helics_bool helicsMessageGetFlagOption(helics_message message, int
  *
  * @return The size of the data payload.
  */
-HELICS_EXPORT int helicsMessageGetDataSize(helics_message message);
+HELICS_EXPORT int helicsMessageGetBytesSize(helics_message message);
 
 /**
  * Get the raw data for a message object.
@@ -603,7 +603,7 @@ HELICS_EXPORT int helicsMessageGetDataSize(helics_message message);
  * @return Raw string data.
  * @endPythonOnly
  */
-HELICS_EXPORT void helicsMessageGetData(helics_message message, void* data, int maxMessageLength, int* actualSize, helics_error* err);
+HELICS_EXPORT void helicsMessageGetBytes(helics_message message, void* data, int maxMessageLength, int* actualSize, helics_error* err);
 
 /**
  * Get a pointer to the raw data of a message.
@@ -612,7 +612,7 @@ HELICS_EXPORT void helicsMessageGetData(helics_message message, void* data, int 
  *
  * @return A pointer to the raw data in memory, the pointer may be NULL if the message is not a valid message.
  */
-HELICS_EXPORT void* helicsMessageGetDataPointer(helics_message message);
+HELICS_EXPORT void* helicsMessageGetBytesPointer(helics_message message);
 
 /**
  * A check if the message contains a valid payload.

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -219,7 +219,7 @@ const char* helicsEndpointGetDefaultDestination(helics_endpoint endpoint)
     return str.c_str();
 }
 
-void helicsEndpointSendMessageRaw(helics_endpoint endpoint, const char* dest, const void* data, int inputDataLength, helics_error* err)
+void helicsEndpointSendData(helics_endpoint endpoint, const void* data, int inputDataLength, const char* dest, helics_error* err)
 {
     auto* endObj = verifyEndpoint(endpoint, err);
     if (endObj == nullptr) {
@@ -872,7 +872,7 @@ const char* helicsMessageGetString(helics_message message)
     return mess->data.char_data();
 }
 
-int helicsMessageGetRawDataSize(helics_message message)
+int helicsMessageGetDataSize(helics_message message)
 {
     auto* mess = getMessageObj(message, nullptr);
     if (mess == nullptr) {
@@ -881,7 +881,7 @@ int helicsMessageGetRawDataSize(helics_message message)
     return static_cast<int>(mess->data.size());
 }
 
-void helicsMessageGetRawData(helics_message message, void* data, int maxMessagelen, int* actualSize, helics_error* err)
+void helicsMessageGetData(helics_message message, void* data, int maxMessagelen, int* actualSize, helics_error* err)
 {
     auto* mess = getMessageObj(message, err);
     if (mess == nullptr || mess->data.empty()) {
@@ -905,7 +905,7 @@ void helicsMessageGetRawData(helics_message message, void* data, int maxMessagel
     }
 }
 
-void* helicsMessageGetRawDataPointer(helics_message message)
+void* helicsMessageGetDataPointer(helics_message message)
 {
     auto* mess = getMessageObj(message, nullptr);
     if (mess == nullptr) {

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -872,7 +872,7 @@ const char* helicsMessageGetString(helics_message message)
     return mess->data.char_data();
 }
 
-int helicsMessageGetDataSize(helics_message message)
+int helicsMessageGetBytesSize(helics_message message)
 {
     auto* mess = getMessageObj(message, nullptr);
     if (mess == nullptr) {
@@ -881,7 +881,7 @@ int helicsMessageGetDataSize(helics_message message)
     return static_cast<int>(mess->data.size());
 }
 
-void helicsMessageGetData(helics_message message, void* data, int maxMessagelen, int* actualSize, helics_error* err)
+void helicsMessageGetBytes(helics_message message, void* data, int maxMessagelen, int* actualSize, helics_error* err)
 {
     auto* mess = getMessageObj(message, err);
     if (mess == nullptr || mess->data.empty()) {
@@ -905,7 +905,7 @@ void helicsMessageGetData(helics_message message, void* data, int maxMessagelen,
     }
 }
 
-void* helicsMessageGetDataPointer(helics_message message)
+void* helicsMessageGetBytesPointer(helics_message message)
 {
     auto* mess = getMessageObj(message, nullptr);
     if (mess == nullptr) {

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -872,7 +872,7 @@ const char* helicsMessageGetString(helics_message message)
     return mess->data.char_data();
 }
 
-int helicsMessageGetBytesSize(helics_message message)
+int helicsMessageGetByteCount(helics_message message)
 {
     auto* mess = getMessageObj(message, nullptr);
     if (mess == nullptr) {

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -245,7 +245,7 @@ void helicsEndpointSendData(helics_endpoint endpoint, const void* data, int inpu
     }
 }
 
-void helicsEndpointSend(helics_endpoint endpoint, const void* data, int inputDataLength, helics_error* err)
+void helicsEndpointSendBytes(helics_endpoint endpoint, const void* data, int inputDataLength, helics_error* err)
 {
     auto* endObj = verifyEndpoint(endpoint, err);
     if (endObj == nullptr) {
@@ -263,7 +263,7 @@ void helicsEndpointSend(helics_endpoint endpoint, const void* data, int inputDat
     }
 }
 
-void helicsEndpointSendTo(helics_endpoint endpoint, const void* data, int inputDataLength, const char* dest, helics_error* err)
+void helicsEndpointSendBytesTo(helics_endpoint endpoint, const void* data, int inputDataLength, const char* dest, helics_error* err)
 {
     auto* endObj = verifyEndpoint(endpoint, err);
     if (endObj == nullptr) {
@@ -281,7 +281,7 @@ void helicsEndpointSendTo(helics_endpoint endpoint, const void* data, int inputD
     }
 }
 
-void helicsEndpointSendAt(helics_endpoint endpoint, const void* data, int inputDataLength, helics_time time, helics_error* err)
+void helicsEndpointSendBytesAt(helics_endpoint endpoint, const void* data, int inputDataLength, helics_time time, helics_error* err)
 {
     auto* endObj = verifyEndpoint(endpoint, err);
     if (endObj == nullptr) {
@@ -299,7 +299,7 @@ void helicsEndpointSendAt(helics_endpoint endpoint, const void* data, int inputD
     }
 }
 
-void helicsEndpointSendToAt(helics_endpoint endpoint,
+void helicsEndpointSendBytesToAt(helics_endpoint endpoint,
                             const void* data,
                             int inputDataLength,
                             const char* dest,

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -326,7 +326,7 @@ HELICS_EXPORT helics_bool helicsPublicationIsValid(helics_publication pub);
  * @param[in,out] err A pointer to an error object for catching errors.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsPublicationPublishRaw(helics_publication pub, const void* data, int inputDataLength, helics_error* err);
+HELICS_EXPORT void helicsPublicationPublishBytes(helics_publication pub, const void* data, int inputDataLength, helics_error* err);
 
 /**
  * Publish a string.
@@ -475,7 +475,7 @@ HELICS_EXPORT void helicsInputAddTarget(helics_input ipt, const char* target, he
  *
  * @return The size of the raw data/string in bytes.
  */
-HELICS_EXPORT int helicsInputGetRawValueSize(helics_input ipt);
+HELICS_EXPORT int helicsInputGetBytesSize(helics_input ipt);
 
 /**
  * Get the raw data for the latest value of a subscription.
@@ -489,10 +489,10 @@ HELICS_EXPORT int helicsInputGetRawValueSize(helics_input ipt);
  * @endforcpponly
  *
  * @beginPythonOnly
- * @return Raw string data.
+ * @return  raw Bytes of the value, the value is uninterpreted raw bytes.
  * @endPythonOnly
  */
-HELICS_EXPORT void helicsInputGetRawValue(helics_input ipt, void* data, int maxDataLength, int* actualSize, helics_error* err);
+HELICS_EXPORT void helicsInputGetBytes(helics_input ipt, void* data, int maxDataLength, int* actualSize, helics_error* err);
 
 /**
  * Get the size of a value for subscription assuming return as a string.
@@ -672,7 +672,7 @@ HELICS_EXPORT void
  * @param[in,out] err An error object that will contain an error code and string if any error occurred during the execution of the function.
  * @endforcpponly
  */
-HELICS_EXPORT void helicsInputSetDefaultRaw(helics_input ipt, const void* data, int inputDataLength, helics_error* err);
+HELICS_EXPORT void helicsInputSetDefaultBytes(helics_input ipt, const void* data, int inputDataLength, helics_error* err);
 
 /**
  * Set the default as a string.

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -475,7 +475,7 @@ HELICS_EXPORT void helicsInputAddTarget(helics_input ipt, const char* target, he
  *
  * @return The size of the raw data/string in bytes.
  */
-HELICS_EXPORT int helicsInputGetBytesSize(helics_input ipt);
+HELICS_EXPORT int helicsInputGetByteCount(helics_input ipt);
 
 /**
  * Get the raw data for the latest value of a subscription.

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -480,14 +480,14 @@ void helicsFederateClearUpdates(helics_federate fed)
 }
 
 /* getting and publishing values */
-void helicsPublicationPublishRaw(helics_publication pub, const void* data, int datalen, helics_error* err)
+void helicsPublicationPublishBytes(helics_publication pub, const void* data, int datalen, helics_error* err)
 {
     auto* pubObj = verifyPublication(pub, err);
     if (pubObj == nullptr) {
         return;
     }
     try {
-        pubObj->fedptr->publishRaw(*pubObj->pubPtr, reinterpret_cast<const char*>(data), datalen);
+        pubObj->fedptr->publishBytes(*pubObj->pubPtr, reinterpret_cast<const char*>(data), datalen);
     }
     catch (...) {
         helicsErrorHandler(err);
@@ -668,13 +668,13 @@ void helicsInputAddTarget(helics_input ipt, const char* target, helics_error* er
     inpObj->inputPtr->addTarget(target);
 }
 
-int helicsInputGetRawValueSize(helics_input inp)
+int helicsInputGetBytesSize(helics_input inp)
 {
     auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return (0);
     }
-    return static_cast<int>(inpObj->inputPtr->getRawSize());
+    return static_cast<int>(inpObj->inputPtr->getBytesSize());
 }
 
 bool checkOutArgString(const char* outputString, int maxlen, helics_error* err)
@@ -687,7 +687,7 @@ bool checkOutArgString(const char* outputString, int maxlen, helics_error* err)
     return true;
 }
 
-void helicsInputGetRawValue(helics_input inp, void* data, int maxDatalen, int* actualSize, helics_error* err)
+void helicsInputGetBytes(helics_input inp, void* data, int maxDatalen, int* actualSize, helics_error* err)
 {
     auto* inpObj = verifyInput(inp, err);
     if (actualSize != nullptr) {  // for initialization
@@ -700,7 +700,7 @@ void helicsInputGetRawValue(helics_input inp, void* data, int maxDatalen, int* a
         return;
     }
     try {
-        auto dv = inpObj->inputPtr->getRawValue();
+        auto dv = inpObj->inputPtr->getBytes();
         if (maxDatalen > static_cast<int>(dv.size())) {
             memcpy(data, dv.data(), dv.size());
             if (actualSize != nullptr) {
@@ -973,7 +973,7 @@ void helicsInputGetNamedPoint(helics_input inp, char* outputString, int maxStrin
     // LCOV_EXCL_STOP
 }
 
-void helicsInputSetDefaultRaw(helics_input inp, const void* data, int dataLen, helics_error* err)
+void helicsInputSetDefaultBytes(helics_input inp, const void* data, int dataLen, helics_error* err)
 {
     auto* inpObj = verifyInput(inp, err);
     if (inpObj == nullptr) {

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -668,13 +668,13 @@ void helicsInputAddTarget(helics_input ipt, const char* target, helics_error* er
     inpObj->inputPtr->addTarget(target);
 }
 
-int helicsInputGetBytesSize(helics_input inp)
+int helicsInputGetByteCount(helics_input inp)
 {
     auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
         return (0);
     }
-    return static_cast<int>(inpObj->inputPtr->getBytesSize());
+    return static_cast<int>(inpObj->inputPtr->getByteCount());
 }
 
 bool checkOutArgString(const char* outputString, int maxlen, helics_error* err)

--- a/tests/helics/application_api/ValueFederateAdditionalTests.cpp
+++ b/tests/helics/application_api/ValueFederateAdditionalTests.cpp
@@ -394,7 +394,7 @@ TEST_P(valuefed_add_single_type_tests_ci_skip, vector_callback_lists)
                                             ++ccnt;
                                         });
     vFed1->enterExecutingMode();
-    vFed1->publishRaw(pubid3, db);
+    vFed1->publishBytes(pubid3, db);
     vFed1->requestTime(1.0);
     // callbacks here
     EXPECT_EQ(ccnt, 0);
@@ -404,7 +404,7 @@ TEST_P(valuefed_add_single_type_tests_ci_skip, vector_callback_lists)
     EXPECT_EQ(ccnt, 1);
 
     ccnt = 0;  // reset the counter
-    vFed1->publishRaw(pubid3, db);
+    vFed1->publishBytes(pubid3, db);
     pubid2.publish(4);
     pubid1.publish("test string2");
     vFed1->requestTime(5.0);

--- a/tests/helics/application_api/ValueFederateKeyTests.cpp
+++ b/tests/helics/application_api/ValueFederateKeyTests.cpp
@@ -622,10 +622,10 @@ TEST_P(valuefed_single_type, block_send_receive)
     helics::SmallBuffer db(547, ';');
 
     vFed1->enterExecutingMode();
-    vFed1->publishRaw(pubid3, db);
+    vFed1->publishBytes(pubid3, db);
     vFed1->requestTime(1.0);
     EXPECT_TRUE(vFed1->isUpdated(sub1));
-    auto res = vFed1->getValueRaw(sub1);
+    auto res = vFed1->getBytes(sub1);
     EXPECT_EQ(res.size(), db.size());
     EXPECT_TRUE(vFed1->isUpdated(sub1) == false);
 }
@@ -654,7 +654,7 @@ TEST_P(valuefed_single_type, all_callback)
         lastId = subid.getHandle();
     });
     vFed1->enterExecutingMode();
-    vFed1->publishRaw(pubid3, db);
+    vFed1->publishBytes(pubid3, db);
     vFed1->requestTime(1.0);
     // the callback should have occurred here
     EXPECT_TRUE(lastId == sub3.getHandle());
@@ -680,13 +680,13 @@ TEST_P(valuefed_single_type, all_callback)
     vFed1->setInputNotificationCallback(
         [&](const helics::Input& /*unused*/, helics::Time /*unused*/) { ++ccnt; });
 
-    vFed1->publishRaw(pubid3, db);
+    vFed1->publishBytes(pubid3, db);
     pubid2.publish(4);
     vFed1->requestTime(4.0);
     // the callback should have occurred here
     EXPECT_EQ(ccnt, 2);
     ccnt = 0;  // reset the counter
-    vFed1->publishRaw(pubid3, db);
+    vFed1->publishBytes(pubid3, db);
     pubid2.publish(4);
     pubid1.publish("test string2");
     vFed1->requestTime(5.0);

--- a/tests/helics/application_api/subPubObjectTests.cpp
+++ b/tests/helics/application_api/subPubObjectTests.cpp
@@ -341,7 +341,7 @@ TEST(subscriptionObject, Size_tests)
     EXPECT_EQ(gtime, 1.0);
     EXPECT_TRUE(subObj.isUpdated());
     EXPECT_EQ(subObj.getStringSize(), str.size());
-    EXPECT_EQ(subObj.getRawSize(), str.size() + 8);
+    EXPECT_EQ(subObj.getBytesSize(), str.size() + 8);
     auto val1 = subObj.getValue<std::string>();
     // now that we got the value it should not be updated
     EXPECT_TRUE(!subObj.isUpdated());

--- a/tests/helics/application_api/subPubObjectTests.cpp
+++ b/tests/helics/application_api/subPubObjectTests.cpp
@@ -341,7 +341,7 @@ TEST(subscriptionObject, Size_tests)
     EXPECT_EQ(gtime, 1.0);
     EXPECT_TRUE(subObj.isUpdated());
     EXPECT_EQ(subObj.getStringSize(), str.size());
-    EXPECT_EQ(subObj.getBytesSize(), str.size() + 8);
+    EXPECT_EQ(subObj.getByteCount(), str.size() + 8);
     auto val1 = subObj.getValue<std::string>();
     // now that we got the value it should not be updated
     EXPECT_TRUE(!subObj.isUpdated());

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -209,7 +209,7 @@ TEST_P(filter_type_tests, message_filter_function)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));
@@ -272,7 +272,7 @@ TEST_P(filter_simple_type_tests, function_mObj)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));
@@ -352,7 +352,7 @@ TEST_P(filter_type_tests, function_two_stage)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTimeComplete(fFed, &err));
@@ -429,7 +429,7 @@ TEST_P(filter_type_tests, function2)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     EXPECT_TRUE(!helicsEndpointHasMessage(p1));
@@ -503,7 +503,7 @@ TEST_P(filter_type_tests, message_filter_function3)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     EXPECT_TRUE(helicsEndpointHasMessage(p1));
@@ -558,7 +558,7 @@ TEST_F(filter_tests, clone_test)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     }
 
     // now check the message clone
@@ -571,7 +571,7 @@ TEST_F(filter_tests, clone_test)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -644,7 +644,7 @@ TEST_F(filter_tests, clone_test_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     }
 
     // now check the message clone
@@ -657,7 +657,7 @@ TEST_F(filter_tests, clone_test_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -720,7 +720,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int>(data.size()));
     }
 
     // now check the message clone
@@ -733,7 +733,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -820,7 +820,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     EXPECT_STREQ(helicsMessageGetSource(m2), "src");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
 
     threaddcFed.join();
 
@@ -828,7 +828,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     EXPECT_STREQ(helicsMessageGetOriginalSource(m3), "src");
     EXPECT_STREQ(helicsMessageGetDestination(m3), "cm");
     EXPECT_STREQ(helicsMessageGetOriginalDestination(m3), "dest");
-    EXPECT_EQ(helicsMessageGetDataSize(m3), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m3), static_cast<int64_t>(data.size()));
 
     CE(state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_finalize);
@@ -885,7 +885,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     }
     CE(helicsFederateFinalizeAsync(sFed, &err));
     CE(helicsFederateFinalizeAsync(dFed, &err));
@@ -907,7 +907,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalize(dcFed, &err));
@@ -977,7 +977,7 @@ TEST_F(filter_tests, multi_clone_test)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
         res = helicsFederateHasMessage(dFed);
         EXPECT_EQ(res, helics_true);
 
@@ -986,7 +986,7 @@ TEST_F(filter_tests, multi_clone_test)
             EXPECT_STREQ(helicsMessageGetSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-            EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data2.size()));
+            EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data2.size()));
         }
     }
 
@@ -1002,7 +1002,7 @@ TEST_F(filter_tests, multi_clone_test)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
         res = helicsFederateHasMessage(dcFed);
         EXPECT_EQ(res, helics_true);
 
@@ -1012,7 +1012,7 @@ TEST_F(filter_tests, multi_clone_test)
             EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
             EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-            EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data2.size()));
+            EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data2.size()));
         }
     }
 
@@ -1113,7 +1113,7 @@ TEST_F(filter_tests, callback_test)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -209,7 +209,7 @@ TEST_P(filter_type_tests, message_filter_function)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));
@@ -272,7 +272,7 @@ TEST_P(filter_simple_type_tests, function_mObj)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));
@@ -352,7 +352,7 @@ TEST_P(filter_type_tests, function_two_stage)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTimeComplete(fFed, &err));
@@ -429,7 +429,7 @@ TEST_P(filter_type_tests, function2)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     EXPECT_TRUE(!helicsEndpointHasMessage(p1));
@@ -503,7 +503,7 @@ TEST_P(filter_type_tests, message_filter_function3)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     EXPECT_TRUE(helicsEndpointHasMessage(p1));
@@ -558,7 +558,7 @@ TEST_F(filter_tests, clone_test)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     }
 
     // now check the message clone
@@ -571,7 +571,7 @@ TEST_F(filter_tests, clone_test)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -644,7 +644,7 @@ TEST_F(filter_tests, clone_test_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     }
 
     // now check the message clone
@@ -657,7 +657,7 @@ TEST_F(filter_tests, clone_test_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -720,7 +720,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int>(data.size()));
     }
 
     // now check the message clone
@@ -733,7 +733,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -820,7 +820,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     EXPECT_STREQ(helicsMessageGetSource(m2), "src");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
 
     threaddcFed.join();
 
@@ -828,7 +828,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     EXPECT_STREQ(helicsMessageGetOriginalSource(m3), "src");
     EXPECT_STREQ(helicsMessageGetDestination(m3), "cm");
     EXPECT_STREQ(helicsMessageGetOriginalDestination(m3), "dest");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m3), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m3), static_cast<int64_t>(data.size()));
 
     CE(state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_finalize);
@@ -885,7 +885,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     }
     CE(helicsFederateFinalizeAsync(sFed, &err));
     CE(helicsFederateFinalizeAsync(dFed, &err));
@@ -907,7 +907,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalize(dcFed, &err));
@@ -977,7 +977,7 @@ TEST_F(filter_tests, multi_clone_test)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
         res = helicsFederateHasMessage(dFed);
         EXPECT_EQ(res, helics_true);
 
@@ -986,7 +986,7 @@ TEST_F(filter_tests, multi_clone_test)
             EXPECT_STREQ(helicsMessageGetSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-            EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data2.size()));
+            EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data2.size()));
         }
     }
 
@@ -1002,7 +1002,7 @@ TEST_F(filter_tests, multi_clone_test)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
         res = helicsFederateHasMessage(dcFed);
         EXPECT_EQ(res, helics_true);
 
@@ -1012,7 +1012,7 @@ TEST_F(filter_tests, multi_clone_test)
             EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
             EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-            EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data2.size()));
+            EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data2.size()));
         }
     }
 
@@ -1113,7 +1113,7 @@ TEST_F(filter_tests, callback_test)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetRawDataSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetDataSize(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -209,7 +209,7 @@ TEST_P(filter_type_tests, message_filter_function)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));
@@ -272,7 +272,7 @@ TEST_P(filter_simple_type_tests, function_mObj)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));
@@ -352,7 +352,7 @@ TEST_P(filter_type_tests, function_two_stage)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTimeComplete(fFed, &err));
@@ -429,7 +429,7 @@ TEST_P(filter_type_tests, function2)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     EXPECT_TRUE(!helicsEndpointHasMessage(p1));
@@ -503,7 +503,7 @@ TEST_P(filter_type_tests, message_filter_function3)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     EXPECT_TRUE(helicsEndpointHasMessage(p1));
@@ -558,7 +558,7 @@ TEST_F(filter_tests, clone_test)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     }
 
     // now check the message clone
@@ -571,7 +571,7 @@ TEST_F(filter_tests, clone_test)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -644,7 +644,7 @@ TEST_F(filter_tests, clone_test_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     }
 
     // now check the message clone
@@ -657,7 +657,7 @@ TEST_F(filter_tests, clone_test_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -720,7 +720,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int>(data.size()));
     }
 
     // now check the message clone
@@ -733,7 +733,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int>(data.size()));
     }
 
     CE(helicsFederateFinalizeAsync(sFed, &err));
@@ -820,7 +820,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     EXPECT_STREQ(helicsMessageGetSource(m2), "src");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
 
     threaddcFed.join();
 
@@ -828,7 +828,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     EXPECT_STREQ(helicsMessageGetOriginalSource(m3), "src");
     EXPECT_STREQ(helicsMessageGetDestination(m3), "cm");
     EXPECT_STREQ(helicsMessageGetOriginalDestination(m3), "dest");
-    EXPECT_EQ(helicsMessageGetBytesSize(m3), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m3), static_cast<int64_t>(data.size()));
 
     CE(state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_finalize);
@@ -885,7 +885,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     }
     CE(helicsFederateFinalizeAsync(sFed, &err));
     CE(helicsFederateFinalizeAsync(dFed, &err));
@@ -907,7 +907,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     }
 
     CE(helicsFederateFinalize(dcFed, &err));
@@ -977,7 +977,7 @@ TEST_F(filter_tests, multi_clone_test)
         EXPECT_STREQ(helicsMessageGetSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
         res = helicsFederateHasMessage(dFed);
         EXPECT_EQ(res, helics_true);
 
@@ -986,7 +986,7 @@ TEST_F(filter_tests, multi_clone_test)
             EXPECT_STREQ(helicsMessageGetSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetDestination(m2), "dest");
-            EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data2.size()));
+            EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data2.size()));
         }
     }
 
@@ -1002,7 +1002,7 @@ TEST_F(filter_tests, multi_clone_test)
         EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src");
         EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
         EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-        EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+        EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
         res = helicsFederateHasMessage(dcFed);
         EXPECT_EQ(res, helics_true);
 
@@ -1012,7 +1012,7 @@ TEST_F(filter_tests, multi_clone_test)
             EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "src2");
             EXPECT_STREQ(helicsMessageGetDestination(m2), "cm");
             EXPECT_STREQ(helicsMessageGetOriginalDestination(m2), "dest");
-            EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data2.size()));
+            EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data2.size()));
         }
     }
 
@@ -1113,7 +1113,7 @@ TEST_F(filter_tests, callback_test)
     EXPECT_STREQ(helicsMessageGetSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetOriginalSource(m2), "port1");
     EXPECT_STREQ(helicsMessageGetDestination(m2), "port2");
-    EXPECT_EQ(helicsMessageGetBytesSize(m2), static_cast<int64_t>(data.size()));
+    EXPECT_EQ(helicsMessageGetByteCount(m2), static_cast<int64_t>(data.size()));
     EXPECT_EQ(helicsMessageGetTime(m2), 2.5);
 
     CE(helicsFederateRequestTime(mFed, 3.0, &err));

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -186,7 +186,7 @@ TEST_P(filter_type_tests, message_filter_function)
     CE(helics_federate_state state = helicsFederateGetState(fFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
 
     CE(helicsFederateRequestTimeAsync(mFed, 1.0, &err));
     CE(helicsFederateRequestTime(fFed, 1.0, &err));
@@ -249,7 +249,7 @@ TEST_P(filter_simple_type_tests, function_mObj)
     CE(helics_federate_state state = helicsFederateGetState(fFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
 
     CE(helicsFederateRequestTimeAsync(mFed, 1.0, &err));
     CE(helicsFederateRequestTime(fFed, 1.0, &err));
@@ -323,7 +323,7 @@ TEST_P(filter_type_tests, function_two_stage)
     CE(helics_federate_state state = helicsFederateGetState(fFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
 
     CE(helicsFederateRequestTimeAsync(mFed, .0, &err));
     CE(helicsFederateRequestTimeAsync(fFed, 1.0, &err));
@@ -405,7 +405,7 @@ TEST_P(filter_type_tests, function2)
     CE(helics_federate_state state = helicsFederateGetState(fFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
 
     CE(helicsFederateRequestTimeAsync(mFed, 1.0, &err));
     CE(helicsFederateRequestTime(fFed, 1.0, &err));
@@ -413,7 +413,7 @@ TEST_P(filter_type_tests, function2)
 
     auto res = helicsFederateHasMessage(mFed);
     EXPECT_TRUE(!res);
-    CE(helicsEndpointSendTo(p2, data.c_str(), static_cast<int>(data.size()), "port1", &err));
+    CE(helicsEndpointSendBytesTo(p2, data.c_str(), static_cast<int>(data.size()), "port1", &err));
     CE(helicsFederateRequestTimeAsync(mFed, 2.0, &err));
     CE(helicsFederateRequestTime(fFed, 2.0, &err));
     CE(helicsFederateRequestTimeComplete(mFed, &err));
@@ -477,7 +477,7 @@ TEST_P(filter_type_tests, message_filter_function3)
     CE(helics_federate_state state = helicsFederateGetState(fFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data = "hello world";
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
 
     CE(helicsFederateRequestTimeAsync(mFed, 1.0, &err));
     CE(helicsFederateRequestTime(fFed, 1.0, &err));
@@ -485,7 +485,7 @@ TEST_P(filter_type_tests, message_filter_function3)
 
     auto res = helicsFederateHasMessage(mFed);
     EXPECT_TRUE(!res);
-    CE(helicsEndpointSendTo(p2, data.c_str(), static_cast<int>(data.size()), "port1", &err));
+    CE(helicsEndpointSendBytesTo(p2, data.c_str(), static_cast<int>(data.size()), "port1", &err));
     CE(helicsFederateRequestTimeAsync(mFed, 2.0, &err));
     CE(helicsFederateRequestTime(fFed, 2.0, &err));
     CE(helicsFederateRequestTimeComplete(mFed, &err));
@@ -542,7 +542,7 @@ TEST_F(filter_tests, clone_test)
     CE(helics_federate_state state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
 
     CE(helicsFederateRequestTimeAsync(sFed, 1.0, &err));
     CE(helicsFederateRequestTimeAsync(dcFed, 1.0, &err));
@@ -628,7 +628,7 @@ TEST_F(filter_tests, clone_test_connections)
     CE(helics_federate_state state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
 
     CE(helicsFederateRequestTimeAsync(sFed, 1.0, &err));
     CE(helicsFederateRequestTimeAsync(dcFed, 1.0, &err));
@@ -704,7 +704,7 @@ TEST_F(filter_tests, clone_test_broker_connections)
     CE(helics_federate_state state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
 
     CE(helicsFederateRequestTimeAsync(sFed, 1.0, &err));
     CE(helicsFederateRequestTimeAsync(dcFed, 1.0, &err));
@@ -790,7 +790,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     CE(helics_federate_state state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
 
     CE(helicsFederateFinalize(sFed, nullptr));
 
@@ -869,7 +869,7 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
     CE(helics_federate_state state = helicsFederateGetState(sFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
 
     CE(helicsFederateRequestTimeAsync(sFed, 1.0, &err));
     CE(helicsFederateRequestTimeAsync(dcFed, 1.0, &err));
@@ -956,8 +956,8 @@ TEST_F(filter_tests, multi_clone_test)
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
     std::string data2(400, 'b');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
-    CE(helicsEndpointSendTo(p2, data2.c_str(), static_cast<int>(data2.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "dest", &err));
+    CE(helicsEndpointSendBytesTo(p2, data2.c_str(), static_cast<int>(data2.size()), "dest", &err));
 
     CE(helicsFederateRequestTimeAsync(sFed, 1.0, &err));
     CE(helicsFederateRequestTimeAsync(sFed2, 1.0, &err));
@@ -1090,7 +1090,7 @@ TEST_F(filter_tests, callback_test)
     CE(helics_federate_state state = helicsFederateGetState(fFed, &err));
     EXPECT_TRUE(state == helics_state_execution);
     std::string data(500, 'a');
-    CE(helicsEndpointSendTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
+    CE(helicsEndpointSendBytesTo(p1, data.c_str(), static_cast<int>(data.size()), "port2", &err));
 
     CE(helicsFederateRequestTimeAsync(mFed, 1.0, &err));
     CE(helicsFederateRequestTime(fFed, 1.0, &err));

--- a/tests/helics/shared_library/TimingTests.cpp
+++ b/tests/helics/shared_library/TimingTests.cpp
@@ -117,7 +117,7 @@ TEST_F(timing_tests, simple_timing_test_message)
 
     // check that the request is only granted at the appropriate period
     EXPECT_NEAR(gtime, 0.6, 0.000000001);
-    CE(helicsEndpointSendTo(ept1, "test1", 5, "e2", &err));
+    CE(helicsEndpointSendBytesTo(ept1, "test1", 5, "e2", &err));
 
     CE(helicsFederateRequestTimeAsync(vFed1, 1.85, &err));
 
@@ -161,7 +161,7 @@ TEST_F(timing_tests, timing_with_input_delay)
     CE(gtime = helicsFederateRequestTime(vFed1, 1.0, &err));
     // check that the request is only granted at the appropriate period
     EXPECT_EQ(gtime, 1.0);
-    CE(helicsEndpointSendTo(ept1, "test1", 5, "e2", &err));
+    CE(helicsEndpointSendBytesTo(ept1, "test1", 5, "e2", &err));
     CE(helicsFederateRequestTimeAsync(vFed1, 1.9, &err));
     CE(gtime = helicsFederateRequestTimeComplete(vFed2, &err));
     EXPECT_DOUBLE_EQ(gtime,

--- a/tests/helics/shared_library/badInputTests.cpp
+++ b/tests/helics/shared_library/badInputTests.cpp
@@ -948,10 +948,10 @@ TEST_F(function_tests, messageFed_messageObject)
     helicsErrorClear(&err);
 
     helics_message mess0 = helicsEndpointGetMessage(ept1);
-    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetByteCount(mess0), 0);
 
     mess0 = helicsFederateGetMessage(mFed1);
-    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetByteCount(mess0), 0);
 
     // send a series of different messages testing different code paths
     helics_message mess1 = helicsFederateCreateMessage(mFed1, nullptr);
@@ -998,10 +998,10 @@ TEST_F(function_tests, messageFed_message_object)
     helicsFederateEnterExecutingMode(mFed1, nullptr);
     helicsEndpointSetDefaultDestination(ept1, "ept1", nullptr);
     auto mess0 = helicsEndpointGetMessage(ept1);
-    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetByteCount(mess0), 0);
 
     mess0 = helicsFederateGetMessage(mFed1);
-    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetByteCount(mess0), 0);
 
     helicsEndpointSendMessage(ept1, nullptr, &err);
     EXPECT_NE(err.error_code, 0);

--- a/tests/helics/shared_library/badInputTests.cpp
+++ b/tests/helics/shared_library/badInputTests.cpp
@@ -948,10 +948,10 @@ TEST_F(function_tests, messageFed_messageObject)
     helicsErrorClear(&err);
 
     helics_message mess0 = helicsEndpointGetMessage(ept1);
-    EXPECT_EQ(helicsMessageGetRawDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
 
     mess0 = helicsFederateGetMessage(mFed1);
-    EXPECT_EQ(helicsMessageGetRawDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
 
     // send a series of different messages testing different code paths
     helics_message mess1 = helicsFederateCreateMessage(mFed1, nullptr);
@@ -998,10 +998,10 @@ TEST_F(function_tests, messageFed_message_object)
     helicsFederateEnterExecutingMode(mFed1, nullptr);
     helicsEndpointSetDefaultDestination(ept1, "ept1", nullptr);
     auto mess0 = helicsEndpointGetMessage(ept1);
-    EXPECT_EQ(helicsMessageGetRawDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
 
     mess0 = helicsFederateGetMessage(mFed1);
-    EXPECT_EQ(helicsMessageGetRawDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
 
     helicsEndpointSendMessage(ept1, nullptr, &err);
     EXPECT_NE(err.error_code, 0);

--- a/tests/helics/shared_library/badInputTests.cpp
+++ b/tests/helics/shared_library/badInputTests.cpp
@@ -313,7 +313,7 @@ TEST_F(function_tests, raw2)
     helicsPublicationPublishDouble(pubid, 27.0, nullptr);
     helicsFederateRequestNextStep(vFed1, nullptr);
     // we are just making sure these don't blow up and cause a seg fault
-    helicsInputGetRawValue(subid, nullptr, 5, nullptr, &err);
+    helicsInputGetBytes(subid, nullptr, 5, nullptr, &err);
     EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
@@ -476,7 +476,7 @@ TEST_F(function_tests, typePub2)
 
     helicsFederateFinalize(vFed1, nullptr);
     // run a bunch of publish fails
-    helicsPublicationPublishRaw(pubid, str, actLen, &err);
+    helicsPublicationPublishBytes(pubid, str, actLen, &err);
     EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationPublishString(pubid, str, &err);
@@ -948,10 +948,10 @@ TEST_F(function_tests, messageFed_messageObject)
     helicsErrorClear(&err);
 
     helics_message mess0 = helicsEndpointGetMessage(ept1);
-    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
 
     mess0 = helicsFederateGetMessage(mFed1);
-    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
 
     // send a series of different messages testing different code paths
     helics_message mess1 = helicsFederateCreateMessage(mFed1, nullptr);
@@ -998,10 +998,10 @@ TEST_F(function_tests, messageFed_message_object)
     helicsFederateEnterExecutingMode(mFed1, nullptr);
     helicsEndpointSetDefaultDestination(ept1, "ept1", nullptr);
     auto mess0 = helicsEndpointGetMessage(ept1);
-    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
 
     mess0 = helicsFederateGetMessage(mFed1);
-    EXPECT_EQ(helicsMessageGetDataSize(mess0), 0);
+    EXPECT_EQ(helicsMessageGetBytesSize(mess0), 0);
 
     helicsEndpointSendMessage(ept1, nullptr, &err);
     EXPECT_NE(err.error_code, 0);

--- a/tests/helics/shared_library/badInputTests.cpp
+++ b/tests/helics/shared_library/badInputTests.cpp
@@ -878,9 +878,9 @@ TEST_F(function_tests, messageFed)
     helicsFederateEnterExecutingMode(mFed1, nullptr);
 
     // test out messages without specifying endpoints
-    helicsEndpointSend(ept1, nullptr, 0, &err);
+    helicsEndpointSendBytes(ept1, nullptr, 0, &err);
 
-    helicsEndpointSendTo(ept1, nullptr, 0, "fed0/ept1", &err);
+    helicsEndpointSendBytesTo(ept1, nullptr, 0, "fed0/ept1", &err);
 
     helicsFederateRequestNextStep(mFed1, nullptr);
     // make sure the message got through
@@ -892,7 +892,7 @@ TEST_F(function_tests, messageFed)
     EXPECT_EQ(cnt, 0);
 
     helicsFederateFinalize(mFed1, nullptr);
-    helicsEndpointSendTo(ept1, nullptr, 0, "fed0/ept1", &err);
+    helicsEndpointSendBytesTo(ept1, nullptr, 0, "fed0/ept1", &err);
     EXPECT_NE(err.error_code, 0);
 }
 
@@ -911,19 +911,19 @@ TEST_F(function_tests, messageFed_event)
     helicsEndpointSetDefaultDestination(ept1, "ept1", nullptr);
     helicsFederateEnterExecutingMode(mFed1, nullptr);
 
-    helicsEndpointSendAt(ept1, nullptr, 0, 0.0, &err);
+    helicsEndpointSendBytesAt(ept1, nullptr, 0, 0.0, &err);
 
-    helicsEndpointSendToAt(ept1, "ept1", 0.0, nullptr, 0, &err);
+    helicsEndpointSendBytesToAt(ept1, "ept1", 0.0, nullptr, 0, &err);
 
     char data[5] = "test";
-    helicsEndpointSendAt(ept1, data, 4, 0.0, &err);
+    helicsEndpointSendBytesAt(ept1, data, 4, 0.0, &err);
     helicsFederateRequestNextStep(mFed1, nullptr);
     auto cnt = helicsEndpointPendingMessagesCount(ept1);
     EXPECT_EQ(cnt, 3);
 
     helicsFederateFinalize(mFed1, nullptr);
     //  can't send an event after the federate is finalized
-    helicsEndpointSendAt(ept1, data, 4, 0.0, &err);
+    helicsEndpointSendBytesAt(ept1, data, 4, 0.0, &err);
     EXPECT_NE(err.error_code, 0);
 }
 

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -3658,7 +3658,7 @@ TEST(evil_endpoint_test, helicsEndpointGetDefaultDestination)
     EXPECT_STREQ(res2, "");
 }
 
-TEST(evil_endpoint_test, helicsEndpointSendTo)
+TEST(evil_endpoint_test, helicsEndpointSendBytesTo)
 {
     // void helicsEndpointSendMessage(helics_endpoint endpoint, const char* dest, const void*
     // data, int inputDataLength, helics_error* err);
@@ -3666,16 +3666,16 @@ TEST(evil_endpoint_test, helicsEndpointSendTo)
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
-    helicsEndpointSendTo(nullptr, nullptr, 45, nullptr, &err);
+    helicsEndpointSendBytesTo(nullptr, nullptr, 45, nullptr, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSendMessage(nullptr, nullptr, nullptr, int inputDataLength,
     // nullptr);
-    helicsEndpointSendTo(evil_ept, rdata, 200, "dest", &err);
+    helicsEndpointSendBytesTo(evil_ept, rdata, 200, "dest", &err);
     EXPECT_NE(err.error_code, 0);
 }
 
-TEST(evil_endpoint_test, helicsEndpointSendToAt)
+TEST(evil_endpoint_test, helicsEndpointSendBytesToAt)
 {
     // void helicsEndpointSendMessage(helics_endpoint endpoint, const char* dest, const void*
     // data, int inputDataLength, helics_error* err);
@@ -3683,27 +3683,27 @@ TEST(evil_endpoint_test, helicsEndpointSendToAt)
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
-    helicsEndpointSendToAt(nullptr, nullptr, 45, nullptr, 0.0, &err);
+    helicsEndpointSendBytesToAt(nullptr, nullptr, 45, nullptr, 0.0, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    helicsEndpointSendToAt(evil_ept, rdata, 200, "dest", -15.7, &err);
+    helicsEndpointSendBytesToAt(evil_ept, rdata, 200, "dest", -15.7, &err);
     EXPECT_NE(err.error_code, 0);
 }
 
-TEST(evil_endpoint_test, helicsEndpointSendAt)
+TEST(evil_endpoint_test, helicsEndpointSendBytesAt)
 {
-    // void helicsEndpointSendToAt(     helics_endpoint endpoint,     const char* dest, const
+    // void helicsEndpointSendBytesToAt(     helics_endpoint endpoint,     const char* dest, const
     // void* data,     int inputDataLength,     helics_time time,     helics_error* err);
     char rdata[256];
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
-    helicsEndpointSendAt(nullptr, nullptr, 25, 3.5, &err);
+    helicsEndpointSendBytesAt(nullptr, nullptr, 25, 3.5, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    // auto res2=helicsEndpointSendToAt(     nullptr,    nullptr,    nullptr,     int
+    // auto res2=helicsEndpointSendBytesToAt(     nullptr,    nullptr,    nullptr,     int
     // inputDataLength,     helics_time time,     nullptr);
-    helicsEndpointSendAt(evil_ept, rdata, 56, 3.5, &err);
+    helicsEndpointSendBytesAt(evil_ept, rdata, 56, 3.5, &err);
     EXPECT_NE(err.error_code, 0);
 }
 

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -2534,14 +2534,14 @@ TEST(evil_input_test, helicsInputAddTarget)
     EXPECT_NE(err.error_code, 0);
 }
 
-TEST(evil_input_test, helicsInputGetBytesSize)
+TEST(evil_input_test, helicsInputGetByteCount)
 {
-    // int helicsInputGetBytesSize(helics_input ipt);
+    // int helicsInputGetByteCount(helics_input ipt);
     char rdata[256];
     auto evil_input = reinterpret_cast<helics_input>(rdata);
-    auto res1 = helicsInputGetBytesSize(nullptr);
+    auto res1 = helicsInputGetByteCount(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsInputGetBytesSize(evil_input);
+    auto res2 = helicsInputGetByteCount(evil_input);
     EXPECT_EQ(res2, 0);
 }
 
@@ -3356,14 +3356,14 @@ TEST(evil_message_object_test, helicsMessageCheckFlag)
     EXPECT_EQ(res2, helics_false);
 }
 
-TEST(evil_message_object_test, helicsMessageGetBytesSize)
+TEST(evil_message_object_test, helicsMessageGetByteCount)
 {
-    // int helicsMessageGetBytesSize(helics_message message);
+    // int helicsMessageGetByteCount(helics_message message);
     char rdata[256];
     auto evil_mo = reinterpret_cast<helics_message>(rdata);
-    auto res1 = helicsMessageGetBytesSize(nullptr);
+    auto res1 = helicsMessageGetByteCount(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsMessageGetBytesSize(evil_mo);
+    auto res2 = helicsMessageGetByteCount(evil_mo);
     EXPECT_EQ(res2, 0);
 }
 

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -3356,34 +3356,34 @@ TEST(evil_message_object_test, helicsMessageCheckFlag)
     EXPECT_EQ(res2, helics_false);
 }
 
-TEST(evil_message_object_test, helicsMessageGetRawDataSize)
+TEST(evil_message_object_test, helicsMessageGetDataSize)
 {
-    // int helicsMessageGetRawDataSize(helics_message message);
+    // int helicsMessageGetDataSize(helics_message message);
     char rdata[256];
     auto evil_mo = reinterpret_cast<helics_message>(rdata);
-    auto res1 = helicsMessageGetRawDataSize(nullptr);
+    auto res1 = helicsMessageGetDataSize(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsMessageGetRawDataSize(evil_mo);
+    auto res2 = helicsMessageGetDataSize(evil_mo);
     EXPECT_EQ(res2, 0);
 }
 
-TEST(evil_message_object_test, helicsMessageGetRawData)
+TEST(evil_message_object_test, helicsMessageGetData)
 {
-    // void helicsMessageGetRawData(helics_message message, void* data, int maxMessagelen,
+    // void helicsMessageGetData(helics_message message, void* data, int maxMessagelen,
     // int* actualSize, helics_error* err);
     char rdata[256];
     auto evil_mo = reinterpret_cast<helics_message>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
     int actSize = 98;
-    helicsMessageGetRawData(nullptr, nullptr, 55, &actSize, &err);
+    helicsMessageGetData(nullptr, nullptr, 55, &actSize, &err);
     EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actSize, 0);
     helicsErrorClear(&err);
     actSize = 45;
-    // auto res2=helicsMessageGetRawData(nullptr, void* data, int maxMessagelen, int* actualSize,
+    // auto res2=helicsMessageGetData(nullptr, void* data, int maxMessagelen, int* actualSize,
     // nullptr);
-    helicsMessageGetRawData(evil_mo, nullptr, 22, &actSize, &err);
+    helicsMessageGetData(evil_mo, nullptr, 22, &actSize, &err);
     EXPECT_EQ(actSize, 0);
     EXPECT_NE(err.error_code, 0);
 }
@@ -3660,7 +3660,7 @@ TEST(evil_endpoint_test, helicsEndpointGetDefaultDestination)
 
 TEST(evil_endpoint_test, helicsEndpointSendTo)
 {
-    // void helicsEndpointSendMessageRaw(helics_endpoint endpoint, const char* dest, const void*
+    // void helicsEndpointSendMessage(helics_endpoint endpoint, const char* dest, const void*
     // data, int inputDataLength, helics_error* err);
     char rdata[256];
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
@@ -3669,7 +3669,7 @@ TEST(evil_endpoint_test, helicsEndpointSendTo)
     helicsEndpointSendTo(nullptr, nullptr, 45, nullptr, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    // auto res2=helicsEndpointSendMessageRaw(nullptr, nullptr, nullptr, int inputDataLength,
+    // auto res2=helicsEndpointSendMessage(nullptr, nullptr, nullptr, int inputDataLength,
     // nullptr);
     helicsEndpointSendTo(evil_ept, rdata, 200, "dest", &err);
     EXPECT_NE(err.error_code, 0);
@@ -3677,7 +3677,7 @@ TEST(evil_endpoint_test, helicsEndpointSendTo)
 
 TEST(evil_endpoint_test, helicsEndpointSendToAt)
 {
-    // void helicsEndpointSendMessageRaw(helics_endpoint endpoint, const char* dest, const void*
+    // void helicsEndpointSendMessage(helics_endpoint endpoint, const char* dest, const void*
     // data, int inputDataLength, helics_error* err);
     char rdata[256];
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
@@ -3686,8 +3686,6 @@ TEST(evil_endpoint_test, helicsEndpointSendToAt)
     helicsEndpointSendToAt(nullptr, nullptr, 45, nullptr, 0.0, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    // auto res2=helicsEndpointSendMessageRaw(nullptr, nullptr, nullptr, int inputDataLength,
-    // nullptr);
     helicsEndpointSendToAt(evil_ept, rdata, 200, "dest", -15.7, &err);
     EXPECT_NE(err.error_code, 0);
 }

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -2225,20 +2225,20 @@ TEST(evil_pub_test, helicsPublicationIsValid)
     EXPECT_NE(helicsPublicationIsValid(evil_pub), helics_true);
 }
 
-TEST(evil_pub_test, helicsPublicationPublishRaw)
+TEST(evil_pub_test, helicsPublicationPublishBytes)
 {
-    // void helicsPublicationPublishRaw(helics_publication pub, const void* data, int
+    // void helicsPublicationPublishBytes(helics_publication pub, const void* data, int
     // inputDataLength, helics_error* err);
     char rdata[256];
     auto evil_pub = reinterpret_cast<helics_publication>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
-    helicsPublicationPublishRaw(nullptr, nullptr, 85, &err);
+    helicsPublicationPublishBytes(nullptr, nullptr, 85, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    // auto res2=helicsPublicationPublishRaw(helics_publication pub, const void* data, int
+    // auto res2=helicsPublicationPublishBytes(helics_publication pub, const void* data, int
     // inputDataLength, nullptr);
-    helicsPublicationPublishRaw(evil_pub, nullptr, 14654181, &err);
+    helicsPublicationPublishBytes(evil_pub, nullptr, 14654181, &err);
     EXPECT_NE(err.error_code, 0);
 }
 
@@ -2534,34 +2534,34 @@ TEST(evil_input_test, helicsInputAddTarget)
     EXPECT_NE(err.error_code, 0);
 }
 
-TEST(evil_input_test, helicsInputGetRawValueSize)
+TEST(evil_input_test, helicsInputGetBytesSize)
 {
-    // int helicsInputGetRawValueSize(helics_input ipt);
+    // int helicsInputGetBytesSize(helics_input ipt);
     char rdata[256];
     auto evil_input = reinterpret_cast<helics_input>(rdata);
-    auto res1 = helicsInputGetRawValueSize(nullptr);
+    auto res1 = helicsInputGetBytesSize(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsInputGetRawValueSize(evil_input);
+    auto res2 = helicsInputGetBytesSize(evil_input);
     EXPECT_EQ(res2, 0);
 }
 
-TEST(evil_input_test, helicsInputGetRawValue)
+TEST(evil_input_test, helicsInputGetBytes)
 {
-    // void helicsInputGetRawValue(helics_input ipt, void* data, int maxDatalen, int* actualSize,
+    // void helicsInputGetBytes(helics_input ipt, void* data, int maxDatalen, int* actualSize,
     // helics_error* err);
     char rdata[256];
     auto evil_input = reinterpret_cast<helics_input>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
     int actLen = 99;
-    helicsInputGetRawValue(nullptr, nullptr, 87, &actLen, &err);
+    helicsInputGetBytes(nullptr, nullptr, 87, &actLen, &err);
     EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actLen, 0);
     helicsErrorClear(&err);
     actLen = 99;
-    // auto res2=helicsInputGetRawValue(helics_input ipt, void* data, int maxDatalen, int*
+    // auto res2=helicsInputGetBytes(helics_input ipt, void* data, int maxDatalen, int*
     // actualSize, nullptr);
-    helicsInputGetRawValue(evil_input, rdata, 10, &actLen, &err);
+    helicsInputGetBytes(evil_input, rdata, 10, &actLen, &err);
     EXPECT_EQ(actLen, 0);
     EXPECT_NE(err.error_code, 0);
 }
@@ -2780,20 +2780,20 @@ TEST(evil_input_test, helicsInputGetNamedPoint)
     EXPECT_NE(err.error_code, 0);
 }
 
-TEST(evil_input_test, helicsInputSetDefaultRaw)
+TEST(evil_input_test, helicsInputSetDefaultBytes)
 {
-    // void helicsInputSetDefaultRaw(helics_input ipt, const void* data, int inputDataLength,
+    // void helicsInputSetDefaultBytes(helics_input ipt, const void* data, int inputDataLength,
     // helics_error* err);
     char rdata[256];
     auto evil_input = reinterpret_cast<helics_input>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
-    helicsInputSetDefaultRaw(nullptr, nullptr, -87, &err);
+    helicsInputSetDefaultBytes(nullptr, nullptr, -87, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    // auto res2=helicsInputSetDefaultRaw(helics_input ipt, const void* data, int inputDataLength,
+    // auto res2=helicsInputSetDefaultBytes(helics_input ipt, const void* data, int inputDataLength,
     // nullptr);
-    helicsInputSetDefaultRaw(evil_input, nullptr, 15, &err);
+    helicsInputSetDefaultBytes(evil_input, nullptr, 15, &err);
     EXPECT_NE(err.error_code, 0);
 }
 
@@ -3356,34 +3356,34 @@ TEST(evil_message_object_test, helicsMessageCheckFlag)
     EXPECT_EQ(res2, helics_false);
 }
 
-TEST(evil_message_object_test, helicsMessageGetDataSize)
+TEST(evil_message_object_test, helicsMessageGetBytesSize)
 {
-    // int helicsMessageGetDataSize(helics_message message);
+    // int helicsMessageGetBytesSize(helics_message message);
     char rdata[256];
     auto evil_mo = reinterpret_cast<helics_message>(rdata);
-    auto res1 = helicsMessageGetDataSize(nullptr);
+    auto res1 = helicsMessageGetBytesSize(nullptr);
     EXPECT_EQ(res1, 0);
-    auto res2 = helicsMessageGetDataSize(evil_mo);
+    auto res2 = helicsMessageGetBytesSize(evil_mo);
     EXPECT_EQ(res2, 0);
 }
 
-TEST(evil_message_object_test, helicsMessageGetData)
+TEST(evil_message_object_test, helicsMessageGetBytes)
 {
-    // void helicsMessageGetData(helics_message message, void* data, int maxMessagelen,
+    // void helicsMessageGetBytes(helics_message message, void* data, int maxMessagelen,
     // int* actualSize, helics_error* err);
     char rdata[256];
     auto evil_mo = reinterpret_cast<helics_message>(rdata);
     auto err = helicsErrorInitialize();
     err.error_code = 45;
     int actSize = 98;
-    helicsMessageGetData(nullptr, nullptr, 55, &actSize, &err);
+    helicsMessageGetBytes(nullptr, nullptr, 55, &actSize, &err);
     EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actSize, 0);
     helicsErrorClear(&err);
     actSize = 45;
     // auto res2=helicsMessageGetData(nullptr, void* data, int maxMessagelen, int* actualSize,
     // nullptr);
-    helicsMessageGetData(evil_mo, nullptr, 22, &actSize, &err);
+    helicsMessageGetBytes(evil_mo, nullptr, 22, &actSize, &err);
     EXPECT_EQ(actSize, 0);
     EXPECT_NE(err.error_code, 0);
 }
@@ -3692,7 +3692,7 @@ TEST(evil_endpoint_test, helicsEndpointSendToAt)
 
 TEST(evil_endpoint_test, helicsEndpointSendAt)
 {
-    // void helicsEndpointSendEventRaw(     helics_endpoint endpoint,     const char* dest, const
+    // void helicsEndpointSendToAt(     helics_endpoint endpoint,     const char* dest, const
     // void* data,     int inputDataLength,     helics_time time,     helics_error* err);
     char rdata[256];
     auto evil_ept = reinterpret_cast<helics_endpoint>(rdata);
@@ -3701,7 +3701,7 @@ TEST(evil_endpoint_test, helicsEndpointSendAt)
     helicsEndpointSendAt(nullptr, nullptr, 25, 3.5, &err);
     EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    // auto res2=helicsEndpointSendEventRaw(     nullptr,    nullptr,    nullptr,     int
+    // auto res2=helicsEndpointSendToAt(     nullptr,    nullptr,    nullptr,     int
     // inputDataLength,     helics_time time,     nullptr);
     helicsEndpointSendAt(evil_ept, rdata, 56, 3.5, &err);
     EXPECT_NE(err.error_code, 0);

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -107,7 +107,7 @@ TEST_P(mfed_simple_type_tests, send_receive)
 
     auto M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetBytesSize(M), 500);
+    ASSERT_EQ(helicsMessageGetByteCount(M), 500);
     char* dptr = reinterpret_cast<char*>(helicsMessageGetBytesPointer(M));
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'a');
@@ -150,7 +150,7 @@ TEST_P(mfed_simple_type_tests, send_receive_mobj)
 
     auto M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetBytesSize(M), 500);
+    ASSERT_EQ(helicsMessageGetByteCount(M), 500);
 
     char* rdata = static_cast<char*>(helicsMessageGetBytesPointer(M));
     if (rdata != nullptr) {
@@ -200,7 +200,7 @@ TEST_F(mfed_tests, message_object_tests)
 
     M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetBytesSize(M), 500);
+    ASSERT_EQ(helicsMessageGetByteCount(M), 500);
 
     char* rdata = static_cast<char*>(helicsMessageGetBytesPointer(M));
     EXPECT_NE(rdata, nullptr);
@@ -276,7 +276,7 @@ TEST_P(mfed_type_tests, send_receive_2fed)
 
     auto M1 = helicsEndpointGetMessage(epid);
     // ASSERT_TRUE(M1);
-    EXPECT_EQ(helicsMessageGetBytesSize(M1), 400);
+    EXPECT_EQ(helicsMessageGetByteCount(M1), 400);
     auto dptr = static_cast<char*>(helicsMessageGetBytesPointer(M1));
     EXPECT_NE(dptr, nullptr);
     if (dptr != nullptr) {
@@ -285,7 +285,7 @@ TEST_P(mfed_type_tests, send_receive_2fed)
 
     auto M2 = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE(M2);
-    EXPECT_EQ(helicsMessageGetBytesSize(M2), 500);
+    EXPECT_EQ(helicsMessageGetByteCount(M2), 500);
     dptr = static_cast<char*>(helicsMessageGetBytesPointer(M2));
     EXPECT_NE(dptr, nullptr);
     if (dptr != nullptr) {
@@ -430,14 +430,14 @@ TEST(message_object, test1)
     helicsErrorClear(&err);
 
     helicsMessageResize(m2, 500, nullptr);
-    auto s2 = helicsMessageGetBytesSize(m2);
+    auto s2 = helicsMessageGetByteCount(m2);
     EXPECT_EQ(s2, 500);
 
     helicsMessageReserve(m2, 2000, nullptr);
 
     helicsMessageAppendData(m2, " more data", 8, nullptr);
 
-    s2 = helicsMessageGetBytesSize(m2);
+    s2 = helicsMessageGetByteCount(m2);
     EXPECT_EQ(s2, 508);
 
     // this should generate an out of memory exception

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -107,8 +107,8 @@ TEST_P(mfed_simple_type_tests, send_receive)
 
     auto M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetDataSize(M), 500);
-    char* dptr = reinterpret_cast<char*>(helicsMessageGetDataPointer(M));
+    ASSERT_EQ(helicsMessageGetBytesSize(M), 500);
+    char* dptr = reinterpret_cast<char*>(helicsMessageGetBytesPointer(M));
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'a');
     } else {
@@ -150,9 +150,9 @@ TEST_P(mfed_simple_type_tests, send_receive_mobj)
 
     auto M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetDataSize(M), 500);
+    ASSERT_EQ(helicsMessageGetBytesSize(M), 500);
 
-    char* rdata = static_cast<char*>(helicsMessageGetDataPointer(M));
+    char* rdata = static_cast<char*>(helicsMessageGetBytesPointer(M));
     if (rdata != nullptr) {
         EXPECT_EQ(rdata[245], 'a');
     } else {
@@ -200,9 +200,9 @@ TEST_F(mfed_tests, message_object_tests)
 
     M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetDataSize(M), 500);
+    ASSERT_EQ(helicsMessageGetBytesSize(M), 500);
 
-    char* rdata = static_cast<char*>(helicsMessageGetDataPointer(M));
+    char* rdata = static_cast<char*>(helicsMessageGetBytesPointer(M));
     EXPECT_NE(rdata, nullptr);
     if (rdata != nullptr) {
         EXPECT_EQ(rdata[245], 'a');
@@ -276,8 +276,8 @@ TEST_P(mfed_type_tests, send_receive_2fed)
 
     auto M1 = helicsEndpointGetMessage(epid);
     // ASSERT_TRUE(M1);
-    EXPECT_EQ(helicsMessageGetDataSize(M1), 400);
-    auto dptr = static_cast<char*>(helicsMessageGetDataPointer(M1));
+    EXPECT_EQ(helicsMessageGetBytesSize(M1), 400);
+    auto dptr = static_cast<char*>(helicsMessageGetBytesPointer(M1));
     EXPECT_NE(dptr, nullptr);
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'b');
@@ -285,8 +285,8 @@ TEST_P(mfed_type_tests, send_receive_2fed)
 
     auto M2 = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE(M2);
-    EXPECT_EQ(helicsMessageGetDataSize(M2), 500);
-    dptr = static_cast<char*>(helicsMessageGetDataPointer(M2));
+    EXPECT_EQ(helicsMessageGetBytesSize(M2), 500);
+    dptr = static_cast<char*>(helicsMessageGetBytesPointer(M2));
     EXPECT_NE(dptr, nullptr);
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'a');
@@ -401,14 +401,14 @@ TEST(message_object, test1)
 
     char data[20];
     int actSize = 10;
-    helicsMessageGetData(m2, nullptr, 0, &actSize, &err);
+    helicsMessageGetBytes(m2, nullptr, 0, &actSize, &err);
     EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(actSize, 0);
     helicsErrorClear(&err);
 
-    EXPECT_EQ(helicsMessageGetDataPointer(nullptr), nullptr);
+    EXPECT_EQ(helicsMessageGetBytesPointer(nullptr), nullptr);
 
-    helicsMessageGetData(m2, data, 20, &actSize, &err);
+    helicsMessageGetBytes(m2, data, 20, &actSize, &err);
     EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 8);
     EXPECT_EQ(std::string(data, data + actSize), "raw data");
@@ -430,14 +430,14 @@ TEST(message_object, test1)
     helicsErrorClear(&err);
 
     helicsMessageResize(m2, 500, nullptr);
-    auto s2 = helicsMessageGetDataSize(m2);
+    auto s2 = helicsMessageGetBytesSize(m2);
     EXPECT_EQ(s2, 500);
 
     helicsMessageReserve(m2, 2000, nullptr);
 
     helicsMessageAppendData(m2, " more data", 8, nullptr);
 
-    s2 = helicsMessageGetDataSize(m2);
+    s2 = helicsMessageGetBytesSize(m2);
     EXPECT_EQ(s2, 508);
 
     // this should generate an out of memory exception
@@ -499,7 +499,7 @@ TEST(message_object, copy)
     char data[20];
     int actSize = 10;
 
-    helicsMessageGetData(m2, data, 20, &actSize, &err);
+    helicsMessageGetBytes(m2, data, 20, &actSize, &err);
     EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 8);
     EXPECT_EQ(std::string(data, data + actSize), "raw data");

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -93,7 +93,7 @@ TEST_P(mfed_simple_type_tests, send_receive)
     EXPECT_TRUE(mFed1State == helics_state_execution);
     std::string data(500, 'a');
 
-    CE(helicsEndpointSendToAt(epid, data.c_str(), 500, "ep2", 0.0, &err));
+    CE(helicsEndpointSendBytesToAt(epid, data.c_str(), 500, "ep2", 0.0, &err));
     helics_time time;
     CE(time = helicsFederateRequestTime(mFed1, 1.0, &err));
     EXPECT_EQ(time, 1.0);
@@ -136,7 +136,7 @@ TEST_P(mfed_simple_type_tests, send_receive_mobj)
     EXPECT_TRUE(mFed1State == helics_state_execution);
     std::string data(500, 'a');
 
-    CE(helicsEndpointSendToAt(epid, data.c_str(), 500, "ep2", 0.0, &err));
+    CE(helicsEndpointSendBytesToAt(epid, data.c_str(), 500, "ep2", 0.0, &err));
     helics_time time;
     CE(time = helicsFederateRequestTime(mFed1, 1.0, &err));
     EXPECT_EQ(time, 1.0);
@@ -251,8 +251,8 @@ TEST_P(mfed_type_tests, send_receive_2fed)
     std::string data(500, 'a');
     std::string data2(400, 'b');
 
-    CE(helicsEndpointSendToAt(epid, data.c_str(), 500, "ep2", 0.0, &err));
-    CE(helicsEndpointSendToAt(epid2, data2.c_str(), 400, "fed0/ep1", 0.0, &err));
+    CE(helicsEndpointSendBytesToAt(epid, data.c_str(), 500, "ep2", 0.0, &err));
+    CE(helicsEndpointSendBytesToAt(epid2, data2.c_str(), 400, "fed0/ep1", 0.0, &err));
     // move the time to 1.0
     helics_time time;
     CE(helicsFederateRequestTimeAsync(mFed1, 1.0, &err));
@@ -328,9 +328,9 @@ TEST_P(mfed_type_tests, send_receive_2fed_multisend)
 
     std::string data(500, 'a');
 
-    CE(helicsEndpointSendTo(epid, data.c_str(), 500, nullptr, &err));
-    CE(helicsEndpointSendTo(epid, data.c_str(), 400, nullptr, &err));
-    CE(helicsEndpointSendTo(epid, data.c_str(), 300, nullptr, &err));
+    CE(helicsEndpointSendBytesTo(epid, data.c_str(), 500, nullptr, &err));
+    CE(helicsEndpointSendBytesTo(epid, data.c_str(), 400, nullptr, &err));
+    CE(helicsEndpointSendBytesTo(epid, data.c_str(), 300, nullptr, &err));
 
     // move the time to 1.0
     helics_time time;

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -107,8 +107,8 @@ TEST_P(mfed_simple_type_tests, send_receive)
 
     auto M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetRawDataSize(M), 500);
-    char* dptr = reinterpret_cast<char*>(helicsMessageGetRawDataPointer(M));
+    ASSERT_EQ(helicsMessageGetDataSize(M), 500);
+    char* dptr = reinterpret_cast<char*>(helicsMessageGetDataPointer(M));
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'a');
     } else {
@@ -150,9 +150,9 @@ TEST_P(mfed_simple_type_tests, send_receive_mobj)
 
     auto M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetRawDataSize(M), 500);
+    ASSERT_EQ(helicsMessageGetDataSize(M), 500);
 
-    char* rdata = static_cast<char*>(helicsMessageGetRawDataPointer(M));
+    char* rdata = static_cast<char*>(helicsMessageGetDataPointer(M));
     if (rdata != nullptr) {
         EXPECT_EQ(rdata[245], 'a');
     } else {
@@ -200,9 +200,9 @@ TEST_F(mfed_tests, message_object_tests)
 
     M = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE (M);
-    ASSERT_EQ(helicsMessageGetRawDataSize(M), 500);
+    ASSERT_EQ(helicsMessageGetDataSize(M), 500);
 
-    char* rdata = static_cast<char*>(helicsMessageGetRawDataPointer(M));
+    char* rdata = static_cast<char*>(helicsMessageGetDataPointer(M));
     EXPECT_NE(rdata, nullptr);
     if (rdata != nullptr) {
         EXPECT_EQ(rdata[245], 'a');
@@ -276,8 +276,8 @@ TEST_P(mfed_type_tests, send_receive_2fed)
 
     auto M1 = helicsEndpointGetMessage(epid);
     // ASSERT_TRUE(M1);
-    EXPECT_EQ(helicsMessageGetRawDataSize(M1), 400);
-    auto dptr = static_cast<char*>(helicsMessageGetRawDataPointer(M1));
+    EXPECT_EQ(helicsMessageGetDataSize(M1), 400);
+    auto dptr = static_cast<char*>(helicsMessageGetDataPointer(M1));
     EXPECT_NE(dptr, nullptr);
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'b');
@@ -285,8 +285,8 @@ TEST_P(mfed_type_tests, send_receive_2fed)
 
     auto M2 = helicsEndpointGetMessage(epid2);
     // ASSERT_TRUE(M2);
-    EXPECT_EQ(helicsMessageGetRawDataSize(M2), 500);
-    dptr = static_cast<char*>(helicsMessageGetRawDataPointer(M2));
+    EXPECT_EQ(helicsMessageGetDataSize(M2), 500);
+    dptr = static_cast<char*>(helicsMessageGetDataPointer(M2));
     EXPECT_NE(dptr, nullptr);
     if (dptr != nullptr) {
         EXPECT_EQ(dptr[245], 'a');
@@ -401,14 +401,14 @@ TEST(message_object, test1)
 
     char data[20];
     int actSize = 10;
-    helicsMessageGetRawData(m2, nullptr, 0, &actSize, &err);
+    helicsMessageGetData(m2, nullptr, 0, &actSize, &err);
     EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(actSize, 0);
     helicsErrorClear(&err);
 
-    EXPECT_EQ(helicsMessageGetRawDataPointer(nullptr), nullptr);
+    EXPECT_EQ(helicsMessageGetDataPointer(nullptr), nullptr);
 
-    helicsMessageGetRawData(m2, data, 20, &actSize, &err);
+    helicsMessageGetData(m2, data, 20, &actSize, &err);
     EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 8);
     EXPECT_EQ(std::string(data, data + actSize), "raw data");
@@ -430,14 +430,14 @@ TEST(message_object, test1)
     helicsErrorClear(&err);
 
     helicsMessageResize(m2, 500, nullptr);
-    auto s2 = helicsMessageGetRawDataSize(m2);
+    auto s2 = helicsMessageGetDataSize(m2);
     EXPECT_EQ(s2, 500);
 
     helicsMessageReserve(m2, 2000, nullptr);
 
     helicsMessageAppendData(m2, " more data", 8, nullptr);
 
-    s2 = helicsMessageGetRawDataSize(m2);
+    s2 = helicsMessageGetDataSize(m2);
     EXPECT_EQ(s2, 508);
 
     // this should generate an out of memory exception
@@ -499,7 +499,7 @@ TEST(message_object, copy)
     char data[20];
     int actSize = 10;
 
-    helicsMessageGetRawData(m2, data, 20, &actSize, &err);
+    helicsMessageGetData(m2, data, 20, &actSize, &err);
     EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 8);
     EXPECT_EQ(std::string(data, data + actSize), "raw data");

--- a/tests/helics/shared_library/test-value-federate1.cpp
+++ b/tests/helics/shared_library/test-value-federate1.cpp
@@ -275,10 +275,10 @@ TEST_F(vfed_single_tests, default_value_tests)
     helicsPublicationAddTarget(pub, "fed0/key8", &err);
     EXPECT_EQ(helicsPublicationIsValid(pub), helics_true);
 
-    helicsInputSetDefaultRaw(inp_raw1, nullptr, -2, &err);
+    helicsInputSetDefaultBytes(inp_raw1, nullptr, -2, &err);
     EXPECT_EQ(err.error_code, 0);
     char data[256] = "this is a string";
-    helicsInputSetDefaultRaw(inp_raw2, data, 30, &err);
+    helicsInputSetDefaultBytes(inp_raw2, data, 30, &err);
 
     helicsInputSetDefaultBoolean(inp_bool, helics_true, &err);
 

--- a/tests/helics/shared_library/test-value-federate2.cpp
+++ b/tests/helics/shared_library/test-value-federate2.cpp
@@ -51,13 +51,13 @@ TEST_P(vfed2_type_tests, block_send_receive)
 
     EXPECT_TRUE(helicsInputIsUpdated(sub1));
 
-    int len1 = helicsInputGetBytesSize(sub1);
+    int len1 = helicsInputGetByteCount(sub1);
 
     EXPECT_EQ(len1, len);
     CE(helicsInputGetBytes(sub1, val, 600, &actualLen, &err));
     EXPECT_EQ(actualLen, len);
 
-    len1 = helicsInputGetBytesSize(sub1);
+    len1 = helicsInputGetByteCount(sub1);
 
     EXPECT_EQ(len1, len);
 

--- a/tests/helics/shared_library/test-value-federate2.cpp
+++ b/tests/helics/shared_library/test-value-federate2.cpp
@@ -45,19 +45,19 @@ TEST_P(vfed2_type_tests, block_send_receive)
     CE(helicsFederateSetTimeProperty(vFed1, helics_property_time_delta, 1.0, &err));
 
     CE(helicsFederateEnterExecutingMode(vFed1, &err));
-    CE(helicsPublicationPublishRaw(pubid3, s.data(), len, &err));
+    CE(helicsPublicationPublishBytes(pubid3, s.data(), len, &err));
 
     CE(helicsFederateRequestTime(vFed1, 1.0, &err));
 
     EXPECT_TRUE(helicsInputIsUpdated(sub1));
 
-    int len1 = helicsInputGetRawValueSize(sub1);
+    int len1 = helicsInputGetBytesSize(sub1);
 
     EXPECT_EQ(len1, len);
-    CE(helicsInputGetRawValue(sub1, val, 600, &actualLen, &err));
+    CE(helicsInputGetBytes(sub1, val, 600, &actualLen, &err));
     EXPECT_EQ(actualLen, len);
 
-    len1 = helicsInputGetRawValueSize(sub1);
+    len1 = helicsInputGetBytesSize(sub1);
 
     EXPECT_EQ(len1, len);
 

--- a/tests/helics/shared_library/test-value-federate2_cpp.cpp
+++ b/tests/helics/shared_library/test-value-federate2_cpp.cpp
@@ -59,11 +59,11 @@ TEST_P(vfed_type_tests, test_block_send_receive)
 
     EXPECT_EQ(len1, len);
     std::vector<char> rawdata;
-    int actualLen = sub1.getRawValue(rawdata);
+    int actualLen = sub1.getBytes(rawdata);
     // raw value has an extra 8 bits
     EXPECT_EQ(actualLen, len + 8);
 
-    len1 = sub1.getRawValueSize();
+    len1 = sub1.getBytesSize();
 
     EXPECT_EQ(len1, len + 8);
 

--- a/tests/helics/shared_library/test-value-federate2_cpp.cpp
+++ b/tests/helics/shared_library/test-value-federate2_cpp.cpp
@@ -63,7 +63,7 @@ TEST_P(vfed_type_tests, test_block_send_receive)
     // raw value has an extra 8 bits
     EXPECT_EQ(actualLen, len + 8);
 
-    len1 = sub1.getBytesSize();
+    len1 = sub1.getByteCount();
 
     EXPECT_EQ(len1, len + 8);
 

--- a/tests/java/JavaHelicsApiTests.java
+++ b/tests/java/JavaHelicsApiTests.java
@@ -439,7 +439,7 @@ public class JavaHelicsApiTests {
              System.out.println(msg2Data);
                 javaHelicsApiTests.helicsAssert("!msg2Data.equals(\"Hello\")");
             }
-            long msg2Length = helics.helicsMessageGetRawDataSize(msg2);
+            long msg2Length = helics.helicsMessageGetBytesSize(msg2);
             if (msg2Length != 5) {
                 javaHelicsApiTests.helicsAssert("msg2Length != 5");
             }
@@ -477,7 +477,7 @@ public class JavaHelicsApiTests {
             if (!"There".equals(msg3Data)) {
                 javaHelicsApiTests.helicsAssert("!msg3Data.equals(\"There\")");
             }
-            long msg3Length = helics.helicsMessageGetRawDataSize(msg3);
+            long msg3Length = helics.helicsMessageGetBytesSize(msg3);
             if (msg3Length != 5) {
                 javaHelicsApiTests.helicsAssert("msg3Length != 5");
             }
@@ -565,7 +565,7 @@ public class JavaHelicsApiTests {
             if (sub3Length[0] != 7) {
                 javaHelicsApiTests.helicsAssert("sub3Length[0] != 7");
             }
-            int sub3ValueSize = helics.helicsInputGetRawValueSize(sub3);
+            int sub3ValueSize = helics.helicsInputGetBytesSize(sub3);
             if (sub3ValueSize != 14) {
                 javaHelicsApiTests.helicsAssert("sub3ValueSize != 14");
             }

--- a/tests/java/JavaHelicsApiTests.java
+++ b/tests/java/JavaHelicsApiTests.java
@@ -439,7 +439,7 @@ public class JavaHelicsApiTests {
              System.out.println(msg2Data);
                 javaHelicsApiTests.helicsAssert("!msg2Data.equals(\"Hello\")");
             }
-            long msg2Length = helics.helicsMessageGetBytesSize(msg2);
+            long msg2Length = helics.helicsMessageGetByteCount(msg2);
             if (msg2Length != 5) {
                 javaHelicsApiTests.helicsAssert("msg2Length != 5");
             }
@@ -477,7 +477,7 @@ public class JavaHelicsApiTests {
             if (!"There".equals(msg3Data)) {
                 javaHelicsApiTests.helicsAssert("!msg3Data.equals(\"There\")");
             }
-            long msg3Length = helics.helicsMessageGetBytesSize(msg3);
+            long msg3Length = helics.helicsMessageGetByteCount(msg3);
             if (msg3Length != 5) {
                 javaHelicsApiTests.helicsAssert("msg3Length != 5");
             }
@@ -565,7 +565,7 @@ public class JavaHelicsApiTests {
             if (sub3Length[0] != 7) {
                 javaHelicsApiTests.helicsAssert("sub3Length[0] != 7");
             }
-            int sub3ValueSize = helics.helicsInputGetBytesSize(sub3);
+            int sub3ValueSize = helics.helicsInputGetByteCount(sub3);
             if (sub3ValueSize != 14) {
                 javaHelicsApiTests.helicsAssert("sub3ValueSize != 14");
             }

--- a/tests/octave/messageFedTests.m
+++ b/tests/octave/messageFedTests.m
@@ -152,7 +152,7 @@ end
 %!
 %! message = helicsEndpointGetMessage(epid2);
 %! assert(helicsMessageGetString(message),data);
-%! assert(double(helicsMessageGetRawDataSize(message)),length(data));
+%! assert(double(helicsMessageGetDataSize(message)),length(data));
 %! assert(helicsMessageGetOriginalSource(message),'fed1/ep1');
 %! assert(helicsMessageGetTime(message),1.0);
 %! success=closeStruct(feds);

--- a/tests/octave/messageFedTests.m
+++ b/tests/octave/messageFedTests.m
@@ -152,7 +152,7 @@ end
 %!
 %! message = helicsEndpointGetMessage(epid2);
 %! assert(helicsMessageGetString(message),data);
-%! assert(double(helicsMessageGetDataSize(message)),length(data));
+%! assert(double(helicsMessageGetBytesSize(message)),length(data));
 %! assert(helicsMessageGetOriginalSource(message),'fed1/ep1');
 %! assert(helicsMessageGetTime(message),1.0);
 %! success=closeStruct(feds);

--- a/tests/octave/messageFedTests.m
+++ b/tests/octave/messageFedTests.m
@@ -152,7 +152,7 @@ end
 %!
 %! message = helicsEndpointGetMessage(epid2);
 %! assert(helicsMessageGetString(message),data);
-%! assert(double(helicsMessageGetBytesSize(message)),length(data));
+%! assert(double(helicsMessageGetByteCount(message)),length(data));
 %! assert(helicsMessageGetOriginalSource(message),'fed1/ep1');
 %! assert(helicsMessageGetTime(message),1.0);
 %! success=closeStruct(feds);

--- a/tests/octave/messageFilterTests.m
+++ b/tests/octave/messageFilterTests.m
@@ -164,7 +164,7 @@ end
 %! helicsFederateEnterExecutingModeComplete(mFed);
 %!
 %! data='hello world';
-%! helicsEndpointSendTo(p1,'port2',data);
+%! helicsEndpointSendBytesTo(p1,'port2',data);
 %!
 %! granted_time=helicsFederateRequestTime(mFed,1.0);
 %! assert(granted_time,1.0);


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will address Issue #1647.  It removes a redundent raw from a few API calls related to messages
