### PR TITLE
add a test for queries on disconnected targets

### DIFF
--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2372,15 +2372,15 @@ void CoreBroker::markAsDisconnected(global_broker_id brkid)
             }
         }
     }
-        for (size_t ii = 0; ii < _federates.size(); ++ii) {  // NOLINT
-            auto& fed = _federates[ii];
+    for (size_t ii = 0; ii < _federates.size(); ++ii) {  // NOLINT
+        auto& fed = _federates[ii];
 
-            if (fed.parent == brkid) {
-                if (fed.state != connection_state::error) {
-                    fed.state = connection_state::disconnected;
-                }
+        if (fed.parent == brkid) {
+            if (fed.state != connection_state::error) {
+                fed.state = connection_state::disconnected;
             }
         }
+    }
 }
 
 void CoreBroker::disconnectBroker(BasicBrokerInfo& brk)

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2357,14 +2357,12 @@ void CoreBroker::checkInFlightQueries(global_broker_id brkid)
 
 void CoreBroker::markAsDisconnected(global_broker_id brkid)
 {
-    bool isCore{false};
     // using regular loop here since dual mapped vector shouldn't produce a modifiable lvalue
     for (size_t ii = 0; ii < _brokers.size(); ++ii) {  // NOLINT
         auto& brk = _brokers[ii];
         if (brk.global_id == brkid) {
             if (brk.state != connection_state::error) {
                 brk.state = connection_state::disconnected;
-                isCore = brk._core;
             }
         }
         if (brk.parent == brkid) {
@@ -2374,7 +2372,6 @@ void CoreBroker::markAsDisconnected(global_broker_id brkid)
             }
         }
     }
-    if (isCore) {
         for (size_t ii = 0; ii < _federates.size(); ++ii) {  // NOLINT
             auto& fed = _federates[ii];
 
@@ -2384,7 +2381,6 @@ void CoreBroker::markAsDisconnected(global_broker_id brkid)
                 }
             }
         }
-    }
 }
 
 void CoreBroker::disconnectBroker(BasicBrokerInfo& brk)
@@ -2943,12 +2939,40 @@ void CoreBroker::processQuery(ActionMessage& m)
             route = fed->route;
             m.dest_id = fed->parent;
             response = checkFedQuery(*fed, m.payload);
+            if (response.empty() && fed->state >= connection_state::error) {
+                route = parent_route_id;
+                switch (fed->state) {
+                    case connection_state::error:
+                        response = "#errored";
+                        break;
+                    case connection_state::disconnected:
+                    case connection_state::request_disconnect:
+                        response = "#disconnected";
+                        break;
+                    default:
+                        break;
+                }
+            }
         } else {
             auto broker = _brokers.find(target);
             if (broker != _brokers.end()) {
                 route = broker->route;
                 m.dest_id = broker->global_id;
                 response = checkBrokerQuery(*broker, m.payload);
+                if (response.empty() && broker->state >= connection_state::error) {
+                    route = parent_route_id;
+                    switch (broker->state) {
+                        case connection_state::error:
+                            response = "#errored";
+                            break;
+                        case connection_state::disconnected:
+                        case connection_state::request_disconnect:
+                            response = "#disconnected";
+                            break;
+                        default:
+                            break;
+                    }
+                }
             } else if (isRootc && m.payload == "exists") {
                 response = "false";
             }
@@ -3061,8 +3085,8 @@ void CoreBroker::checkDependencies()
             }
         }
     } else {
-        // if there is more than 2 dependents(higher broker + 2 or more other objects then we
-        // need to be a timeCoordinator
+        // if there is more than 2 dependents(higher broker + 2 or more other objects
+        // then we need to be a timeCoordinator
         if (timeCoord->getDependents().size() > 2) {
             return;
         }

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -910,10 +910,16 @@ TEST_F(query, queries_disconnected)
     vFed2->finalize();
     vFed1->requestTime(3.0);
     res = vFed1->query(vFed2->getName(), "state");
+    int ii{0};
     while (res != "disconnected") {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         res = vFed1->query(vFed2->getName(), "state");
+        if (++ii > 10)
+        {
+            break;
+        }
     }
+    EXPECT_EQ(res, "disconnected");
     res = vFed1->query(vFed2->getName(), "dependency_graph");
     EXPECT_EQ(res, "#disconnected");
     vFed1->finalize();

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -845,6 +845,7 @@ TEST_F(query, queries_query)
     vFed2->finalize();
     helics::cleanupHelicsLibrary();
 }
+#endif
 
 TEST_F(query, queries_callback_test)
 {
@@ -894,4 +895,27 @@ TEST_F(query, concurrent_callback)
     vFed2->finalize();
     helics::cleanupHelicsLibrary();
 }
-#endif
+
+TEST_F(query, queries_disconnected)
+{
+    SetupTest<helics::ValueFederate>("test_4", 2);
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
+    vFed1->enterExecutingModeAsync();
+    vFed2->enterExecutingMode();
+    vFed1->enterExecutingModeComplete();
+
+    auto res = vFed1->query(vFed2->getName(), "dependency_graph");
+    EXPECT_NE(res[0], '#');
+    vFed2->finalize();
+    vFed1->requestTime(3.0);
+    res = vFed1->query(vFed2->getName(), "state");
+    while (res != "disconnected")
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        res = vFed1->query(vFed2->getName(), "state");
+    }
+    res = vFed1->query(vFed2->getName(), "dependency_graph");
+    EXPECT_EQ(res, "#disconnected");
+    vFed1->finalize();
+}

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -914,8 +914,7 @@ TEST_F(query, queries_disconnected)
     while (res != "disconnected") {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         res = vFed1->query(vFed2->getName(), "state");
-        if (++ii > 10)
-        {
+        if (++ii > 10) {
             break;
         }
     }

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -910,8 +910,7 @@ TEST_F(query, queries_disconnected)
     vFed2->finalize();
     vFed1->requestTime(3.0);
     res = vFed1->query(vFed2->getName(), "state");
-    while (res != "disconnected")
-    {
+    while (res != "disconnected") {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         res = vFed1->query(vFed2->getName(), "state");
     }


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will address Issue #1667.
It will add a test for queries on disconnected targets and respond appropriately.  
It will also fix a bug in the marking of disconnected federates in the case of a multilayer broker scheme.  

