### PR TITLE
Update macOS deployment target to 10.14

### DIFF
--- a/.github/actions/setup-macos-10.9-sdk.sh
+++ b/.github/actions/setup-macos-10.9-sdk.sh
@@ -3,7 +3,7 @@
 XCODE_MACOS_PLATFORM_PATH="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform"
 XCODE_MACOS_SDK_PATH="${XCODE_MACOS_PLATFORM_PATH}/Developer/SDKs"
 
-SDK_VER=10.9
+SDK_VER=10.14
 
 # Download macOS SDK
 wget "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX${SDK_VER}.sdk.tar.xz"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -136,7 +136,7 @@ jobs:
             os: macos-latest
             arch: x64
             cpack_gen: ZIP
-            macos_target_ver: '10.9'
+            macos_target_ver: '10.14'
           - id: linux-x64
             os: ubuntu-latest
             arch: x64
@@ -224,7 +224,7 @@ jobs:
           - id: macos-x64
             os: macos-latest
             arch: x64
-            macos_target_ver: '10.9'
+            macos_target_ver: '10.14'
           - id: ubuntu-x64
             os: ubuntu-latest
             arch: x64


### PR DESCRIPTION

### Summary

If merged this pull request will install the macOS 10.14 SDK and update the deployment target to 10.14 due to C++ features being used that Apple doesn't support in older versions.

### Proposed changes

- Install macOS 10.14 SDK
- Update macOS deployment target for release builds to 10.14
