### PR TITLE
Fix offset timing bug

### DIFF
--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2004,7 +2004,6 @@ void CommonCore::initializeMapBuilder(const std::string& request,
     base["name"] = getIdentifier();
     base["id"] = global_broker_id_local.baseValue();
     base["parent"] = higher_broker_id.baseValue();
-    base["brokers"] = Json::arrayValue;
     ActionMessage queryReq(CMD_QUERY);
     queryReq.payload = request;
     queryReq.source_id = global_broker_id_local;

--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -350,11 +350,20 @@ Time TimeCoordinator::generateAllowedTime(Time testTime) const
         if (testTime == Time::maxVal()) {
             return testTime;
         }
-        if (testTime - time_grantBase > info.period) {
-            auto blk = std::ceil((testTime - time_grantBase) / info.period);
-            testTime = time_grantBase + blk * info.period;
+        auto timeBase = time_grantBase;
+        if (time_grantBase<info.offset)
+        {
+            timeBase = info.offset;
+            if (testTime <= info.offset)
+            {
+                return info.offset;
+            }
+        }
+        if (testTime - timeBase > info.period) {
+            auto blk = std::ceil((testTime - timeBase) / info.period);
+            testTime = timeBase + blk * info.period;
         } else {
-            testTime = time_grantBase + info.period;
+            testTime = timeBase + info.period;
         }
     }
     return testTime;

--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -351,11 +351,9 @@ Time TimeCoordinator::generateAllowedTime(Time testTime) const
             return testTime;
         }
         auto timeBase = time_grantBase;
-        if (time_grantBase<info.offset)
-        {
+        if (time_grantBase < info.offset) {
             timeBase = info.offset;
-            if (testTime <= info.offset)
-            {
+            if (testTime <= info.offset) {
                 return info.offset;
             }
         }

--- a/tests/helics/system_tests/TimingTests2.cpp
+++ b/tests/helics/system_tests/TimingTests2.cpp
@@ -321,7 +321,45 @@ TEST_F(timing_tests2, wait_for_current_time_flag)
     vFed3->finalize();
 }
 
-// Tests out the restrictive time policy
+TEST_F(timing_tests2, offset_timing)
+{
+    SetupTest<helics::ValueFederate>("test_2", 2);
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
+    vFed1->setFlagOption(helics::defs::ignore_time_mismatch_warnings);
+    vFed2->setFlagOption(helics::defs::ignore_time_mismatch_warnings);
+    vFed1->setProperty(helics::defs::period, 60.0);
+    vFed2->setProperty(helics::defs::period, 60.0);
+    vFed1->setProperty(helics::defs::offset, 10.0);
+
+    auto pub1 = helics::make_publication<double>(helics::GLOBAL, vFed1, "pub1");
+
+    auto& sub2 = vFed2->registerSubscription("pub1");
+    sub2.setDefault(2.6);
+
+    vFed1->enterExecutingModeAsync();
+    vFed2->enterExecutingMode();
+    vFed1->enterExecutingModeComplete();
+
+    // this works since there are no reverse dependencies
+    auto tm1=vFed1->requestTime(70.0);
+    EXPECT_EQ(tm1, 70.0);
+    pub1->publish(3.5);
+    tm1 = vFed1->requestTime(120.0);
+    EXPECT_EQ(tm1, 130.0);
+
+    auto tm2 = vFed2->requestTime(60.0);
+    EXPECT_EQ(tm2, 60.0);
+    tm2 = vFed2->requestTime(70.0);
+    EXPECT_EQ(tm2, 120.0);
+    double val2 = sub2.getValue<double>();
+    EXPECT_DOUBLE_EQ(val2, 3.5);  // shouldn't have gotten the update
+
+    vFed1->finalize();
+    vFed2->finalize();
+}
+
+// Tests out the time barrier
 TEST_F(timing_tests2, time_barrier1)
 {
     SetupTest<helics::ValueFederate>("test_2", 2);

--- a/tests/helics/system_tests/TimingTests2.cpp
+++ b/tests/helics/system_tests/TimingTests2.cpp
@@ -342,7 +342,7 @@ TEST_F(timing_tests2, offset_timing)
     vFed1->enterExecutingModeComplete();
 
     // this works since there are no reverse dependencies
-    auto tm1=vFed1->requestTime(70.0);
+    auto tm1 = vFed1->requestTime(70.0);
     EXPECT_EQ(tm1, 70.0);
     pub1->publish(3.5);
     tm1 = vFed1->requestTime(120.0);


### PR DESCRIPTION
FIx issue using 'offset' property if the first interval is not used.  
brought up in [Gitter](https://gitter.im/GMLC-TDC/HELICS?at=6050e015d74bbe49e0fb1ac0)

fix a few warnings as well 