### PR TITLE
Skip CI builds for automated formatting PRs/commits

### DIFF
--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -38,8 +38,8 @@ trigger:
       - refs/heads/master
       - refs/heads/develop
       - refs/heads/helics3
-      - "refs/pull/**"
-      - "refs/tags/**"
+      - 'refs/pull/**'
+      - 'refs/tags/**'
 
 ---
 kind: pipeline
@@ -82,5 +82,5 @@ trigger:
       - refs/heads/master
       - refs/heads/develop
       - refs/heads/helics3
-      - "refs/pull/**"
-      - "refs/tags/**"
+      - 'refs/pull/**'
+      - 'refs/tags/**'

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -33,14 +33,10 @@ steps:
 
 trigger:
   branch:
-    include:
-    - main
-    - master
-    - develop
-    - helics3
-    - refs/heads/**
-    exclude:
-    - pre-commit/**
+  - main
+  - master
+  - develop
+  - helics3
 
 ---
 kind: pipeline
@@ -78,11 +74,7 @@ steps:
 
 trigger:
   branch:
-    include:
-    - main
-    - master
-    - develop
-    - helics3
-    - refs/heads/**
-    exclude:
-    - pre-commit/**
+  - main
+  - master
+  - develop
+  - helics3

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -33,15 +33,8 @@ steps:
 
 trigger:
   branch:
-    include:
-      - main
-      - master
-      - develop
-      - helics3
-  event:
-    include:
-      - push
-      - pull_request
+    exclude:
+      - pre-commit/**
 
 ---
 kind: pipeline
@@ -79,12 +72,5 @@ steps:
 
 trigger:
   branch:
-    include:
-      - main
-      - master
-      - develop
-      - helics3
-  event:
-    include:
-      - push
-      - pull_request
+    exclude:
+      - pre-commit/**

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -31,6 +31,17 @@ steps:
       - cmake --build .
       - ctest -L Continuous --output-on-failure
 
+trigger:
+  branch:
+    include:
+    - main
+    - master
+    - develop
+    - helics3
+    - refs/heads/**
+    exclude:
+    - pre-commit/**
+
 ---
 kind: pipeline
 name: arm64
@@ -64,3 +75,14 @@ steps:
       - cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
       - cmake --build .
       - ctest -L Continuous --output-on-failure
+
+trigger:
+  branch:
+    include:
+    - main
+    - master
+    - develop
+    - helics3
+    - refs/heads/**
+    exclude:
+    - pre-commit/**

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -33,10 +33,11 @@ steps:
 
 trigger:
   branch:
-  - main
-  - master
-  - develop
-  - helics3
+    include:
+      - main
+      - master
+      - develop
+      - helics3
 
 ---
 kind: pipeline
@@ -74,7 +75,8 @@ steps:
 
 trigger:
   branch:
-  - main
-  - master
-  - develop
-  - helics3
+    include:
+      - main
+      - master
+      - develop
+      - helics3

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -32,9 +32,13 @@ steps:
       - ctest -L Continuous --output-on-failure
 
 trigger:
-  branch:
-    exclude:
-      - pre-commit/**
+  ref:
+    include:
+    - refs/heads/main
+    - refs/heads/master
+    - refs/heads/develop
+    - refs/heads/helics3
+    - refs/pull/**
 
 ---
 kind: pipeline
@@ -71,6 +75,10 @@ steps:
       - ctest -L Continuous --output-on-failure
 
 trigger:
-  branch:
-    exclude:
-      - pre-commit/**
+  ref:
+    include:
+    - refs/heads/main
+    - refs/heads/master
+    - refs/heads/develop
+    - refs/heads/helics3
+    - refs/pull/**

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -38,6 +38,10 @@ trigger:
       - master
       - develop
       - helics3
+  event:
+    include:
+      - push
+      - pull_request
 
 ---
 kind: pipeline
@@ -80,3 +84,7 @@ trigger:
       - master
       - develop
       - helics3
+  event:
+    include:
+      - push
+      - pull_request

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -34,11 +34,11 @@ steps:
 trigger:
   ref:
     include:
-    - refs/heads/main
-    - refs/heads/master
-    - refs/heads/develop
-    - refs/heads/helics3
-    - refs/pull/**
+      - refs/heads/main
+      - refs/heads/master
+      - refs/heads/develop
+      - refs/heads/helics3
+      - refs/pull/**
 
 ---
 kind: pipeline
@@ -77,8 +77,8 @@ steps:
 trigger:
   ref:
     include:
-    - refs/heads/main
-    - refs/heads/master
-    - refs/heads/develop
-    - refs/heads/helics3
-    - refs/pull/**
+      - refs/heads/main
+      - refs/heads/master
+      - refs/heads/develop
+      - refs/heads/helics3
+      - refs/pull/**

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -38,7 +38,8 @@ trigger:
       - refs/heads/master
       - refs/heads/develop
       - refs/heads/helics3
-      - refs/pull/**
+      - "refs/pull/**"
+      - "refs/tags/**"
 
 ---
 kind: pipeline
@@ -81,4 +82,5 @@ trigger:
       - refs/heads/master
       - refs/heads/develop
       - refs/heads/helics3
-      - refs/pull/**
+      - "refs/pull/**"
+      - "refs/tags/**"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -2,11 +2,11 @@ trigger:
   branches:
     exclude:
     - pre-commit/*
-  pr:
-    - main
-    - master
-    - develop
-    - helics3
+pr:
+  - main
+  - master
+  - develop
+  - helics3
     
 jobs:
   - job: Windows

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,13 +1,13 @@
 trigger:
   branches:
     exclude:
-    - pre-commit/*
+      - pre-commit/*
 pr:
   - main
   - master
   - develop
   - helics3
-    
+
 jobs:
   - job: Windows
     strategy:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,3 +1,13 @@
+trigger:
+  branches:
+    exclude:
+    - pre-commit/*
+  pr:
+    - main
+    - master
+    - develop
+    - helics3
+    
 jobs:
   - job: Windows
     strategy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,11 @@ jobs:
 workflows:
   version: 2
   helics_test:
+    filters:
+      branches:
+        ignore: /pre-commit\/.*/
     jobs:
