### PR TITLE
Install Boost for Windows GitHub Actions Workflows

### DIFF
--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -12,13 +12,14 @@ cpack_dir="${cpack_dir%/cmake}"
 # Install Boost
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-cd $(mktemp -d)
-curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfj "download.tar.bz2"
-mkdir -p "$BOOST_ROOT"
-cp -r boost_*/* "$BOOST_ROOT"
+(
+    cd $(mktemp -d) || exit
+    curl --location --output "download.tar.bz2" "$BOOST_URL"
+    tar xfj "download.tar.bz2"
+    mkdir -p "$BOOST_ROOT"
+    cp -r boost_*/* "$BOOST_ROOT"
+) || exit
 export BOOST_ROOT
-cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -13,7 +13,7 @@ cpack_dir="${cpack_dir%/cmake}"
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 (
-    cd $(mktemp -d) || exit
+    cd "$(mktemp -d)" || exit
     curl --location --output "download.tar.bz2" "$BOOST_URL"
     tar xfj "download.tar.bz2"
     mkdir -p "$BOOST_ROOT"

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -14,7 +14,7 @@ BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 cd $(mktemp -d)
 curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfvj "download.tar.bz2"
+tar xfj "download.tar.bz2"
 mkdir -p "$BOOST_ROOT"
 cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -4,8 +4,22 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
+
+# Fix cpack command (interferes with chocolatey)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+
+# Install Boost
+BOOST_ROOT="/c/boost"
+BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
+cd $(mktemp -d)
+curl --location --output "download.tar.bz2" "$BOOST_URL"
+tar xfvj "download.tar.bz2"
+mkdir -p "$BOOST_ROOT"
+cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -5,7 +5,7 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 
-# Fix cpack command (interferes with chocolatey)
+# Find cpack command (interferes with chocolatey)
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 
@@ -24,8 +24,6 @@ cd -
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -18,6 +18,7 @@ tar xfvj "download.tar.bz2"
 mkdir -p "$BOOST_ROOT"
 cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -5,21 +5,9 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 
-# Find cpack command (interferes with chocolatey)
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
-
-# Install Boost
-BOOST_ROOT="/c/boost"
-BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-(
-    cd "$(mktemp -d)" || exit
-    curl --location --output "download.tar.bz2" "$BOOST_URL"
-    tar xfj "download.tar.bz2"
-    mkdir -p "$BOOST_ROOT"
-    cp -r boost_*/* "$BOOST_ROOT"
-) || exit
-export BOOST_ROOT
+COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+source ${COMMON_SCRIPTS/find-cpack.sh
+source ${COMMON_SCRIPTS}/install-boost.sh
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -6,7 +6,9 @@
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+# shellcheck source=../common/Windows/find-cpack.sh
 source "${COMMON_SCRIPTS}/find-cpack.sh"
+# shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
 
 # Build

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -6,8 +6,8 @@
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
-source ${COMMON_SCRIPTS/find-cpack.sh
-source ${COMMON_SCRIPTS}/install-boost.sh
+source "${COMMON_SCRIPTS}/find-cpack.sh"
+source "${COMMON_SCRIPTS}/install-boost.sh"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -4,11 +4,15 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install Boost
 COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
-# shellcheck source=../common/Windows/find-cpack.sh
-source "${COMMON_SCRIPTS}/find-cpack.sh"
 # shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/common/Windows/find-cpack.sh
+++ b/.github/actions/common/Windows/find-cpack.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Find cpack command (chocolatey has a command with the same name)
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
-export cpack_dir

--- a/.github/actions/common/Windows/find-cpack.sh
+++ b/.github/actions/common/Windows/find-cpack.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Find cpack command (chocolatey has a command with the same name)
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"

--- a/.github/actions/common/Windows/find-cpack.sh
+++ b/.github/actions/common/Windows/find-cpack.sh
@@ -1,0 +1,4 @@
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+export cpack_dir

--- a/.github/actions/common/Windows/install-boost.sh
+++ b/.github/actions/common/Windows/install-boost.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Install Boost
+BOOST_VERSION="1.74.0"
+BOOST_ROOT="/c/boost"
+BOOST_URL="https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download"
+(
+    cd "$(mktemp -d)" || exit
+    curl --location --output "download.tar.bz2" "$BOOST_URL"
+    tar xfj "download.tar.bz2"
+    mkdir -p "$BOOST_ROOT"
+    cp -r boost_*/* "$BOOST_ROOT"
+) || exit
+export BOOST_ROOT
+
+

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -5,13 +5,26 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
+
+# Find cpack command (interferes with chocolatey)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+
+# Install Boost
+BOOST_ROOT="/c/boost"
+BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
+cd $(mktemp -d)
+curl --location --output "download.tar.bz2" "$BOOST_URL"
+tar xfj "download.tar.bz2"
+mkdir -p "$BOOST_ROOT"
+cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+cd -
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_JAVA_INTERFACE=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -4,12 +4,18 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install SWIG
 choco install -y swig
+
+# Install Boost
 COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
-# shellcheck source=../common/Windows/find-cpack.sh
-source "${COMMON_SCRIPTS}/find-cpack.sh"
 # shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -5,22 +5,9 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-
-# Find cpack command (interferes with chocolatey)
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
-
-# Install Boost
-BOOST_ROOT="/c/boost"
-BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-(
-    cd "$(mktemp -d)" || exit
-    curl --location --output "download.tar.bz2" "$BOOST_URL"
-    tar xfj "download.tar.bz2"
-    mkdir -p "$BOOST_ROOT"
-    cp -r boost_*/* "$BOOST_ROOT"
-) || exit
-export BOOST_ROOT
+COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+source ${COMMON_SCRIPTS/find-cpack.sh
+source ${COMMON_SCRIPTS}/install-boost.sh
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -14,7 +14,7 @@ cpack_dir="${cpack_dir%/cmake}"
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 (
-    cd $(mktemp -d) || exit
+    cd "$(mktemp -d)" || exit
     curl --location --output "download.tar.bz2" "$BOOST_URL"
     tar xfj "download.tar.bz2"
     mkdir -p "$BOOST_ROOT"

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -6,8 +6,11 @@
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+# shellcheck source=../common/Windows/find-cpack.sh
 source "${COMMON_SCRIPTS}/find-cpack.sh"
+# shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -6,8 +6,8 @@
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
-source ${COMMON_SCRIPTS/find-cpack.sh
-source ${COMMON_SCRIPTS}/install-boost.sh
+source "${COMMON_SCRIPTS}/find-cpack.sh"
+source "${COMMON_SCRIPTS}/install-boost.sh"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -13,13 +13,14 @@ cpack_dir="${cpack_dir%/cmake}"
 # Install Boost
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-cd $(mktemp -d)
-curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfj "download.tar.bz2"
-mkdir -p "$BOOST_ROOT"
-cp -r boost_*/* "$BOOST_ROOT"
+(
+    cd $(mktemp -d) || exit
+    curl --location --output "download.tar.bz2" "$BOOST_URL"
+    tar xfj "download.tar.bz2"
+    mkdir -p "$BOOST_ROOT"
+    cp -r boost_*/* "$BOOST_ROOT"
+) || exit
 export BOOST_ROOT
-cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -7,7 +7,7 @@
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 
-# Fix cpack command (interferes with chocolatey)
+# Find cpack command (interferes with chocolatey)
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -6,22 +6,9 @@
 
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-
-# Find cpack command (interferes with chocolatey)
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
-
-# Install Boost
-BOOST_ROOT="/c/boost"
-BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-(
-    cd "$(mktemp -d)" || exit
-    curl --location --output "download.tar.bz2" "$BOOST_URL"
-    tar xfj "download.tar.bz2"
-    mkdir -p "$BOOST_ROOT"
-    cp -r boost_*/* "$BOOST_ROOT"
-) || exit
-export BOOST_ROOT
+COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+source ${COMMON_SCRIPTS/find-cpack.sh
+source ${COMMON_SCRIPTS}/install-boost.sh
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -6,10 +6,22 @@
 
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
+
+# Fix cpack command (interferes with chocolatey)
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
+
+# Install Boost
+BOOST_ROOT="/c/boost"
+BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
+cd $(mktemp -d)
+curl --location --output "download.tar.bz2" "$BOOST_URL"
+tar xfvj "download.tar.bz2"
+mkdir -p "$BOOST_ROOT"
+cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Debug -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=ON -DHELICS_DISABLE_C_SHARED_LIB=ON ..
 cmake --build . --config Debug

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -7,8 +7,8 @@
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
-source ${COMMON_SCRIPTS/find-cpack.sh
-source ${COMMON_SCRIPTS}/install-boost.sh
+source "${COMMON_SCRIPTS}/find-cpack.sh"
+source "${COMMON_SCRIPTS}/install-boost.sh"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -5,12 +5,18 @@
 # 3. moving the generated installer with a rename to add msvcYYYY to the file name
 
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install SWIG
 choco install -y swig
+
+# Install Boost
 COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
-# shellcheck source=../common/Windows/find-cpack.sh
-source "${COMMON_SCRIPTS}/find-cpack.sh"
 # shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -20,6 +20,7 @@ tar xfvj "download.tar.bz2"
 mkdir -p "$BOOST_ROOT"
 cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -14,13 +14,14 @@ cpack_dir="${cpack_dir%/cmake}"
 # Install Boost
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-cd $(mktemp -d)
-curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfj "download.tar.bz2"
-mkdir -p "$BOOST_ROOT"
-cp -r boost_*/* "$BOOST_ROOT"
+(
+    cd $(mktemp -d) || exit
+    curl --location --output "download.tar.bz2" "$BOOST_URL"
+    tar xfj "download.tar.bz2"
+    mkdir -p "$BOOST_ROOT"
+    cp -r boost_*/* "$BOOST_ROOT"
+) || exit
 export BOOST_ROOT
-cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -15,7 +15,7 @@ cpack_dir="${cpack_dir%/cmake}"
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 (
-    cd $(mktemp -d) || exit
+    cd "$(mktemp -d)" || exit
     curl --location --output "download.tar.bz2" "$BOOST_URL"
     tar xfj "download.tar.bz2"
     mkdir -p "$BOOST_ROOT"

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -7,8 +7,11 @@
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+# shellcheck source=../common/Windows/find-cpack.sh
 source "${COMMON_SCRIPTS}/find-cpack.sh"
+# shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -16,7 +16,7 @@ BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 cd $(mktemp -d)
 curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfvj "download.tar.bz2"
+tar xfj "download.tar.bz2"
 mkdir -p "$BOOST_ROOT"
 cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -4,12 +4,18 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install SWIG
 choco install -y swig
+
+# Install Boost
 COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
-# shellcheck source=../common/Windows/find-cpack.sh
-source "${COMMON_SCRIPTS}/find-cpack.sh"
 # shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -5,22 +5,9 @@
 
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-
-# Find cpack command (interferes with chocolatey)
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
-
-# Install Boost
-BOOST_ROOT="/c/boost"
-BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-(
-    cd "$(mktemp -d)" || exit
-    curl --location --output "download.tar.bz2" "$BOOST_URL"
-    tar xfj "download.tar.bz2"
-    mkdir -p "$BOOST_ROOT"
-    cp -r boost_*/* "$BOOST_ROOT"
-) || exit
-export BOOST_ROOT
+COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+source ${COMMON_SCRIPTS/find-cpack.sh
+source ${COMMON_SCRIPTS}/install-boost.sh
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -6,8 +6,11 @@
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
+# shellcheck source=../common/Windows/find-cpack.sh
 source "${COMMON_SCRIPTS}/find-cpack.sh"
+# shellcheck source=../common/Windows/install-boost.sh
 source "${COMMON_SCRIPTS}/install-boost.sh"
+
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -15,7 +15,7 @@ BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 cd $(mktemp -d)
 curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfvj "download.tar.bz2"
+tar xfj "download.tar.bz2"
 mkdir -p "$BOOST_ROOT"
 cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -5,8 +5,22 @@
 
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
+
+# Fix cpack command (interferes with chocolatey)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+
+# Install Boost
+BOOST_ROOT="/c/boost"
+BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
+cd $(mktemp -d)
+curl --location --output "download.tar.bz2" "$BOOST_URL"
+tar xfvj "download.tar.bz2"
+mkdir -p "$BOOST_ROOT"
+cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -19,6 +19,7 @@ tar xfvj "download.tar.bz2"
 mkdir -p "$BOOST_ROOT"
 cp -r boost_*/* "$BOOST_ROOT"
 export BOOST_ROOT
+cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -6,8 +6,8 @@
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 COMMON_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../common/Windows" && pwd )"
-source ${COMMON_SCRIPTS/find-cpack.sh
-source ${COMMON_SCRIPTS}/install-boost.sh
+source "${COMMON_SCRIPTS}/find-cpack.sh"
+source "${COMMON_SCRIPTS}/install-boost.sh"
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -14,7 +14,7 @@ cpack_dir="${cpack_dir%/cmake}"
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
 (
-    cd $(mktemp -d) || exit
+    cd "$(mktemp -d)" || exit
     curl --location --output "download.tar.bz2" "$BOOST_URL"
     tar xfj "download.tar.bz2"
     mkdir -p "$BOOST_ROOT"

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -13,13 +13,14 @@ cpack_dir="${cpack_dir%/cmake}"
 # Install Boost
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download"
-cd $(mktemp -d)
-curl --location --output "download.tar.bz2" "$BOOST_URL"
-tar xfj "download.tar.bz2"
-mkdir -p "$BOOST_ROOT"
-cp -r boost_*/* "$BOOST_ROOT"
+(
+    cd $(mktemp -d) || exit
+    curl --location --output "download.tar.bz2" "$BOOST_URL"
+    tar xfj "download.tar.bz2"
+    mkdir -p "$BOOST_ROOT"
+    cp -r boost_*/* "$BOOST_ROOT"
+) || exit
 export BOOST_ROOT
-cd -
 
 # Build
 mkdir build && cd build || exit

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -6,7 +6,7 @@
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 choco install -y swig
 
-# Fix cpack command (interferes with chocolatey)
+# Find cpack command (interferes with chocolatey)
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
 
@@ -25,8 +25,6 @@ cd -
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages


### PR DESCRIPTION
### Summary

If merged this pull request will install the Boost 1.74 headers needed to build HELICS for the GitHub Actions workflows running on Windows -- release builds and benchmark installers.

This addresses the same issue of Boost getting removed from the virtual environments as Azure Pipelines had.

Benchmarks run: https://github.com/GMLC-TDC/HELICS/actions/runs/680686297
Releases run: https://github.com/GMLC-TDC/HELICS/actions/runs/680686725

### Proposed changes

- Install Boost 1.74 for Windows release build packaging and benchmark installer GitHub Actions workflows
- Comment and minor clean-up of the scripts used for the Windows GHA workflows
