### PR TITLE
Pin Drone Cloud ARM32 build to alpine:3.12

### DIFF
--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -18,7 +18,7 @@ steps:
       - git submodule update --init --recursive
 
   - name: build
-    image: alpine
+    image: alpine:3.12
     commands:
       - apk update
       - apk add --no-cache build-base git bash cmake ninja boost-dev zeromq-dev

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
   - name: uname
-    image: alpine
+    image: alpine:3.12
     commands:
       - uname -a
 


### PR DESCRIPTION
### Summary

If merged this pull request will pin the Docker image used for ARM32 builds on Drone Cloud to `alpine:3.12`. If docker manages to fix their arm32 issues, newer versions of the alpine image should work again. 

### Proposed changes

* Pin the Docker image used for ARM32 builds on Drone Cloud to `alpine:3.12`