-      - helicsMSan
+    - helicsMSan
       - helicsASan
       - helicsInstall1
       - helicsInstall2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,15 +155,27 @@ jobs:
 workflows:
   version: 2
   helics_test:
-    filters:
-      branches:
-        ignore: /pre-commit\/.*/
     jobs:
-    - helicsMSan
-      - helicsASan
-      - helicsInstall1
-      - helicsInstall2
-      - helicsgccTSan
+      - helicsMSan:
+        filters:
+          branches:
+            ignore: /pre-commit\/.*/
+      - helicsASan:
+        filters:
+          branches:
+            ignore: /pre-commit\/.*/
+      - helicsInstall1:
+        filters:
+          branches:
+            ignore: /pre-commit\/.*/
+      - helicsInstall2:
+        filters:
+          branches:
+            ignore: /pre-commit\/.*/
+      - helicsgccTSan:
+        filters:
+          branches:
+            ignore: /pre-commit\/.*/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,25 +157,25 @@ workflows:
   helics_test:
     jobs:
       - helicsMSan:
-        filters:
-          branches:
-            ignore: /pre-commit\/.*/
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
       - helicsASan:
-        filters:
-          branches:
-            ignore: /pre-commit\/.*/
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
       - helicsInstall1:
-        filters:
-          branches:
-            ignore: /pre-commit\/.*/
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
       - helicsInstall2:
-        filters:
-          branches:
-            ignore: /pre-commit\/.*/
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
       - helicsgccTSan:
-        filters:
-          branches:
-            ignore: /pre-commit\/.*/
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
 
   nightly:
     triggers:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_instance:
   image_family: freebsd-12-1
 
 task:
-  only_if: $CIRRUS_BRANCH == 'pull/.*' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'develop' || $CIRRUS_BRANCH == 'helics3'
+  skip: $CIRRUS_BRANCH == 'pre-commit/.*'
   install_script: |
     pkg install -y cmake libzmq4 ninja git
   build_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,7 @@ freebsd_instance:
   image_family: freebsd-12-1
 
 task:
+  only_if: $CIRRUS_BRANCH == 'pull/.*' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'develop' || $CIRRUS_BRANCH == 'helics3'
   install_script: |
     pkg install -y cmake libzmq4 ninja git
   build_script: |

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -38,8 +38,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         COMMIT_MSG: "Automated formatting of repo files"
-        PR_TITLE: "Automated formatting of repo files"
-        PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}. [skip ci]"
+        PR_TITLE: "Automated formatting of repo files [skip ci]"
+        PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_NAME: "github-actions[bot]"
         GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         BRANCH_PREFIX: "pre-commit/"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -36,7 +36,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         COMMIT_MSG: "Automated formatting of repo files [skip ci]"
-        PR_TITLE: "Automated formatting of repo files [skip ci]"
+        PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -37,9 +37,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting of repo files [skip ci]"
-        PR_TITLE: "Automated formatting of repo files [skip ci]"
-        PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
+        COMMIT_MSG: "Automated formatting of repo files"
+        PR_TITLE: "Automated formatting of repo files"
+        PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}. [skip ci]"
         GIT_NAME: "github-actions[bot]"
         GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         BRANCH_PREFIX: "pre-commit/"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,11 +3,13 @@ on:
   push:
     branches:
       - develop
+      - main
       - master
       - helics3
   pull_request:
     branches:
       - develop
