### PR TITLE
Fix pre-commit shellcheck workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
         args: [-s, ./config/.markdownlintrc]
         exclude: "mac.md"
       - id: shellcheck
+        additional_dependencies: []
       - id: shfmt
         args: [-w]
       - id: script-must-have-extension


### PR DESCRIPTION
### Summary

If merged this pull request will add a (temporary?) fix to the shellcheck pre-commit-hooks config. A [change to pre-commit](https://github.com/pre-commit/pre-commit/pull/1771/files) broke pre-commit-hooks. I sent an email to the maintainer mentioning the issue, and asked about future plans for updating pre-commit-hooks.

The related pre-commit-hooks issue is: https://github.com/jumanjihouse/pre-commit-hooks/issues/82

### Proposed changes

- override `additional_dependencies` key for shellcheck in pre-commit config file
