### PR TITLE
Pin jumanjihouse/pre-commit hooks to tag rev 2.1.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: prettier
         exclude: ^(examples/user_guide_examples/)
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 7cc5848088fd8412905ab79feea6c8edc3ac76c6
+    rev: 2.1.5
     hooks:
       - id: markdownlint
         args: [-s, ./config/.markdownlintrc]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: prettier
         exclude: ^(examples/user_guide_examples/)
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.0.2
+    rev: 7cc5848088fd8412905ab79feea6c8edc3ac76c6
     hooks:
       - id: markdownlint
         args: [-s, ./config/.markdownlintrc]


### PR DESCRIPTION
### Summary

If merged this pull request will pin the jumanjihouse pre-commit-hooks to the tagged 2.1.5 version, the latest release that fixes the shellcheck error.

### Proposed changes

- pin jumanjihouse/pre-commit-hooks rev to 2.1.5 tag