+      - main
       - master
       - helics3
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -37,9 +37,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting of repo files [skip ci]"
-        PR_TITLE: "Automated formatting of repo files"
+        COMMIT_MSG: "Automated formatting of repo files"
+        PR_TITLE: "Automated formatting of repo files [skip ci]"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
+        GIT_NAME: "github-actions[bot]"
+        GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -33,18 +33,13 @@ jobs:
     - uses: pre-commit/action@v1.1.0
     - name: Create/update a file update PR with changed files
       if: failure() && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository
-      uses: gmlc-tdc/create-pr-action@v0.1
+      uses: gmlc-tdc/create-pr-action@v0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: |
-          Automated formatting of repo files
-          
-          [skip ci]
+        COMMIT_MSG: "Automated formatting of repo files [skip ci]"
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
-        GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
-        GIT_NAME: "github-actions[bot]"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -35,7 +35,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting of repo files"
+        COMMIT_MSG: "Automated formatting of repo files [skip azurepipelines]"
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -40,6 +40,8 @@ jobs:
         COMMIT_MSG: "Automated formatting of repo files [skip ci]"
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
+        GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+        GIT_NAME: "github-actions[bot]"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -38,8 +38,6 @@ jobs:
         COMMIT_MSG: "Automated formatting of repo files [skip ci]"
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
-        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
-        GIT_NAME: "HELICS-bot"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting of repo files"
+        COMMIT_MSG: "Automated formatting of repo files [skip ci]"
         PR_TITLE: "Automated formatting of repo files [skip ci]"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_NAME: "github-actions[bot]"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -40,8 +40,9 @@ jobs:
         COMMIT_MSG: "Automated formatting of repo files [skip ci]"
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
-        GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
-        GIT_NAME: "github-actions[bot]"
+        # Git Email/Name for commits should be HELICS-bot (not GitHub Actions); this way, when the PR is merged the default new commit name uses the PR title (avoiding [skip ci] in the new commit message)
+        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
+        GIT_NAME: "HELICS-bot"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -37,12 +37,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting of repo files [skip ci]"
+        COMMIT_MSG: |
+          Automated formatting of repo files
+          
+          [skip ci]
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         # Git Email/Name for commits should be HELICS-bot (not GitHub Actions); this way, when the PR is merged the default new commit name uses the PR title (avoiding [skip ci] in the new commit message)
-        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
-        GIT_NAME: "HELICS-bot"
+        GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+        GIT_NAME: "github-actions[bot]"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -35,8 +35,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        COMMIT_MSG: "Automated formatting of repo files [skip azurepipelines]"
-        PR_TITLE: "Automated formatting of repo files [skip azurepipelines]"
+        COMMIT_MSG: "Automated formatting of repo files [skip ci]"
+        PR_TITLE: "Automated formatting of repo files [skip ci]"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -43,7 +43,6 @@ jobs:
           [skip ci]
         PR_TITLE: "Automated formatting of repo files"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
-        # Git Email/Name for commits should be HELICS-bot (not GitHub Actions); this way, when the PR is merged the default new commit name uses the PR title (avoiding [skip ci] in the new commit message)
         GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         GIT_NAME: "github-actions[bot]"
         BRANCH_PREFIX: "pre-commit/"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -36,7 +36,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         COMMIT_MSG: "Automated formatting of repo files [skip azurepipelines]"
-        PR_TITLE: "Automated formatting of repo files"
+        PR_TITLE: "Automated formatting of repo files [skip azurepipelines]"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
         GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
         GIT_NAME: "HELICS-bot"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@ clone_depth: 1
 
 branches:
   only:
-  - main
-  - master
-  - develop
-  - helics3
+    - main
+    - master
+    - develop
+    - helics3
 
 version: 2.6.1.{build}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@ clone_depth: 1
 
 branches:
   only:
-    - main
-    - master
-    - develop
-    - helics3
+  - main
+  - master
+  - develop
+  - helics3
 
 version: 2.6.1.{build}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,12 @@
 clone_depth: 1
 
+branches:
+  only:
+    - main
+    - master
+    - develop
+    - helics3
+
 version: 2.6.1.{build}
 
 image: Visual Studio 2015


### PR DESCRIPTION
### Summary

If merged this pull request will add a keyword for skipping ci builds to the PR title and modify the config files for the various CI services to run less frequently (never on the pre-commit formatting branch).

The ci skipping keyword shouldn't propagate into the squashed commit messages with this setup.

### Proposed changes

* Include ci skipping keyword in PR title to skip running on Drone on formatting PRs
* Run Drone for all non-formatting PRs and commits to `master`, `main`, `develop`, and `helics3`
* Run CircleCI and Cirrus for pushes and PRs except those in or from a `pre-commit/` branch
* Run Appveyor only for PRs/pushes to `master`, `main`, `develop`, and `helics3`
* Exclude Azure Pipelines from running on `pre-commit` branches
* Run Azure Pipelines for PRs targeting `master`, `main`, `develop`, and `helics3`
