### PR TITLE
Pin Linux release build Docker base image version to hbb 2.1.0

### DIFF
--- a/.github/actions/linux-release-builder/Dockerfile
+++ b/.github/actions/linux-release-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/holy-build-box-64:2.2.0
+FROM phusion/holy-build-box-64:2.1.0
 
 # Install a copy of git and the Boost headers
 # curl -L follows redirects and -k ignores SSL certificate warnings

--- a/.github/actions/linux-release-builder/Dockerfile
+++ b/.github/actions/linux-release-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/holy-build-box-64:latest
+FROM phusion/holy-build-box-64:2.2.0
 
 # Install a copy of git and the Boost headers
 # curl -L follows redirects and -k ignores SSL certificate warnings

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -147,7 +147,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -234,7 +234,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build'
+      if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2


### PR DESCRIPTION
### Summary

If merged this pull request will pin the base docker image builds to hbb 2.1.0, one of the last ones using CentOS 6, and ensures a checkout step runs regardless of what triggered the workflow run. Workflow file change needs to get made to the master branch, pinning the docker image will need to make its way to the develop/helics3 branches. This PR will fix the nightly builds once merged into master+develop.

Latest test run: https://github.com/GMLC-TDC/HELICS/actions/runs/516313478

### Proposed changes

* Pin base docker image to HBB 2.1.0
* Run event ref checkout step for anything that isn't a scheduled build. If the ref (from client_payload) is set to nothing, then it defaults to checking out the current branch for the event.