### PR TITLE
Replace deprecated set-env in GitHub Actions

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
     - name: set PY
-      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
+      run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - name: install shfmt
       run: sudo snap install shfmt
     - uses: actions/cache@v1


### PR DESCRIPTION

### Summary

Due to a CVE, set-env has been deprecated in GitHub Actions and will be disabled Nov 16. Looks like we only use it in the formatting action. Blog post: https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/

If merged this pull request will replace the use of set-env with environment files. Docs on the new method: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

### Proposed changes

- Replace GitHub Actions set-env with environment files