### PR TITLE
add the option of ordered queries

### DIFF
--- a/src/helics/application_api/BrokerApp.cpp
+++ b/src/helics/application_api/BrokerApp.cpp
@@ -214,9 +214,10 @@ const std::string& BrokerApp::getAddress() const
     return (broker) ? broker->getAddress() : estring;
 }
 /** make a query at the broker*/
-std::string BrokerApp::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
+std::string
+    BrokerApp::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
 {
-    return (broker) ? broker->query(target, queryStr,mode) : std::string("#error");
+    return (broker) ? broker->query(target, queryStr, mode) : std::string("#error");
 }
 
 void BrokerApp::setGlobal(const std::string& valueName, const std::string& value)

--- a/src/helics/application_api/BrokerApp.cpp
+++ b/src/helics/application_api/BrokerApp.cpp
@@ -214,9 +214,9 @@ const std::string& BrokerApp::getAddress() const
     return (broker) ? broker->getAddress() : estring;
 }
 /** make a query at the broker*/
-std::string BrokerApp::query(const std::string& target, const std::string& queryStr)
+std::string BrokerApp::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
 {
-    return (broker) ? broker->query(target, queryStr) : std::string("#error");
+    return (broker) ? broker->query(target, queryStr,mode) : std::string("#error");
 }
 
 void BrokerApp::setGlobal(const std::string& valueName, const std::string& value)

--- a/src/helics/application_api/BrokerApp.hpp
+++ b/src/helics/application_api/BrokerApp.hpp
@@ -107,9 +107,10 @@ class HELICS_CXX_EXPORT BrokerApp {
     @param target the target of the query "federation", "parent", "broker", or a specific named
     object
     @param queryStr the query to make
+    @param mode the ordering mode to use (fast for asynchronous priority channels, and ordered for slower but well ordered queries)
     @return a string containing the query results
     */
-    std::string query(const std::string& target, const std::string& queryStr);
+    std::string query(const std::string& target, const std::string& queryStr, helics_query_mode mode=helics_query_mode_fast);
     /** set a federation global value
      @details this overwrites any previous value for this name
      globals can be queried with a target of "global" and queryStr of the value to Query

--- a/src/helics/application_api/BrokerApp.hpp
+++ b/src/helics/application_api/BrokerApp.hpp
@@ -107,10 +107,13 @@ class HELICS_CXX_EXPORT BrokerApp {
     @param target the target of the query "federation", "parent", "broker", or a specific named
     object
     @param queryStr the query to make
-    @param mode the ordering mode to use (fast for asynchronous priority channels, and ordered for slower but well ordered queries)
+    @param mode the ordering mode to use (fast for asynchronous priority channels, and ordered for
+    slower but well ordered queries)
     @return a string containing the query results
     */
-    std::string query(const std::string& target, const std::string& queryStr, helics_query_mode mode=helics_query_mode_fast);
+    std::string query(const std::string& target,
+                      const std::string& queryStr,
+                      helics_query_mode mode = helics_query_mode_fast);
     /** set a federation global value
      @details this overwrites any previous value for this name
      globals can be queried with a target of "global" and queryStr of the value to Query

--- a/src/helics/application_api/CoreApp.cpp
+++ b/src/helics/application_api/CoreApp.cpp
@@ -209,7 +209,7 @@ const std::string& CoreApp::getAddress() const
 
 /** make a query at the core*/
 std::string
-    CoreApp::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+    CoreApp::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
 {
     return (core) ? core->query(target, queryStr, mode) : std::string("#error");
 }

--- a/src/helics/application_api/CoreApp.cpp
+++ b/src/helics/application_api/CoreApp.cpp
@@ -208,7 +208,8 @@ const std::string& CoreApp::getAddress() const
 }
 
 /** make a query at the core*/
-std::string CoreApp::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+std::string
+    CoreApp::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
 {
     return (core) ? core->query(target, queryStr, mode) : std::string("#error");
 }

--- a/src/helics/application_api/CoreApp.cpp
+++ b/src/helics/application_api/CoreApp.cpp
@@ -208,9 +208,9 @@ const std::string& CoreApp::getAddress() const
 }
 
 /** make a query at the core*/
-std::string CoreApp::query(const std::string& target, const std::string& queryStr)
+std::string CoreApp::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
 {
-    return (core) ? core->query(target, queryStr) : std::string("#error");
+    return (core) ? core->query(target, queryStr, mode) : std::string("#error");
 }
 
 void CoreApp::setGlobal(const std::string& valueName, const std::string& value)

--- a/src/helics/application_api/CoreApp.hpp
+++ b/src/helics/application_api/CoreApp.hpp
@@ -108,8 +108,8 @@ class HELICS_CXX_EXPORT CoreApp {
     @param target the target of the query "federation", "parent", "core","broker" or a specific
     named object
     @param queryStr the query to make
-    @param mode defaults to fast (asynchronous) meaning the query goes into priority channels, ordered
-    (synchronous) means slower queries but has more ordering guarantees
+    @param mode defaults to fast (asynchronous) meaning the query goes into priority channels,
+    ordered (synchronous) means slower queries but has more ordering guarantees
     @return a string containing the query results
     */
     std::string query(const std::string& target,

--- a/src/helics/application_api/CoreApp.hpp
+++ b/src/helics/application_api/CoreApp.hpp
@@ -114,7 +114,7 @@ class HELICS_CXX_EXPORT CoreApp {
     */
     std::string query(const std::string& target,
                       const std::string& queryStr,
-                      query_synch_mode mode = helics_query_mode_fast);
+                      helics_query_mode mode = helics_query_mode_fast);
 
     /** set a federation global value
     @details this overwrites any previous value for this name

--- a/src/helics/application_api/CoreApp.hpp
+++ b/src/helics/application_api/CoreApp.hpp
@@ -108,9 +108,11 @@ class HELICS_CXX_EXPORT CoreApp {
     @param target the target of the query "federation", "parent", "core","broker" or a specific
     named object
     @param queryStr the query to make
+    @param mod default to asynchronous meaning the query goes into priority channels, synchronous means slower queries but has more ordering guarantees
     @return a string containing the query results
     */
-    std::string query(const std::string& target, const std::string& queryStr);
+    std::string
+        query(const std::string& target, const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast);
 
     /** set a federation global value
     @details this overwrites any previous value for this name

--- a/src/helics/application_api/CoreApp.hpp
+++ b/src/helics/application_api/CoreApp.hpp
@@ -108,11 +108,13 @@ class HELICS_CXX_EXPORT CoreApp {
     @param target the target of the query "federation", "parent", "core","broker" or a specific
     named object
     @param queryStr the query to make
-    @param mod default to asynchronous meaning the query goes into priority channels, synchronous means slower queries but has more ordering guarantees
+    @param mod default to asynchronous meaning the query goes into priority channels, synchronous
+    means slower queries but has more ordering guarantees
     @return a string containing the query results
     */
-    std::string
-        query(const std::string& target, const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast);
+    std::string query(const std::string& target,
+                      const std::string& queryStr,
+                      query_synch_mode mode = helics_query_mode_fast);
 
     /** set a federation global value
     @details this overwrites any previous value for this name

--- a/src/helics/application_api/CoreApp.hpp
+++ b/src/helics/application_api/CoreApp.hpp
@@ -108,8 +108,8 @@ class HELICS_CXX_EXPORT CoreApp {
     @param target the target of the query "federation", "parent", "core","broker" or a specific
     named object
     @param queryStr the query to make
-    @param mod default to asynchronous meaning the query goes into priority channels, synchronous
-    means slower queries but has more ordering guarantees
+    @param mode defaults to fast (asynchronous) meaning the query goes into priority channels, ordered
+    (synchronous) means slower queries but has more ordering guarantees
     @return a string containing the query results
     */
     std::string query(const std::string& target,

--- a/src/helics/application_api/Federate.cpp
+++ b/src/helics/application_api/Federate.cpp
@@ -1105,7 +1105,7 @@ std::string Federate::query(const std::string& queryStr, query_synch_mode mode)
     }
     if (res.empty()) {
         if (coreObject) {
-            res = coreObject->query(getName(), queryStr,mode);
+            res = coreObject->query(getName(), queryStr, mode);
         } else {
             res = "#disconnected";
         }
@@ -1121,7 +1121,7 @@ std::string
         res = query(queryStr);
     } else {
         if (coreObject) {
-            res = coreObject->query(target, queryStr,mode);
+            res = coreObject->query(target, queryStr, mode);
         } else {
             res = "#disconnected";
         }
@@ -1129,10 +1129,12 @@ std::string
     return res;
 }
 
-query_id_t Federate::queryAsync(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+query_id_t Federate::queryAsync(const std::string& target,
+                                const std::string& queryStr,
+                                query_synch_mode mode)
 {
-    auto queryFut = std::async(std::launch::async, [this, target, queryStr,mode]() {
-        return coreObject->query(target, queryStr,mode);
+    auto queryFut = std::async(std::launch::async, [this, target, queryStr, mode]() {
+        return coreObject->query(target, queryStr, mode);
     });
     auto asyncInfo = asyncCallInfo->lock();
     int cnt = asyncInfo->queryCounter++;
@@ -1143,7 +1145,8 @@ query_id_t Federate::queryAsync(const std::string& target, const std::string& qu
 
 query_id_t Federate::queryAsync(const std::string& queryStr, query_synch_mode mode)
 {
-    auto queryFut = std::async(std::launch::async, [this, queryStr,mode]() { return query(queryStr,mode); });
+    auto queryFut =
+        std::async(std::launch::async, [this, queryStr, mode]() { return query(queryStr, mode); });
     auto asyncInfo = asyncCallInfo->lock();
     int cnt = asyncInfo->queryCounter++;
 

--- a/src/helics/application_api/Federate.cpp
+++ b/src/helics/application_api/Federate.cpp
@@ -1087,7 +1087,7 @@ std::string Federate::localQuery(const std::string& /*queryStr*/) const
 {
     return std::string{};
 }
-std::string Federate::query(const std::string& queryStr, query_synch_mode mode)
+std::string Federate::query(const std::string& queryStr, helics_query_mode mode)
 {
     std::string res;
     if (queryStr == "name") {
@@ -1114,7 +1114,7 @@ std::string Federate::query(const std::string& queryStr, query_synch_mode mode)
 }
 
 std::string
-    Federate::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+    Federate::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
 {
     std::string res;
     if ((target.empty()) || (target == "federate") || (target == getName())) {
@@ -1131,7 +1131,7 @@ std::string
 
 query_id_t Federate::queryAsync(const std::string& target,
                                 const std::string& queryStr,
-                                query_synch_mode mode)
+                                helics_query_mode mode)
 {
     auto queryFut = std::async(std::launch::async, [this, target, queryStr, mode]() {
         return coreObject->query(target, queryStr, mode);
@@ -1143,7 +1143,7 @@ query_id_t Federate::queryAsync(const std::string& target,
     return query_id_t(cnt);
 }
 
-query_id_t Federate::queryAsync(const std::string& queryStr, query_synch_mode mode)
+query_id_t Federate::queryAsync(const std::string& queryStr, helics_query_mode mode)
 {
     auto queryFut =
         std::async(std::launch::async, [this, queryStr, mode]() { return query(queryStr, mode); });

--- a/src/helics/application_api/Federate.cpp
+++ b/src/helics/application_api/Federate.cpp
@@ -1087,7 +1087,7 @@ std::string Federate::localQuery(const std::string& /*queryStr*/) const
 {
     return std::string{};
 }
-std::string Federate::query(const std::string& queryStr)
+std::string Federate::query(const std::string& queryStr, query_synch_mode mode)
 {
     std::string res;
     if (queryStr == "name") {
@@ -1105,7 +1105,7 @@ std::string Federate::query(const std::string& queryStr)
     }
     if (res.empty()) {
         if (coreObject) {
-            res = coreObject->query(getName(), queryStr);
+            res = coreObject->query(getName(), queryStr,mode);
         } else {
             res = "#disconnected";
         }
@@ -1113,14 +1113,15 @@ std::string Federate::query(const std::string& queryStr)
     return res;
 }
 
-std::string Federate::query(const std::string& target, const std::string& queryStr)
+std::string
+    Federate::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
 {
     std::string res;
     if ((target.empty()) || (target == "federate") || (target == getName())) {
         res = query(queryStr);
     } else {
         if (coreObject) {
-            res = coreObject->query(target, queryStr);
+            res = coreObject->query(target, queryStr,mode);
         } else {
             res = "#disconnected";
         }
@@ -1128,10 +1129,10 @@ std::string Federate::query(const std::string& target, const std::string& queryS
     return res;
 }
 
-query_id_t Federate::queryAsync(const std::string& target, const std::string& queryStr)
+query_id_t Federate::queryAsync(const std::string& target, const std::string& queryStr, query_synch_mode mode)
 {
-    auto queryFut = std::async(std::launch::async, [this, target, queryStr]() {
-        return coreObject->query(target, queryStr);
+    auto queryFut = std::async(std::launch::async, [this, target, queryStr,mode]() {
+        return coreObject->query(target, queryStr,mode);
     });
     auto asyncInfo = asyncCallInfo->lock();
     int cnt = asyncInfo->queryCounter++;
@@ -1140,9 +1141,9 @@ query_id_t Federate::queryAsync(const std::string& target, const std::string& qu
     return query_id_t(cnt);
 }
 
-query_id_t Federate::queryAsync(const std::string& queryStr)
+query_id_t Federate::queryAsync(const std::string& queryStr, query_synch_mode mode)
 {
-    auto queryFut = std::async(std::launch::async, [this, queryStr]() { return query(queryStr); });
+    auto queryFut = std::async(std::launch::async, [this, queryStr,mode]() { return query(queryStr,mode); });
     auto asyncInfo = asyncCallInfo->lock();
     int cnt = asyncInfo->queryCounter++;
 

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -324,7 +324,7 @@ class HELICS_CXX_EXPORT Federate {
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate if the local federate does not recognize the query it
     sends it on to the federation
-    @param mode asynchronous(default) means the query goes on priority channels, synchronous is
+    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered (synchronous) is
     slower but has more ordering guarantees
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -314,7 +314,8 @@ class HELICS_CXX_EXPORT Federate {
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string query(const std::string& target, const std::string& queryStr);
+    std::string
+        query(const std::string& target, const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast);
 
     /** make a query of the core
     @details this call is blocking until the value is returned which make take some time depending
@@ -322,11 +323,12 @@ class HELICS_CXX_EXPORT Federate {
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate if the local federate does not recognize the query it
     sends it on to the federation
+    @param mode asynchronous(default) means the query goes on priority channels, synchronous is slower but has more ordering guarantees
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string query(const std::string& queryStr);
+    std::string query(const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast);
 
     /** make a query of the core in an async fashion
     @details this call is blocking until the value is returned which make take some time depending
@@ -335,9 +337,13 @@ class HELICS_CXX_EXPORT Federate {
     specific name of a federate, core, or broker
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
+    @param mode asynchronous(default) means the query goes on priority channels, synchronous is
+    slower but has more ordering guarantees
     @return a query_id_t to use for returning the result
     */
-    query_id_t queryAsync(const std::string& target, const std::string& queryStr);
+    query_id_t queryAsync(const std::string& target,
+                          const std::string& queryStr,
+                          query_synch_mode mode = helics_query_mode_fast);
 
     /** make a query of the core in an async fashion
     @details this call is blocking until the value is returned which make take some time depending
@@ -346,7 +352,7 @@ class HELICS_CXX_EXPORT Federate {
     query, can be defined by the federate
     @return a query_id_t used to get the results of the query in the future
     */
-    query_id_t queryAsync(const std::string& queryStr);
+    query_id_t queryAsync(const std::string& queryStr, query_synch_mode mode = helics_query_mode_fast);
 
     /** get the results of an async query
     @details the call will block until the results are returned inquiry of queryCompleted() to check

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -314,8 +314,9 @@ class HELICS_CXX_EXPORT Federate {
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string
-        query(const std::string& target, const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast);
+    std::string query(const std::string& target,
+                      const std::string& queryStr,
+                      query_synch_mode mode = helics_query_mode_fast);
 
     /** make a query of the core
     @details this call is blocking until the value is returned which make take some time depending
@@ -323,12 +324,13 @@ class HELICS_CXX_EXPORT Federate {
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate if the local federate does not recognize the query it
     sends it on to the federation
-    @param mode asynchronous(default) means the query goes on priority channels, synchronous is slower but has more ordering guarantees
+    @param mode asynchronous(default) means the query goes on priority channels, synchronous is
+    slower but has more ordering guarantees
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string query(const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast);
+    std::string query(const std::string& queryStr, query_synch_mode mode = helics_query_mode_fast);
 
     /** make a query of the core in an async fashion
     @details this call is blocking until the value is returned which make take some time depending
@@ -352,7 +354,8 @@ class HELICS_CXX_EXPORT Federate {
     query, can be defined by the federate
     @return a query_id_t used to get the results of the query in the future
     */
-    query_id_t queryAsync(const std::string& queryStr, query_synch_mode mode = helics_query_mode_fast);
+    query_id_t queryAsync(const std::string& queryStr,
+                          query_synch_mode mode = helics_query_mode_fast);
 
     /** get the results of an async query
     @details the call will block until the results are returned inquiry of queryCompleted() to check

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -341,8 +341,8 @@ class HELICS_CXX_EXPORT Federate {
     specific name of a federate, core, or broker
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
-    @param mode asynchronous(default) means the query goes on priority channels, synchronous is
-    slower but has more ordering guarantees
+    @param mode fast (asynchronous; default) means the query goes on priority channels,
+    ordered(synchronous) is slower but has more ordering guarantees
     @return a query_id_t to use for returning the result
     */
     query_id_t queryAsync(const std::string& target,

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -326,8 +326,8 @@ class HELICS_CXX_EXPORT Federate {
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate if the local federate does not recognize the query it
     sends it on to the federation
-    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered (synchronous) is
-    slower but has more ordering guarantees
+    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered
+    (synchronous) is slower but has more ordering guarantees
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid

--- a/src/helics/application_api/Federate.hpp
+++ b/src/helics/application_api/Federate.hpp
@@ -310,13 +310,15 @@ class HELICS_CXX_EXPORT Federate {
     specific name of a federate, core, or broker
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
+    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered
+      (synchronous) is slower but has more ordering guarantees
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
     std::string query(const std::string& target,
                       const std::string& queryStr,
-                      query_synch_mode mode = helics_query_mode_fast);
+                      helics_query_mode mode = helics_query_mode_fast);
 
     /** make a query of the core
     @details this call is blocking until the value is returned which make take some time depending
@@ -330,7 +332,7 @@ class HELICS_CXX_EXPORT Federate {
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string query(const std::string& queryStr, query_synch_mode mode = helics_query_mode_fast);
+    std::string query(const std::string& queryStr, helics_query_mode mode = helics_query_mode_fast);
 
     /** make a query of the core in an async fashion
     @details this call is blocking until the value is returned which make take some time depending
@@ -345,7 +347,7 @@ class HELICS_CXX_EXPORT Federate {
     */
     query_id_t queryAsync(const std::string& target,
                           const std::string& queryStr,
-                          query_synch_mode mode = helics_query_mode_fast);
+                          helics_query_mode mode = helics_query_mode_fast);
 
     /** make a query of the core in an async fashion
     @details this call is blocking until the value is returned which make take some time depending
@@ -355,7 +357,7 @@ class HELICS_CXX_EXPORT Federate {
     @return a query_id_t used to get the results of the query in the future
     */
     query_id_t queryAsync(const std::string& queryStr,
-                          query_synch_mode mode = helics_query_mode_fast);
+                          helics_query_mode mode = helics_query_mode_fast);
 
     /** get the results of an async query
     @details the call will block until the results are returned inquiry of queryCompleted() to check

--- a/src/helics/application_api/queryFunctions.cpp
+++ b/src/helics/application_api/queryFunctions.cpp
@@ -91,7 +91,7 @@ bool waitForInit(helics::Federate* fed,
                  const std::string& fedName,
                  std::chrono::milliseconds timeout)
 {
-    auto res = fed->query(fedName, "isinit");
+    auto res = fed->query(fedName, "isinit",helics_query_mode_ordered);
     std::chrono::milliseconds waitTime{0};
     const std::chrono::milliseconds delta{400};
     while (res != "true") {
@@ -99,7 +99,7 @@ bool waitForInit(helics::Federate* fed,
             return false;
         }
         std::this_thread::sleep_for(delta);
-        res = fed->query(fedName, "isinit");
+        res = fed->query(fedName, "isinit", helics_query_mode_ordered);
         waitTime += delta;
         if (waitTime >= timeout) {
             return false;
@@ -128,7 +128,7 @@ bool waitForFed(helics::Federate* fed,
 
 std::string queryFederateSubscriptions(helics::Federate* fed, const std::string& fedName)
 {
-    auto res = fed->query(fedName, "subscriptions");
+    auto res = fed->query(fedName, "subscriptions", helics_query_mode_ordered);
     if (res.size() > 2 && res != "#invalid") {
         res = fed->query("gid_to_name", res);
     }

--- a/src/helics/application_api/queryFunctions.cpp
+++ b/src/helics/application_api/queryFunctions.cpp
@@ -91,7 +91,7 @@ bool waitForInit(helics::Federate* fed,
                  const std::string& fedName,
                  std::chrono::milliseconds timeout)
 {
-    auto res = fed->query(fedName, "isinit",helics_query_mode_ordered);
+    auto res = fed->query(fedName, "isinit", helics_query_mode_ordered);
     std::chrono::milliseconds waitTime{0};
     const std::chrono::milliseconds delta{400};
     while (res != "true") {

--- a/src/helics/apps/Clone.cpp
+++ b/src/helics/apps/Clone.cpp
@@ -182,7 +182,8 @@ namespace apps {
     {
         auto res = waitForInit(fed.get(), captureFederate);
         if (res) {
-            auto pubs = vectorizeQueryResult(fed->query(captureFederate, "publications",helics_query_mode_ordered));
+            auto pubs = vectorizeQueryResult(
+                fed->query(captureFederate, "publications", helics_query_mode_ordered));
             for (auto& pub : pubs) {
                 if (pub.empty()) {
                     continue;

--- a/src/helics/apps/Clone.cpp
+++ b/src/helics/apps/Clone.cpp
@@ -182,14 +182,15 @@ namespace apps {
     {
         auto res = waitForInit(fed.get(), captureFederate);
         if (res) {
-            auto pubs = vectorizeQueryResult(fed->query(captureFederate, "publications"));
+            auto pubs = vectorizeQueryResult(fed->query(captureFederate, "publications",helics_query_mode_ordered));
             for (auto& pub : pubs) {
                 if (pub.empty()) {
                     continue;
                 }
                 addSubscription(pub);
             }
-            auto epts = vectorizeQueryResult(fed->query(captureFederate, "endpoints"));
+            auto epts = vectorizeQueryResult(
+                fed->query(captureFederate, "endpoints", helics_query_mode_ordered));
             for (auto& ept : epts) {
                 if (ept.empty()) {
                     continue;
@@ -204,7 +205,7 @@ namespace apps {
                                                      std::string{}),
                                          cloneSubscriptionNames.end());
 
-            fedConfig = fed->query(captureFederate, "config");
+            fedConfig = fed->query(captureFederate, "config", helics_query_mode_ordered);
         }
     }
 

--- a/src/helics/apps/Recorder.cpp
+++ b/src/helics/apps/Recorder.cpp
@@ -351,7 +351,8 @@ namespace apps {
         for (auto& capt : captureInterfaces) {
             auto res = waitForInit(fed.get(), capt);
             if (res) {
-                auto pubs = vectorizeQueryResult(fed->query(capt, "publications"));
+                auto pubs = vectorizeQueryResult(
+                    fed->query(capt, "publications",helics_query_mode_ordered));
                 for (auto& pub : pubs) {
                     addSubscription(pub);
                 }

--- a/src/helics/apps/Recorder.cpp
+++ b/src/helics/apps/Recorder.cpp
@@ -352,7 +352,7 @@ namespace apps {
             auto res = waitForInit(fed.get(), capt);
             if (res) {
                 auto pubs = vectorizeQueryResult(
-                    fed->query(capt, "publications",helics_query_mode_ordered));
+                    fed->query(capt, "publications", helics_query_mode_ordered));
                 for (auto& pub : pubs) {
                     addSubscription(pub);
                 }

--- a/src/helics/apps/Tracer.cpp
+++ b/src/helics/apps/Tracer.cpp
@@ -229,7 +229,8 @@ namespace apps {
         for (auto& capt : captureInterfaces) {
             auto res = waitForInit(fed.get(), capt);
             if (res) {
-                auto pubs = vectorizeQueryResult(fed->query(capt, "publications"));
+                auto pubs = vectorizeQueryResult(
+                    fed->query(capt, "publications", helics_query_mode_ordered));
                 for (auto& pub : pubs) {
                     addSubscription(pub);
                 }

--- a/src/helics/core/ActionMessageDefintions.hpp
+++ b/src/helics/core/ActionMessageDefintions.hpp
@@ -33,11 +33,11 @@ across different compilers*/
             -254,  //!< priority commands usually do not have an ack this is an ack that
         //!< doesn't do anything
         cmd_query = -cmd_info_basis - 37,  //!< send a query this is a priority command
-        cmd_query_synchronous =
+        cmd_query_ordered =
             937,  //!< send a query along the synchronous paths instead of priority channels
         cmd_set_global = -cmd_info_basis - 55,  //!< set a global value
         cmd_broker_query = -37,  //!< send a query to a core
-        cmd_broker_query_synchronous = 939,  //!< send a query to a core
+        cmd_broker_query_ordered = 939,  //!< send a query to a core
         cmd_query_reply = -cmd_info_basis - 38,  //!< response to a query
         cmd_reg_broker =
             -cmd_info_basis - 40,  //!< for a broker to connect with a higher level broker
@@ -315,9 +315,9 @@ across different compilers*/
 #define CMD_PRIORITY_ACK action_message_def::action_t::cmd_priority_ack
 
 #define CMD_QUERY action_message_def::action_t::cmd_query
-#define CMD_QUERY_SYNCHRONOUS action_message_def::action_t::cmd_query_synchronous
+#define CMD_QUERY_ORDERED action_message_def::action_t::cmd_query_ordered
 #define CMD_BROKER_QUERY action_message_def::action_t::cmd_broker_query
-#define CMD_BROKER_QUERY_SYNCHRONOUS action_message_def::action_t::cmd_broker_query_synchronous
+#define CMD_BROKER_QUERY_ORDERED action_message_def::action_t::cmd_broker_query_ordered
 #define CMD_QUERY_REPLY action_message_def::action_t::cmd_query_reply
 #define CMD_SET_GLOBAL action_message_def::action_t::cmd_set_global
 

--- a/src/helics/core/ActionMessageDefintions.hpp
+++ b/src/helics/core/ActionMessageDefintions.hpp
@@ -29,10 +29,12 @@ across different compilers*/
         cmd_route_ack = -16,  //!< acknowledge reply to a route registration
         cmd_register_route = -15,  //!< instructions to create a direct route to another federate
         cmd_reg_fed = -105,  //!< register a federate
-        cmd_priority_ack = -254,  //!< priority commands usually do not have an ack this is an ack that
+        cmd_priority_ack =
+            -254,  //!< priority commands usually do not have an ack this is an ack that
         //!< doesn't do anything
         cmd_query = -cmd_info_basis - 37,  //!< send a query this is a priority command
-        cmd_query_synchronous = 937, //!< send a query along the synchronous paths instead of priority channels
+        cmd_query_synchronous =
+            937,  //!< send a query along the synchronous paths instead of priority channels
         cmd_set_global = -cmd_info_basis - 55,  //!< set a global value
         cmd_broker_query = -37,  //!< send a query to a core
         cmd_broker_query_synchronous = 939,  //!< send a query to a core

--- a/src/helics/core/ActionMessageDefintions.hpp
+++ b/src/helics/core/ActionMessageDefintions.hpp
@@ -29,11 +29,13 @@ across different compilers*/
         cmd_route_ack = -16,  //!< acknowledge reply to a route registration
         cmd_register_route = -15,  //!< instructions to create a direct route to another federate
         cmd_reg_fed = -105,  //!< register a federate
-        cmd_priority_ack = -254,  //!< priority commands usually have an ack this is an ack that
+        cmd_priority_ack = -254,  //!< priority commands usually do not have an ack this is an ack that
         //!< doesn't do anything
         cmd_query = -cmd_info_basis - 37,  //!< send a query this is a priority command
+        cmd_query_synchronous = 937, //!< send a query along the synchronous paths instead of priority channels
         cmd_set_global = -cmd_info_basis - 55,  //!< set a global value
         cmd_broker_query = -37,  //!< send a query to a core
+        cmd_broker_query_synchronous = 939,  //!< send a query to a core
         cmd_query_reply = -cmd_info_basis - 38,  //!< response to a query
         cmd_reg_broker =
             -cmd_info_basis - 40,  //!< for a broker to connect with a higher level broker
@@ -311,7 +313,9 @@ across different compilers*/
 #define CMD_PRIORITY_ACK action_message_def::action_t::cmd_priority_ack
 
 #define CMD_QUERY action_message_def::action_t::cmd_query
+#define CMD_QUERY_SYNCHRONOUS action_message_def::action_t::cmd_query_synchronous
 #define CMD_BROKER_QUERY action_message_def::action_t::cmd_broker_query
+#define CMD_BROKER_QUERY_SYNCHRONOUS action_message_def::action_t::cmd_broker_query_synchronous
 #define CMD_QUERY_REPLY action_message_def::action_t::cmd_query_reply
 #define CMD_SET_GLOBAL action_message_def::action_t::cmd_set_global
 

--- a/src/helics/core/Broker.hpp
+++ b/src/helics/core/Broker.hpp
@@ -95,7 +95,7 @@ class Broker {
       @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */
-    virtual std::string query(const std::string& target, const std::string& queryStr) = 0;
+    virtual std::string query(const std::string& target, const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast) = 0;
 
     /** set a federation global value
     @details this overwrites any previous value for this name

--- a/src/helics/core/Broker.hpp
+++ b/src/helics/core/Broker.hpp
@@ -95,7 +95,9 @@ class Broker {
       @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */
-    virtual std::string query(const std::string& target, const std::string& queryStr, query_synch_mode mode=helics_query_mode_fast) = 0;
+    virtual std::string query(const std::string& target,
+                              const std::string& queryStr,
+                              query_synch_mode mode = helics_query_mode_fast) = 0;
 
     /** set a federation global value
     @details this overwrites any previous value for this name

--- a/src/helics/core/Broker.hpp
+++ b/src/helics/core/Broker.hpp
@@ -99,7 +99,7 @@ class Broker {
     */
     virtual std::string query(const std::string& target,
                               const std::string& queryStr,
-                              query_synch_mode mode = helics_query_mode_fast) = 0;
+                              helics_query_mode mode = helics_query_mode_fast) = 0;
 
     /** set a federation global value
     @details this overwrites any previous value for this name

--- a/src/helics/core/Broker.hpp
+++ b/src/helics/core/Broker.hpp
@@ -92,8 +92,8 @@ class Broker {
     query is a broken
     @param target the specific target of the query
     @param queryStr the actual query
-    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered (synchronous) is
-    slower but has more ordering guarantees
+    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered
+    (synchronous) is slower but has more ordering guarantees
       @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */

--- a/src/helics/core/Broker.hpp
+++ b/src/helics/core/Broker.hpp
@@ -92,6 +92,8 @@ class Broker {
     query is a broken
     @param target the specific target of the query
     @param queryStr the actual query
+    @param mode fast (asynchronous; default) means the query goes on priority channels, ordered (synchronous) is
+    slower but has more ordering guarantees
       @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -1920,7 +1920,9 @@ std::string CommonCore::filteredEndpointQuery(const FederateState* fed) const
     return generateJsonString(base);
 }
 
-std::string CommonCore::federateQuery(const FederateState* fed, const std::string& queryStr, bool synchronous) const
+std::string CommonCore::federateQuery(const FederateState* fed,
+                                      const std::string& queryStr,
+                                      bool synchronous) const
 {
     if (fed == nullptr) {
         if (queryStr == "exists") {
@@ -1938,14 +1940,12 @@ std::string CommonCore::federateQuery(const FederateState* fed, const std::strin
         return (fed->init_transmitted.load()) ? "true" : "false";
     }
     if (queryStr == "state") {
-        if (!synchronous)
-        {
+        if (!synchronous) {
             return fedStateString(fed->getState());
         }
     }
     if (queryStr == "filtered_endpoints") {
-        if (!synchronous)
-        {
+        if (!synchronous) {
             return filteredEndpointQuery(fed);
         }
     }
@@ -1953,7 +1953,7 @@ std::string CommonCore::federateQuery(const FederateState* fed, const std::strin
         return std::string("[exists;isinit;state;version;queries;filtered_endpoints;") +
             fed->processQuery(queryStr) + "]";
     }
-    return fed->processQuery(queryStr,synchronous);
+    return fed->processQuery(queryStr, synchronous);
 }
 
 std::string CommonCore::quickCoreQueries(const std::string& queryStr) const
@@ -1999,7 +1999,8 @@ void CommonCore::loadBasicJsonInfo(
 
 void CommonCore::initializeMapBuilder(const std::string& request,
                                       std::uint16_t index,
-                                      bool reset, bool synchronous) const
+                                      bool reset,
+                                      bool synchronous) const
 {
     if (!isValidIndex(index, mapBuilders)) {
         mapBuilders.resize(index + 1);
@@ -2011,7 +2012,7 @@ void CommonCore::initializeMapBuilder(const std::string& request,
     base["name"] = getIdentifier();
     base["id"] = global_broker_id_local.baseValue();
     base["parent"] = higher_broker_id.baseValue();
-    ActionMessage queryReq(synchronous?CMD_QUERY_SYNCHRONOUS:CMD_QUERY);
+    ActionMessage queryReq(synchronous ? CMD_QUERY_SYNCHRONOUS : CMD_QUERY);
     queryReq.payload = request;
     queryReq.source_id = global_broker_id_local;
     queryReq.counter = index;  // indicating which processing to use
@@ -2020,7 +2021,7 @@ void CommonCore::initializeMapBuilder(const std::string& request,
         for (const auto& fed : loopFederates) {
             int brkindex =
                 builder.generatePlaceHolder("federates", fed->global_id.load().baseValue());
-            std::string ret = federateQuery(fed.fed, request,synchronous);
+            std::string ret = federateQuery(fed.fed, request, synchronous);
             if (ret == "#wait") {
                 queryReq.messageID = brkindex;
                 queryReq.dest_id = fed.fed->global_id;
@@ -2167,7 +2168,7 @@ std::string CommonCore::coreQuery(const std::string& queryStr, bool synchronous)
             }
         }
 
-        initializeMapBuilder(queryStr, index, mi->second.second,synchronous);
+        initializeMapBuilder(queryStr, index, mi->second.second, synchronous);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
             if (!mi->second.second) {
                 auto center = generateMapObjectCounter();
@@ -2207,7 +2208,8 @@ std::string CommonCore::coreQuery(const std::string& queryStr, bool synchronous)
     return "#invalid";
 }
 
-std::string CommonCore::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+std::string
+    CommonCore::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
 {
     if (brokerState.load() >= broker_state_t::terminating) {
         if (target == "core" || target == getIdentifier() || target.empty()) {
@@ -2218,7 +2220,7 @@ std::string CommonCore::query(const std::string& target, const std::string& quer
         }
         return "#disconnected";
     }
-    ActionMessage querycmd(mode==helics_query_mode_fast?CMD_QUERY:CMD_QUERY_SYNCHRONOUS);
+    ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_QUERY : CMD_QUERY_SYNCHRONOUS);
     querycmd.source_id = direct_core_id;
     querycmd.dest_id = parent_broker_id;
     querycmd.payload = queryStr;
@@ -2234,7 +2236,8 @@ std::string CommonCore::query(const std::string& target, const std::string& quer
         if (queryStr == "address") {
             return getAddress();
         }
-        querycmd.setAction(mode == helics_query_mode_fast ? CMD_BROKER_QUERY : CMD_BROKER_QUERY_SYNCHRONOUS);
+        querycmd.setAction(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
+                                                            CMD_BROKER_QUERY_SYNCHRONOUS);
         querycmd.dest_id = direct_core_id;
     }
     if (querycmd.dest_id != direct_core_id) {
@@ -3567,12 +3570,12 @@ void CommonCore::processCoreConfigureCommands(ActionMessage& cmd)
 
 void CommonCore::processQueryCommand(ActionMessage& cmd)
 {
-    switch (cmd.action())
-        {
+    switch (cmd.action()) {
         case CMD_BROKER_QUERY:
         case CMD_BROKER_QUERY_SYNCHRONOUS:
             if (cmd.dest_id == global_broker_id_local || cmd.dest_id == direct_core_id) {
-                std::string repStr = coreQuery(cmd.payload, cmd.action()==CMD_BROKER_QUERY_SYNCHRONOUS);
+                std::string repStr =
+                    coreQuery(cmd.payload, cmd.action() == CMD_BROKER_QUERY_SYNCHRONOUS);
                 if (repStr != "#wait") {
                     if (cmd.source_id == direct_core_id) {
                         // TODO(PT) make setDelayedValue have a move method
@@ -3592,75 +3595,72 @@ void CommonCore::processQueryCommand(ActionMessage& cmd)
                     queryResp.source_id = global_broker_id_local;
                     queryResp.messageID = cmd.messageID;
                     queryResp.counter = cmd.counter;
-                    std::get<1>(mapBuilders[mapIndex.at(cmd.payload).first])
-                        .push_back(queryResp);
+                    std::get<1>(mapBuilders[mapIndex.at(cmd.payload).first]).push_back(queryResp);
                 }
 
             } else {
                 routeMessage(std::move(cmd));
             }
             break;
-    case CMD_QUERY:
-        case CMD_QUERY_SYNCHRONOUS:
-            {
-        bool synch = (cmd.action() == CMD_QUERY_SYNCHRONOUS);
-        if (cmd.dest_id == parent_broker_id) {
-            const auto& target = cmd.getString(targetStringLoc);
-            if (target == "root" || target == "federation") {
-                cmd.setAction(synch?CMD_BROKER_QUERY_SYNCHRONOUS:CMD_BROKER_QUERY);
-                cmd.dest_id = root_broker_id;
-                cmd.clearStringData();
-            } else if (target == "parent" || target == "broker") {
-                cmd.setAction(synch ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
-                cmd.dest_id = higher_broker_id;
-                cmd.clearStringData();
-            }
-            if (global_broker_id_local != parent_broker_id) {
-                // forward on to Broker
-                cmd.source_id = global_broker_id_local;
-                transmit(parent_route_id, std::move(cmd));
-            } else {
-                // this will get processed when this core is assigned a global id
-                cmd.source_id = direct_core_id;
-                delayTransmitQueue.push(std::move(cmd));
-            }
-        } else {
-            std::string repStr;
-            ActionMessage queryResp(CMD_QUERY_REPLY);
-            queryResp.dest_id = cmd.source_id;
-            queryResp.source_id = cmd.dest_id;
-            queryResp.messageID = cmd.messageID;
-            queryResp.counter = cmd.counter;
-            const std::string& target = cmd.getString(targetStringLoc);
-            if (target == getIdentifier()) {
-                queryResp.source_id = global_broker_id_local;
-                repStr = coreQuery(cmd.payload,synch);
-            } else {
-                auto* fedptr = getFederateCore(target);
-                repStr = federateQuery(fedptr, cmd.payload,synch);
-                if (repStr == "#wait") {
-                    if (fedptr != nullptr) {
-                        cmd.dest_id = fedptr->global_id;
-                        fedptr->addAction(std::move(cmd));
-                        break;
-                    }
-                    repStr = "#error";
+        case CMD_QUERY:
+        case CMD_QUERY_SYNCHRONOUS: {
+            bool synch = (cmd.action() == CMD_QUERY_SYNCHRONOUS);
+            if (cmd.dest_id == parent_broker_id) {
+                const auto& target = cmd.getString(targetStringLoc);
+                if (target == "root" || target == "federation") {
+                    cmd.setAction(synch ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
+                    cmd.dest_id = root_broker_id;
+                    cmd.clearStringData();
+                } else if (target == "parent" || target == "broker") {
+                    cmd.setAction(synch ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
+                    cmd.dest_id = higher_broker_id;
+                    cmd.clearStringData();
                 }
-            }
+                if (global_broker_id_local != parent_broker_id) {
+                    // forward on to Broker
+                    cmd.source_id = global_broker_id_local;
+                    transmit(parent_route_id, std::move(cmd));
+                } else {
+                    // this will get processed when this core is assigned a global id
+                    cmd.source_id = direct_core_id;
+                    delayTransmitQueue.push(std::move(cmd));
+                }
+            } else {
+                std::string repStr;
+                ActionMessage queryResp(CMD_QUERY_REPLY);
+                queryResp.dest_id = cmd.source_id;
+                queryResp.source_id = cmd.dest_id;
+                queryResp.messageID = cmd.messageID;
+                queryResp.counter = cmd.counter;
+                const std::string& target = cmd.getString(targetStringLoc);
+                if (target == getIdentifier()) {
+                    queryResp.source_id = global_broker_id_local;
+                    repStr = coreQuery(cmd.payload, synch);
+                } else {
+                    auto* fedptr = getFederateCore(target);
+                    repStr = federateQuery(fedptr, cmd.payload, synch);
+                    if (repStr == "#wait") {
+                        if (fedptr != nullptr) {
+                            cmd.dest_id = fedptr->global_id;
+                            fedptr->addAction(std::move(cmd));
+                            break;
+                        }
+                        repStr = "#error";
+                    }
+                }
 
-            queryResp.payload = std::move(repStr);
-            transmit(getRoute(queryResp.dest_id), queryResp);
-        }
-        }
-    break;
-    case CMD_QUERY_REPLY:
-        if (cmd.dest_id == global_broker_id_local || cmd.dest_id == direct_core_id) {
-            processQueryResponse(cmd);
-        } else {
-            transmit(getRoute(cmd.dest_id), cmd);
-        }
-        break;
-        }
+                queryResp.payload = std::move(repStr);
+                transmit(getRoute(queryResp.dest_id), queryResp);
+            }
+        } break;
+        case CMD_QUERY_REPLY:
+            if (cmd.dest_id == global_broker_id_local || cmd.dest_id == direct_core_id) {
+                processQueryResponse(cmd);
+            } else {
+                transmit(getRoute(cmd.dest_id), cmd);
+            }
+            break;
+    }
 }
 
 void CommonCore::processCommandsForCore(const ActionMessage& cmd)

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -3985,8 +3985,7 @@ ActionMessage& CommonCore::processMessage(ActionMessage& m)
         return m;
     }
     if (checkActionFlag(*handle, has_source_filter_flag)) {
-        if (filterFed)
-        {
+        if (filterFed) {
             return filterFed->processMessage(m, handle);
         }
     }

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2208,8 +2208,9 @@ std::string CommonCore::coreQuery(const std::string& queryStr, bool force_orderi
     return "#invalid";
 }
 
-std::string
-    CommonCore::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
+std::string CommonCore::query(const std::string& target,
+                              const std::string& queryStr,
+                              helics_query_mode mode)
 {
     if (brokerState.load() >= broker_state_t::terminating) {
         if (target == "core" || target == getIdentifier() || target.empty()) {

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -1922,7 +1922,7 @@ std::string CommonCore::filteredEndpointQuery(const FederateState* fed) const
 
 std::string CommonCore::federateQuery(const FederateState* fed,
                                       const std::string& queryStr,
-                                      bool synchronous) const
+                                      bool force_ordering) const
 {
     if (fed == nullptr) {
         if (queryStr == "exists") {
@@ -1940,12 +1940,12 @@ std::string CommonCore::federateQuery(const FederateState* fed,
         return (fed->init_transmitted.load()) ? "true" : "false";
     }
     if (queryStr == "state") {
-        if (!synchronous) {
+        if (!force_ordering) {
             return fedStateString(fed->getState());
         }
     }
     if (queryStr == "filtered_endpoints") {
-        if (!synchronous) {
+        if (!force_ordering) {
             return filteredEndpointQuery(fed);
         }
     }
@@ -1953,7 +1953,7 @@ std::string CommonCore::federateQuery(const FederateState* fed,
         return std::string("[exists;isinit;state;version;queries;filtered_endpoints;") +
             fed->processQuery(queryStr) + "]";
     }
-    return fed->processQuery(queryStr, synchronous);
+    return fed->processQuery(queryStr, force_ordering);
 }
 
 std::string CommonCore::quickCoreQueries(const std::string& queryStr) const
@@ -2000,7 +2000,7 @@ void CommonCore::loadBasicJsonInfo(
 void CommonCore::initializeMapBuilder(const std::string& request,
                                       std::uint16_t index,
                                       bool reset,
-                                      bool synchronous) const
+                                      bool force_ordering) const
 {
     if (!isValidIndex(index, mapBuilders)) {
         mapBuilders.resize(index + 1);
@@ -2012,7 +2012,7 @@ void CommonCore::initializeMapBuilder(const std::string& request,
     base["name"] = getIdentifier();
     base["id"] = global_broker_id_local.baseValue();
     base["parent"] = higher_broker_id.baseValue();
-    ActionMessage queryReq(synchronous ? CMD_QUERY_SYNCHRONOUS : CMD_QUERY);
+    ActionMessage queryReq(force_ordering ? CMD_QUERY_ORDERED : CMD_QUERY);
     queryReq.payload = request;
     queryReq.source_id = global_broker_id_local;
     queryReq.counter = index;  // indicating which processing to use
@@ -2021,7 +2021,7 @@ void CommonCore::initializeMapBuilder(const std::string& request,
         for (const auto& fed : loopFederates) {
             int brkindex =
                 builder.generatePlaceHolder("federates", fed->global_id.load().baseValue());
-            std::string ret = federateQuery(fed.fed, request, synchronous);
+            std::string ret = federateQuery(fed.fed, request, force_ordering);
             if (ret == "#wait") {
                 queryReq.messageID = brkindex;
                 queryReq.dest_id = fed.fed->global_id;
@@ -2071,7 +2071,7 @@ void CommonCore::initializeMapBuilder(const std::string& request,
     }
 }
 
-std::string CommonCore::coreQuery(const std::string& queryStr, bool synchronous) const
+std::string CommonCore::coreQuery(const std::string& queryStr, bool force_ordering) const
 {
     auto res = quickCoreQueries(queryStr);
     if (!res.empty()) {
@@ -2168,7 +2168,7 @@ std::string CommonCore::coreQuery(const std::string& queryStr, bool synchronous)
             }
         }
 
-        initializeMapBuilder(queryStr, index, mi->second.second, synchronous);
+        initializeMapBuilder(queryStr, index, mi->second.second, force_ordering);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
             if (!mi->second.second) {
                 auto center = generateMapObjectCounter();
@@ -2209,7 +2209,7 @@ std::string CommonCore::coreQuery(const std::string& queryStr, bool synchronous)
 }
 
 std::string
-    CommonCore::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+    CommonCore::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
 {
     if (brokerState.load() >= broker_state_t::terminating) {
         if (target == "core" || target == getIdentifier() || target.empty()) {
@@ -2220,7 +2220,7 @@ std::string
         }
         return "#disconnected";
     }
-    ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_QUERY : CMD_QUERY_SYNCHRONOUS);
+    ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_QUERY : CMD_QUERY_ORDERED);
     querycmd.source_id = direct_core_id;
     querycmd.dest_id = parent_broker_id;
     querycmd.payload = queryStr;
@@ -2237,7 +2237,7 @@ std::string
             return getAddress();
         }
         querycmd.setAction(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
-                                                            CMD_BROKER_QUERY_SYNCHRONOUS);
+                                                            CMD_BROKER_QUERY_ORDERED);
         querycmd.dest_id = direct_core_id;
     }
     if (querycmd.dest_id != direct_core_id) {
@@ -2700,8 +2700,8 @@ void CommonCore::processCommand(ActionMessage&& command)
         case CMD_TIME_UNBLOCK:
             manageTimeBlocks(command);
             break;
-        case CMD_BROKER_QUERY_SYNCHRONOUS:
-        case CMD_QUERY_SYNCHRONOUS:
+        case CMD_BROKER_QUERY_ORDERED:
+        case CMD_QUERY_ORDERED:
             processQueryCommand(command);
             break;
         case CMD_DISCONNECT_CHECK:
@@ -3572,10 +3572,10 @@ void CommonCore::processQueryCommand(ActionMessage& cmd)
 {
     switch (cmd.action()) {
         case CMD_BROKER_QUERY:
-        case CMD_BROKER_QUERY_SYNCHRONOUS:
+        case CMD_BROKER_QUERY_ORDERED:
             if (cmd.dest_id == global_broker_id_local || cmd.dest_id == direct_core_id) {
                 std::string repStr =
-                    coreQuery(cmd.payload, cmd.action() == CMD_BROKER_QUERY_SYNCHRONOUS);
+                    coreQuery(cmd.payload, cmd.action() == CMD_BROKER_QUERY_ORDERED);
                 if (repStr != "#wait") {
                     if (cmd.source_id == direct_core_id) {
                         // TODO(PT) make setDelayedValue have a move method
@@ -3603,16 +3603,16 @@ void CommonCore::processQueryCommand(ActionMessage& cmd)
             }
             break;
         case CMD_QUERY:
-        case CMD_QUERY_SYNCHRONOUS: {
-            bool synch = (cmd.action() == CMD_QUERY_SYNCHRONOUS);
+        case CMD_QUERY_ORDERED: {
+            bool force_ordered = (cmd.action() == CMD_QUERY_ORDERED);
             if (cmd.dest_id == parent_broker_id) {
                 const auto& target = cmd.getString(targetStringLoc);
                 if (target == "root" || target == "federation") {
-                    cmd.setAction(synch ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
+                    cmd.setAction(force_ordered ? CMD_BROKER_QUERY_ORDERED : CMD_BROKER_QUERY);
                     cmd.dest_id = root_broker_id;
                     cmd.clearStringData();
                 } else if (target == "parent" || target == "broker") {
-                    cmd.setAction(synch ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
+                    cmd.setAction(force_ordered ? CMD_BROKER_QUERY_ORDERED : CMD_BROKER_QUERY);
                     cmd.dest_id = higher_broker_id;
                     cmd.clearStringData();
                 }
@@ -3635,10 +3635,10 @@ void CommonCore::processQueryCommand(ActionMessage& cmd)
                 const std::string& target = cmd.getString(targetStringLoc);
                 if (target == getIdentifier()) {
                     queryResp.source_id = global_broker_id_local;
-                    repStr = coreQuery(cmd.payload, synch);
+                    repStr = coreQuery(cmd.payload, force_ordered);
                 } else {
                     auto* fedptr = getFederateCore(target);
-                    repStr = federateQuery(fedptr, cmd.payload, synch);
+                    repStr = federateQuery(fedptr, cmd.payload, force_ordered);
                     if (repStr == "#wait") {
                         if (fedptr != nullptr) {
                             cmd.dest_id = fedptr->global_id;

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -3985,7 +3985,10 @@ ActionMessage& CommonCore::processMessage(ActionMessage& m)
         return m;
     }
     if (checkActionFlag(*handle, has_source_filter_flag)) {
-        return filterFed->processMessage(m, handle);
+        if (filterFed)
+        {
+            return filterFed->processMessage(m, handle);
+        }
     }
 
     return m;

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -218,7 +218,7 @@ class CommonCore: public Core, public BrokerBase {
 
     virtual void setLogFile(const std::string& lfile) override final;
 
-    virtual std::string query(const std::string& target, const std::string& queryStr) override;
+    virtual std::string query(const std::string& target, const std::string& queryStr, query_synch_mode mode) override;
     virtual void
         setQueryCallback(local_federate_id federateID,
                          std::function<std::string(const std::string&)> queryFunction) override;
@@ -341,6 +341,8 @@ class CommonCore: public Core, public BrokerBase {
     void processCommandsForCore(const ActionMessage& cmd);
     /** process configure commands for the core*/
     void processCoreConfigureCommands(ActionMessage& cmd);
+    /** handle the processing for a query command*/
+    void processQueryCommand(ActionMessage& cmd);
     /** check if a newly registered subscription has a local publication
     if it does return true*/
     bool checkForLocalPublication(ActionMessage& cmd);
@@ -350,10 +352,18 @@ class CommonCore: public Core, public BrokerBase {
     void loadBasicJsonInfo(
         Json::Value& base,
         const std::function<void(Json::Value& fedval, const FedInfo& fed)>& fedLoader) const;
-    /** generate a mapbuilder for the federates*/
-    void initializeMapBuilder(const std::string& request, std::uint16_t index, bool reset) const;
+    /** generate a mapbuilder for the federates
+    @param request the query to build the map for
+    @param index the key of the request
+    @param reset whether the builder should reset or use an existing (true to not use existing)
+    @param synchronous true if the request should use the synchronous pathways
+    */
+    void initializeMapBuilder(const std::string& request,
+                              std::uint16_t index,
+                              bool reset,
+                              bool synchronous) const;
     /** generate results for core queries*/
-    std::string coreQuery(const std::string& queryStr) const;
+    std::string coreQuery(const std::string& queryStr,bool synchronous) const;
 
     /** generate results for some core queries that do not depend on the main processing loop
      * running*/
@@ -454,7 +464,7 @@ class CommonCore: public Core, public BrokerBase {
     @return "#wait" if the lock cannot be granted immediately and no result can be obtained
     otherwise an answer to the query
     */
-    std::string federateQuery(const FederateState* fed, const std::string& queryStr) const;
+    std::string federateQuery(const FederateState* fed, const std::string& queryStr, bool synchronous) const;
 
     /** send an error code and message to all the federates*/
     void sendErrorToFederates(int error_code, const std::string& message);

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -220,7 +220,7 @@ class CommonCore: public Core, public BrokerBase {
 
     virtual std::string query(const std::string& target,
                               const std::string& queryStr,
-                              query_synch_mode mode) override;
+                              helics_query_mode mode) override;
     virtual void
         setQueryCallback(local_federate_id federateID,
                          std::function<std::string(const std::string&)> queryFunction) override;
@@ -358,14 +358,14 @@ class CommonCore: public Core, public BrokerBase {
     @param request the query to build the map for
     @param index the key of the request
     @param reset whether the builder should reset or use an existing (true to not use existing)
-    @param synchronous true if the request should use the synchronous pathways
+    @param force_ordering true if the request should use the force_ordering pathways
     */
     void initializeMapBuilder(const std::string& request,
                               std::uint16_t index,
                               bool reset,
-                              bool synchronous) const;
+                              bool force_ordering) const;
     /** generate results for core queries*/
-    std::string coreQuery(const std::string& queryStr, bool synchronous) const;
+    std::string coreQuery(const std::string& queryStr, bool force_ordering) const;
 
     /** generate results for some core queries that do not depend on the main processing loop
      * running*/
@@ -468,7 +468,7 @@ class CommonCore: public Core, public BrokerBase {
     */
     std::string federateQuery(const FederateState* fed,
                               const std::string& queryStr,
-                              bool synchronous) const;
+                              bool force_ordering) const;
 
     /** send an error code and message to all the federates*/
     void sendErrorToFederates(int error_code, const std::string& message);

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -218,7 +218,9 @@ class CommonCore: public Core, public BrokerBase {
 
     virtual void setLogFile(const std::string& lfile) override final;
 
-    virtual std::string query(const std::string& target, const std::string& queryStr, query_synch_mode mode) override;
+    virtual std::string query(const std::string& target,
+                              const std::string& queryStr,
+                              query_synch_mode mode) override;
     virtual void
         setQueryCallback(local_federate_id federateID,
                          std::function<std::string(const std::string&)> queryFunction) override;
@@ -363,7 +365,7 @@ class CommonCore: public Core, public BrokerBase {
                               bool reset,
                               bool synchronous) const;
     /** generate results for core queries*/
-    std::string coreQuery(const std::string& queryStr,bool synchronous) const;
+    std::string coreQuery(const std::string& queryStr, bool synchronous) const;
 
     /** generate results for some core queries that do not depend on the main processing loop
      * running*/
@@ -464,7 +466,9 @@ class CommonCore: public Core, public BrokerBase {
     @return "#wait" if the lock cannot be granted immediately and no result can be obtained
     otherwise an answer to the query
     */
-    std::string federateQuery(const FederateState* fed, const std::string& queryStr, bool synchronous) const;
+    std::string federateQuery(const FederateState* fed,
+                              const std::string& queryStr,
+                              bool synchronous) const;
 
     /** send an error code and message to all the federates*/
     void sendErrorToFederates(int error_code, const std::string& message);

--- a/src/helics/core/Core.hpp
+++ b/src/helics/core/Core.hpp
@@ -723,7 +723,7 @@ class Core {
     return until the query is answered so use with caution
     */
     virtual std::string
-        query(const std::string& target, const std::string& queryStr, query_synch_mode mode) = 0;
+        query(const std::string& target, const std::string& queryStr, helics_query_mode mode) = 0;
 
     /** supply a query callback function
     @details the intention of the query callback is to allow federates to answer particular requests

--- a/src/helics/core/Core.hpp
+++ b/src/helics/core/Core.hpp
@@ -718,7 +718,7 @@ class Core {
     target can also be "global" to query a global value stored in the broker
     @param target the specific target of the query
     @param queryStr the actual query
-    @param mode
+    @param mode the synchronization mode for the query
     @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */

--- a/src/helics/core/Core.hpp
+++ b/src/helics/core/Core.hpp
@@ -718,7 +718,7 @@ class Core {
     target can also be "global" to query a global value stored in the broker
     @param target the specific target of the query
     @param queryStr the actual query
-    @param mode 
+    @param mode
     @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */

--- a/src/helics/core/Core.hpp
+++ b/src/helics/core/Core.hpp
@@ -718,10 +718,12 @@ class Core {
     target can also be "global" to query a global value stored in the broker
     @param target the specific target of the query
     @param queryStr the actual query
+    @param mode 
     @return a string containing the response to the query.  Query is a blocking call and will not
     return until the query is answered so use with caution
     */
-    virtual std::string query(const std::string& target, const std::string& queryStr) = 0;
+    virtual std::string
+        query(const std::string& target, const std::string& queryStr, query_synch_mode mode) = 0;
 
     /** supply a query callback function
     @details the intention of the query callback is to allow federates to answer particular requests

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -574,40 +574,12 @@ void CoreBroker::processPriorityCommand(ActionMessage&& command)
         case CMD_REG_ROUTE:
             break;
         case CMD_BROKER_QUERY:
-            if (!connectionEstablished) {
-                earlyMessages.push_back(std::move(command));
-                break;
-            }
-            if (command.dest_id == global_broker_id_local ||
-                (isRootc && command.dest_id == parent_broker_id)) {
-                processLocalQuery(command);
-            } else {
-                routeMessage(command);
-            }
-            break;
         case CMD_QUERY:
-            processQuery(command);
-            break;
         case CMD_QUERY_REPLY:
-            if (command.dest_id == global_broker_id_local) {
-                processQueryResponse(command);
-            } else {
-                transmit(getRoute(command.dest_id), command);
-            }
-            break;
         case CMD_SET_GLOBAL:
-            if (isRootc) {
-                global_values[command.name] = command.getString(0);
-            } else {
-                if ((global_broker_id_local.isValid()) &&
-                    (global_broker_id_local != parent_broker_id)) {
-                    transmit(parent_route_id, command);
-                } else {
-                    // delay the response if we are not fully registered yet
-                    delayTransmitQueue.push(command);
-                }
-            }
+            processQueryCommand(command);
             break;
+        
         default:
             // must not have been a priority command
             break;
@@ -1181,6 +1153,10 @@ void CoreBroker::processCommand(ActionMessage&& command)
             break;
         case CMD_BROKER_CONFIGURE:
             processBrokerConfigureCommands(command);
+            break;
+        case CMD_BROKER_QUERY_SYNCHRONOUS:
+        case CMD_QUERY_SYNCHRONOUS:
+            processQueryCommand(command);
             break;
         default:
             if (command.dest_id != global_broker_id_local) {
@@ -2441,11 +2417,13 @@ void CoreBroker::setLogFile(const std::string& lfile)
 }
 
 // public query function
-std::string CoreBroker::query(const std::string& target, const std::string& queryStr)
+std::string
+    CoreBroker::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
 {
     auto gid = global_id.load();
     if (target == "broker" || target == getIdentifier() || target.empty()) {
-        ActionMessage querycmd(CMD_BROKER_QUERY);
+        ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
+                                                                CMD_BROKER_QUERY_SYNCHRONOUS);
         querycmd.source_id = querycmd.dest_id = gid;
         auto index = ++queryCounter;
         querycmd.messageID = index;
@@ -2460,7 +2438,8 @@ std::string CoreBroker::query(const std::string& target, const std::string& quer
         if (isRootc) {
             return "#na";
         }
-        ActionMessage querycmd(CMD_BROKER_QUERY);
+        ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
+                                                                CMD_BROKER_QUERY_SYNCHRONOUS);
         querycmd.source_id = gid;
         querycmd.messageID = ++queryCounter;
         querycmd.payload = queryStr;
@@ -2471,7 +2450,8 @@ std::string CoreBroker::query(const std::string& target, const std::string& quer
         return ret;
     }
     if ((target == "root") || (target == "rootbroker")) {
-        ActionMessage querycmd(CMD_BROKER_QUERY);
+        ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
+                                                                CMD_BROKER_QUERY_SYNCHRONOUS);
         querycmd.source_id = gid;
         auto index = ++queryCounter;
         querycmd.messageID = index;
@@ -2484,7 +2464,7 @@ std::string CoreBroker::query(const std::string& target, const std::string& quer
         return ret;
     }
 
-    ActionMessage querycmd(CMD_QUERY);
+    ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_QUERY : CMD_QUERY_SYNCHRONOUS);
     querycmd.source_id = gid;
     auto index = ++queryCounter;
     querycmd.messageID = index;
@@ -2530,7 +2510,7 @@ static const std::map<std::string, std::pair<std::uint16_t, bool>> mapIndex{
     {"global_time_debugging", {global_time_debugging, true}},
 };
 
-std::string CoreBroker::generateQueryAnswer(const std::string& request)
+std::string CoreBroker::generateQueryAnswer(const std::string& request, bool synchronous)
 {
     if (request == "isinit") {
         return (brokerState >= broker_state_t::operating) ? std::string("true") :
@@ -2651,7 +2631,7 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request)
             }
         }
 
-        initializeMapBuilder(request, index, mi->second.second);
+        initializeMapBuilder(request, index, mi->second.second, synchronous);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
             if (!mi->second.second) {
                 auto center = generateMapObjectCounter();
@@ -2749,7 +2729,10 @@ std::string CoreBroker::getNameList(std::string gidString) const
     return gidString;
 }
 
-void CoreBroker::initializeMapBuilder(const std::string& request, std::uint16_t index, bool reset)
+void CoreBroker::initializeMapBuilder(const std::string& request,
+                                      std::uint16_t index,
+                                      bool reset,
+                                      bool synchronous)
 {
     if (!isValidIndex(index, mapBuilders)) {
         mapBuilders.resize(index + 1);
@@ -2767,7 +2750,7 @@ void CoreBroker::initializeMapBuilder(const std::string& request, std::uint16_t 
         base["parent"] = higher_broker_id.baseValue();
     }
     base["brokers"] = Json::arrayValue;
-    ActionMessage queryReq(CMD_BROKER_QUERY);
+    ActionMessage queryReq(synchronous ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
     queryReq.payload = request;
     queryReq.source_id = global_broker_id_local;
     queryReq.counter = index;  // indicating which processing to use
@@ -2864,7 +2847,9 @@ void CoreBroker::processLocalQuery(const ActionMessage& m)
     queryRep.source_id = global_broker_id_local;
     queryRep.dest_id = m.source_id;
     queryRep.messageID = m.messageID;
-    queryRep.payload = generateQueryAnswer(m.payload);
+    queryRep.payload = generateQueryAnswer(m.payload,
+                                           m.action() == CMD_QUERY_SYNCHRONOUS ||
+                                               m.action() == CMD_BROKER_QUERY_SYNCHRONOUS);
     queryRep.counter = m.counter;
     if (queryRep.payload == "#wait") {
         std::get<1>(mapBuilders[mapIndex.at(m.payload).first]).push_back(queryRep);
@@ -2916,6 +2901,49 @@ static std::string checkBrokerQuery(const BasicBrokerInfo& brk, const std::strin
         }
     }
     return response;
+}
+
+void CoreBroker::processQueryCommand(ActionMessage& cmd)
+{
+    switch (cmd.action()) {
+        case CMD_BROKER_QUERY:
+        case CMD_BROKER_QUERY_SYNCHRONOUS:
+            if (!connectionEstablished) {
+                earlyMessages.push_back(std::move(cmd));
+                break;
+            }
+            if (cmd.dest_id == global_broker_id_local ||
+                (isRootc && cmd.dest_id == parent_broker_id)) {
+                processLocalQuery(cmd);
+            } else {
+                routeMessage(cmd);
+            }
+            break;
+        case CMD_QUERY:
+        case CMD_QUERY_SYNCHRONOUS:
+            processQuery(cmd);
+            break;
+        case CMD_QUERY_REPLY:
+            if (cmd.dest_id == global_broker_id_local) {
+                processQueryResponse(cmd);
+            } else {
+                transmit(getRoute(cmd.dest_id), cmd);
+            }
+            break;
+        case CMD_SET_GLOBAL:
+            if (isRootc) {
+                global_values[cmd.name] = cmd.getString(0);
+            } else {
+                if ((global_broker_id_local.isValid()) &&
+                    (global_broker_id_local != parent_broker_id)) {
+                    transmit(parent_route_id, cmd);
+                } else {
+                    // delay the response if we are not fully registered yet
+                    delayTransmitQueue.push(cmd);
+                }
+            }
+            break;
+    }
 }
 
 void CoreBroker::processQuery(ActionMessage& m)

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -1154,8 +1154,8 @@ void CoreBroker::processCommand(ActionMessage&& command)
         case CMD_BROKER_CONFIGURE:
             processBrokerConfigureCommands(command);
             break;
-        case CMD_BROKER_QUERY_SYNCHRONOUS:
-        case CMD_QUERY_SYNCHRONOUS:
+        case CMD_BROKER_QUERY_ORDERED:
+        case CMD_QUERY_ORDERED:
             processQueryCommand(command);
             break;
         default:
@@ -2418,12 +2418,12 @@ void CoreBroker::setLogFile(const std::string& lfile)
 
 // public query function
 std::string
-    CoreBroker::query(const std::string& target, const std::string& queryStr, query_synch_mode mode)
+    CoreBroker::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
 {
     auto gid = global_id.load();
     if (target == "broker" || target == getIdentifier() || target.empty()) {
         ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
-                                                                CMD_BROKER_QUERY_SYNCHRONOUS);
+                                                                CMD_BROKER_QUERY_ORDERED);
         querycmd.source_id = querycmd.dest_id = gid;
         auto index = ++queryCounter;
         querycmd.messageID = index;
@@ -2439,7 +2439,7 @@ std::string
             return "#na";
         }
         ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
-                                                                CMD_BROKER_QUERY_SYNCHRONOUS);
+                                                                CMD_BROKER_QUERY_ORDERED);
         querycmd.source_id = gid;
         querycmd.messageID = ++queryCounter;
         querycmd.payload = queryStr;
@@ -2451,7 +2451,7 @@ std::string
     }
     if ((target == "root") || (target == "rootbroker")) {
         ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_BROKER_QUERY :
-                                                                CMD_BROKER_QUERY_SYNCHRONOUS);
+                                                                CMD_BROKER_QUERY_ORDERED);
         querycmd.source_id = gid;
         auto index = ++queryCounter;
         querycmd.messageID = index;
@@ -2464,7 +2464,7 @@ std::string
         return ret;
     }
 
-    ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_QUERY : CMD_QUERY_SYNCHRONOUS);
+    ActionMessage querycmd(mode == helics_query_mode_fast ? CMD_QUERY : CMD_QUERY_ORDERED);
     querycmd.source_id = gid;
     auto index = ++queryCounter;
     querycmd.messageID = index;
@@ -2510,7 +2510,7 @@ static const std::map<std::string, std::pair<std::uint16_t, bool>> mapIndex{
     {"global_time_debugging", {global_time_debugging, true}},
 };
 
-std::string CoreBroker::generateQueryAnswer(const std::string& request, bool synchronous)
+std::string CoreBroker::generateQueryAnswer(const std::string& request, bool force_ordering)
 {
     if (request == "isinit") {
         return (brokerState >= broker_state_t::operating) ? std::string("true") :
@@ -2631,7 +2631,7 @@ std::string CoreBroker::generateQueryAnswer(const std::string& request, bool syn
             }
         }
 
-        initializeMapBuilder(request, index, mi->second.second, synchronous);
+        initializeMapBuilder(request, index, mi->second.second, force_ordering);
         if (std::get<0>(mapBuilders[index]).isCompleted()) {
             if (!mi->second.second) {
                 auto center = generateMapObjectCounter();
@@ -2732,7 +2732,7 @@ std::string CoreBroker::getNameList(std::string gidString) const
 void CoreBroker::initializeMapBuilder(const std::string& request,
                                       std::uint16_t index,
                                       bool reset,
-                                      bool synchronous)
+                                      bool force_ordering)
 {
     if (!isValidIndex(index, mapBuilders)) {
         mapBuilders.resize(index + 1);
@@ -2750,7 +2750,7 @@ void CoreBroker::initializeMapBuilder(const std::string& request,
         base["parent"] = higher_broker_id.baseValue();
     }
     base["brokers"] = Json::arrayValue;
-    ActionMessage queryReq(synchronous ? CMD_BROKER_QUERY_SYNCHRONOUS : CMD_BROKER_QUERY);
+    ActionMessage queryReq(force_ordering ? CMD_BROKER_QUERY_ORDERED : CMD_BROKER_QUERY);
     queryReq.payload = request;
     queryReq.source_id = global_broker_id_local;
     queryReq.counter = index;  // indicating which processing to use
@@ -2848,8 +2848,8 @@ void CoreBroker::processLocalQuery(const ActionMessage& m)
     queryRep.dest_id = m.source_id;
     queryRep.messageID = m.messageID;
     queryRep.payload = generateQueryAnswer(m.payload,
-                                           m.action() == CMD_QUERY_SYNCHRONOUS ||
-                                               m.action() == CMD_BROKER_QUERY_SYNCHRONOUS);
+                                           m.action() == CMD_QUERY_ORDERED ||
+                                               m.action() == CMD_BROKER_QUERY_ORDERED);
     queryRep.counter = m.counter;
     if (queryRep.payload == "#wait") {
         std::get<1>(mapBuilders[mapIndex.at(m.payload).first]).push_back(queryRep);
@@ -2907,7 +2907,7 @@ void CoreBroker::processQueryCommand(ActionMessage& cmd)
 {
     switch (cmd.action()) {
         case CMD_BROKER_QUERY:
-        case CMD_BROKER_QUERY_SYNCHRONOUS:
+        case CMD_BROKER_QUERY_ORDERED:
             if (!connectionEstablished) {
                 earlyMessages.push_back(std::move(cmd));
                 break;
@@ -2920,7 +2920,7 @@ void CoreBroker::processQueryCommand(ActionMessage& cmd)
             }
             break;
         case CMD_QUERY:
-        case CMD_QUERY_SYNCHRONOUS:
+        case CMD_QUERY_ORDERED:
             processQuery(cmd);
             break;
         case CMD_QUERY_REPLY:

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -579,7 +579,7 @@ void CoreBroker::processPriorityCommand(ActionMessage&& command)
         case CMD_SET_GLOBAL:
             processQueryCommand(command);
             break;
-        
+
         default:
             // must not have been a priority command
             break;

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -2417,8 +2417,9 @@ void CoreBroker::setLogFile(const std::string& lfile)
 }
 
 // public query function
-std::string
-    CoreBroker::query(const std::string& target, const std::string& queryStr, helics_query_mode mode)
+std::string CoreBroker::query(const std::string& target,
+                              const std::string& queryStr,
+                              helics_query_mode mode)
 {
     auto gid = global_id.load();
     if (target == "broker" || target == getIdentifier() || target.empty()) {

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -352,7 +352,10 @@ class CoreBroker: public Broker, public BrokerBase {
 
     //   bool updateSourceFilterOperator (ActionMessage &m);
     /** generate a JSON string containing one of the data Maps*/
-    void initializeMapBuilder(const std::string& request, std::uint16_t index, bool reset, bool synchronous);
+    void initializeMapBuilder(const std::string& request,
+                              std::uint16_t index,
+                              bool reset,
+                              bool synchronous);
 
     /** send an error code to all direct cores*/
     void sendErrorToImmediateBrokers(int error_code);

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -285,7 +285,7 @@ class CoreBroker: public Broker, public BrokerBase {
     virtual void setLogFile(const std::string& lfile) override final;
     virtual std::string query(const std::string& target,
                               const std::string& queryStr,
-                              query_synch_mode mode = helics_query_mode_fast) override final;
+                              helics_query_mode mode = helics_query_mode_fast) override final;
     virtual void setGlobal(const std::string& valueName, const std::string& value) override final;
     virtual void makeConnections(const std::string& file) override final;
     virtual void dataLink(const std::string& publication, const std::string& input) override final;
@@ -332,7 +332,7 @@ class CoreBroker: public Broker, public BrokerBase {
     /** generate an answer to a local query*/
     void processLocalQuery(const ActionMessage& m);
     /** generate an actual response string to a query*/
-    std::string generateQueryAnswer(const std::string& request, bool synchronous);
+    std::string generateQueryAnswer(const std::string& request, bool force_ordering);
     /** generate a list of names of interfaces from a list of global_ids in a string*/
     std::string getNameList(std::string gidString) const;
     /** locate the route to take to a particular federate*/
@@ -355,7 +355,7 @@ class CoreBroker: public Broker, public BrokerBase {
     void initializeMapBuilder(const std::string& request,
                               std::uint16_t index,
                               bool reset,
-                              bool synchronous);
+                              bool force_ordering);
 
     /** send an error code to all direct cores*/
     void sendErrorToImmediateBrokers(int error_code);

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -284,7 +284,8 @@ class CoreBroker: public Broker, public BrokerBase {
     virtual void setLoggingLevel(int logLevel) override final;
     virtual void setLogFile(const std::string& lfile) override final;
     virtual std::string query(const std::string& target,
-                              const std::string& queryStr) override final;
+                              const std::string& queryStr,
+                              query_synch_mode mode = helics_query_mode_fast) override final;
     virtual void setGlobal(const std::string& valueName, const std::string& value) override final;
     virtual void makeConnections(const std::string& file) override final;
     virtual void dataLink(const std::string& publication, const std::string& input) override final;
@@ -321,6 +322,8 @@ class CoreBroker: public Broker, public BrokerBase {
     void checkForNamedInterface(ActionMessage& command);
     /** remove a named target from an interface*/
     void removeNamedTarget(ActionMessage& command);
+    /** handle the processing for a query command*/
+    void processQueryCommand(ActionMessage& cmd);
     /** answer a query or route the message the appropriate location*/
     void processQuery(ActionMessage& m);
 
@@ -329,7 +332,7 @@ class CoreBroker: public Broker, public BrokerBase {
     /** generate an answer to a local query*/
     void processLocalQuery(const ActionMessage& m);
     /** generate an actual response string to a query*/
-    std::string generateQueryAnswer(const std::string& request);
+    std::string generateQueryAnswer(const std::string& request, bool synchronous);
     /** generate a list of names of interfaces from a list of global_ids in a string*/
     std::string getNameList(std::string gidString) const;
     /** locate the route to take to a particular federate*/
@@ -349,7 +352,7 @@ class CoreBroker: public Broker, public BrokerBase {
 
     //   bool updateSourceFilterOperator (ActionMessage &m);
     /** generate a JSON string containing one of the data Maps*/
-    void initializeMapBuilder(const std::string& request, std::uint16_t index, bool reset);
+    void initializeMapBuilder(const std::string& request, std::uint16_t index, bool reset, bool synchronous);
 
     /** send an error code to all direct cores*/
     void sendErrorToImmediateBrokers(int error_code);

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1123,7 +1123,7 @@ message_processing_result FederateState::processActionMessage(ActionMessage& cmd
         case CMD_INTERFACE_CONFIGURE:
             setInterfaceProperty(cmd);
             break;
-        case CMD_QUERY_SYNCHRONOUS:
+        case CMD_QUERY_ORDERED:
         case CMD_QUERY: {
             std::string repStr;
             ActionMessage queryResp(CMD_QUERY_REPLY);
@@ -1710,10 +1710,10 @@ std::string FederateState::processQueryActual(const std::string& query) const
     return "#invalid";
 }
 
-std::string FederateState::processQuery(const std::string& query, bool synchronous) const
+std::string FederateState::processQuery(const std::string& query, bool force_ordering) const
 {
     std::string qstring;
-    if (!synchronous &&
+    if (!force_ordering &&
         (query == "publications" || query == "inputs" || query == "endpoints" ||
          query == "global_state")) {  // these never need to be locked
         qstring = processQueryActual(query);

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1713,14 +1713,15 @@ std::string FederateState::processQueryActual(const std::string& query) const
 std::string FederateState::processQuery(const std::string& query, bool synchronous) const
 {
     std::string qstring;
-    if (!synchronous && (query == "publications" || query == "inputs" || query == "endpoints" ||
-        query == "global_state")) {  // these never need to be locked
+    if (!synchronous &&
+        (query == "publications" || query == "inputs" || query == "endpoints" ||
+         query == "global_state")) {  // these never need to be locked
         qstring = processQueryActual(query);
     } else if ((query == "queries") || (query == "available_queries")) {
         qstring =
             "publications;inputs;endpoints;interfaces;subscriptions;current_state;global_state;dependencies;timeconfig;config;dependents;current_time";
     } else {  // the rest might to prevent a race condition
-       if (try_lock()) {
+        if (try_lock()) {
             qstring = processQueryActual(query);
             unlock();
         } else {

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -376,7 +376,7 @@ class FederateState {
     @param synchronous true if the query should be processed in a synchronous way
     @return the resulting string from the query or "#wait" if the federate is not available to
     answer immediately*/
-    std::string processQuery(const std::string& query, bool synchronous=false) const;
+    std::string processQuery(const std::string& query, bool synchronous = false) const;
     /** check if a value should be published or not and if needed archive it as a changed value for
     future change detection
     @param pub_id the handle of the publication

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -373,9 +373,10 @@ class FederateState {
     }
     /** generate the result of a query string
     @param query a query string
+    @param synchronous true if the query should be processed in a synchronous way
     @return the resulting string from the query or "#wait" if the federate is not available to
     answer immediately*/
-    std::string processQuery(const std::string& query) const;
+    std::string processQuery(const std::string& query, bool synchronous=false) const;
     /** check if a value should be published or not and if needed archive it as a changed value for
     future change detection
     @param pub_id the handle of the publication

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -373,10 +373,10 @@ class FederateState {
     }
     /** generate the result of a query string
     @param query a query string
-    @param synchronous true if the query should be processed in a synchronous way
+    @param force_ordering true if the query should be processed in a force_ordering way
     @return the resulting string from the query or "#wait" if the federate is not available to
     answer immediately*/
-    std::string processQuery(const std::string& query, bool synchronous = false) const;
+    std::string processQuery(const std::string& query, bool force_ordering = false) const;
     /** check if a value should be published or not and if needed archive it as a changed value for
     future change detection
     @param pub_id the handle of the publication

--- a/src/helics/core/flagOperations.hpp
+++ b/src/helics/core/flagOperations.hpp
@@ -24,7 +24,7 @@ enum operation_flags : uint16_t {
     optional_flag = 8,  //!< flag indicating that a connection is optional and may not be matched
     clone_flag =
         9,  //!< flag indicating the filter is a clone filter or the data needs to be cloned
-    extra_flag2 = 8,  //!< extra flag
+    extra_flag2 = 10,  //!< extra flag
     destination_processing_flag =
         11,  //!< flag indicating the message is for destination processing
     disconnected_flag = 12,  //!< flag indicating that a broker/federate is disconnected

--- a/src/helics/cpp98/Broker.hpp
+++ b/src/helics/cpp98/Broker.hpp
@@ -144,7 +144,7 @@ class Broker {
   specific name of a federate, core, or broker
   @param queryStr a string with the query, see other documentation for specific properties to
   query, can be defined by the federate
-  @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+  @param mode the ordering mode to use for the query (fast for priority channels, ordered for normal
   channels ordered with all other messages)
   @return a string with the value requested.  this is either going to be a vector of strings value
   or a JSON string stored in the first element of the vector.  The string "#invalid" is returned

--- a/src/helics/cpp98/Broker.hpp
+++ b/src/helics/cpp98/Broker.hpp
@@ -144,14 +144,20 @@ class Broker {
   specific name of a federate, core, or broker
   @param queryStr a string with the query, see other documentation for specific properties to
   query, can be defined by the federate
+  @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal channels ordered with all other messages)
   @return a string with the value requested.  this is either going to be a vector of strings value
   or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
   if the query was not valid
   */
-    std::string query(const std::string& target, const std::string& queryStr) const
+    std::string query(const std::string& target,
+                      const std::string& queryStr,
+                      helics_query_mode mode = helics_query_mode_fast) const
     {
         // returns helics_query
         helics_query q = helicsCreateQuery(target.c_str(), queryStr.c_str());
+        if (mode != helics_query_mode_fast) {
+            helicsQuerySetOrdering(q, mode, HELICS_IGNORE_ERROR);
+        }
         std::string result(helicsQueryBrokerExecute(q, broker, hThrowOnError()));
         helicsQueryFree(q);
         return result;

--- a/src/helics/cpp98/Broker.hpp
+++ b/src/helics/cpp98/Broker.hpp
@@ -144,7 +144,8 @@ class Broker {
   specific name of a federate, core, or broker
   @param queryStr a string with the query, see other documentation for specific properties to
   query, can be defined by the federate
-  @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal channels ordered with all other messages)
+  @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+  channels ordered with all other messages)
   @return a string with the value requested.  this is either going to be a vector of strings value
   or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
   if the query was not valid

--- a/src/helics/cpp98/Core.hpp
+++ b/src/helics/cpp98/Core.hpp
@@ -134,13 +134,14 @@ channels ordered with all other messages)
 or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
 if the query was not valid
 */
-    std::string query(const std::string& target, const std::string& queryStr, helics_query_mode mode=helics_query_mode_fast) const
+    std::string query(const std::string& target,
+                      const std::string& queryStr,
+                      helics_query_mode mode = helics_query_mode_fast) const
     {
         // returns helics_query
         helics_query q = helicsCreateQuery(target.c_str(), queryStr.c_str());
-        if (mode != helics_query_mode_fast)
-        {
-            helicsQuerySetOrdering(q,mode,HELICS_IGNORE_ERROR);
+        if (mode != helics_query_mode_fast) {
+            helicsQuerySetOrdering(q, mode, HELICS_IGNORE_ERROR);
         }
         std::string result(helicsQueryCoreExecute(q, core, hThrowOnError()));
         helicsQueryFree(q);

--- a/src/helics/cpp98/Core.hpp
+++ b/src/helics/cpp98/Core.hpp
@@ -128,14 +128,20 @@ on the size of the federation and the specific string being queried
 specific name of a federate, core, or broker
 @param queryStr a string with the query, see other documentation for specific properties to
 query, can be defined by the federate
+@param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+channels ordered with all other messages)
 @return a string with the value requested.  this is either going to be a vector of strings value
 or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
 if the query was not valid
 */
-    std::string query(const std::string& target, const std::string& queryStr) const
+    std::string query(const std::string& target, const std::string& queryStr, helics_query_mode mode=helics_query_mode_fast) const
     {
         // returns helics_query
         helics_query q = helicsCreateQuery(target.c_str(), queryStr.c_str());
+        if (mode != helics_query_mode_fast)
+        {
+            helicsQuerySetOrdering(q,mode,HELICS_IGNORE_ERROR);
+        }
         std::string result(helicsQueryCoreExecute(q, core, hThrowOnError()));
         helicsQueryFree(q);
         return result;

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -465,14 +465,21 @@ class Federate {
     specific name of a federate, core, or broker
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
+    @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+    channels ordered with all other messages)
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string query(const std::string& target, const std::string& queryStr) const
+    std::string query(const std::string& target,
+                      const std::string& queryStr,
+                      helics_query_mode mode = helics_query_mode_fast) const
     {
         // returns helics_query
         helics_query q = helicsCreateQuery(target.c_str(), queryStr.c_str());
+        if (mode != helics_query_mode_fast) {
+            helicsQuerySetOrdering(q, mode, HELICS_IGNORE_ERROR);
+        }
         std::string result(helicsQueryExecute(q, fed, hThrowOnError()));
         helicsQueryFree(q);
         return result;
@@ -485,14 +492,20 @@ class Federate {
 
     @param queryStr a string with the query, see other documentation for specific properties to
     query, can be defined by the federate
+    @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+    channels ordered with all other messages)
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
     */
-    std::string query(const std::string& queryStr) const
+    std::string query(const std::string& queryStr,
+                      helics_query_mode mode = helics_query_mode_fast) const
     {
         // returns helics_query
         helics_query q = helicsCreateQuery(HELICS_NULL_POINTER, queryStr.c_str());
+        if (mode != helics_query_mode_fast) {
+            helicsQuerySetOrdering(q, mode, HELICS_IGNORE_ERROR);
+        }
         std::string result(helicsQueryExecute(q, fed, hThrowOnError()));
         helicsQueryFree(q);
         return result;

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -465,8 +465,8 @@ class Federate {
     specific name of a federate, core, or broker
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
-    @param mode the ordering mode to use for the query (fast for priority channels, ordered for normal
-    channels ordered with all other messages)
+    @param mode the ordering mode to use for the query (fast for priority channels, ordered for
+    normal channels ordered with all other messages)
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid
@@ -492,8 +492,8 @@ class Federate {
 
     @param queryStr a string with the query, see other documentation for specific properties to
     query, can be defined by the federate
-    @param mode the ordering mode to use for the query (fast for priority channels, ordered for normal
-    channels ordered with all other messages)
+    @param mode the ordering mode to use for the query (fast for priority channels, ordered for
+    normal channels ordered with all other messages)
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
     if the query was not valid

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -465,7 +465,7 @@ class Federate {
     specific name of a federate, core, or broker
     @param queryStr a string with the query see other documentation for specific properties to
     query, can be defined by the federate
-    @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+    @param mode the ordering mode to use for the query (fast for priority channels, ordered for normal
     channels ordered with all other messages)
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned
@@ -492,7 +492,7 @@ class Federate {
 
     @param queryStr a string with the query, see other documentation for specific properties to
     query, can be defined by the federate
-    @param mode the ordering mode to use for the query (fast-priority channels, ordered for normal
+    @param mode the ordering mode to use for the query (fast for priority channels, ordered for normal
     channels ordered with all other messages)
     @return a string with the value requested.  this is either going to be a vector of strings value
     or a JSON string stored in the first element of the vector.  The string "#invalid" is returned

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -306,8 +306,9 @@ typedef enum {
 } helics_filter_type;
 
 /** enumeration of sequencing modes for queries
-fast is the default meaning the query travels along priority channels and takes precedence of over existing messages
-ordered means it follows normal priority patterns and will be ordered along with existing messages
+fast is the default meaning the query travels along priority channels and takes precedence of over
+existing messages ordered means it follows normal priority patterns and will be ordered along with
+existing messages
 */
 typedef enum { helics_query_mode_fast = 0, helics_query_mode_ordered = 1 } query_synch_mode;
 

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -305,6 +305,12 @@ typedef enum {
 
 } helics_filter_type;
 
+/** enumeration of sequencing modes for queries
+fast is the default meaning the query travels along priority channels and takes precedence of over existing messages
+ordered means it follows normal priority patterns and will be ordered along with existing messages
+*/
+typedef enum { helics_query_mode_fast = 0, helics_query_mode_ordered = 1 } query_synch_mode;
+
 #ifdef __cplusplus
 } /* end of extern "C" { */
 #endif

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -310,7 +310,7 @@ fast is the default, meaning the query travels along priority channels and takes
 existing messages; ordered means it follows normal priority patterns and will be ordered along with
 existing messages
 */
-typedef enum { helics_query_mode_fast = 0, helics_query_mode_ordered = 1 } query_synch_mode;
+typedef enum { helics_query_mode_fast = 0, helics_query_mode_ordered = 1 } helics_query_mode;
 
 #ifdef __cplusplus
 } /* end of extern "C" { */

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -306,8 +306,8 @@ typedef enum {
 } helics_filter_type;
 
 /** enumeration of sequencing modes for queries
-fast is the default meaning the query travels along priority channels and takes precedence of over
-existing messages ordered means it follows normal priority patterns and will be ordered along with
+fast is the default, meaning the query travels along priority channels and takes precedence of over
+existing messages; ordered means it follows normal priority patterns and will be ordered along with
 existing messages
 */
 typedef enum { helics_query_mode_fast = 0, helics_query_mode_ordered = 1 } query_synch_mode;

--- a/src/helics/shared_api_library/helics.h
+++ b/src/helics/shared_api_library/helics.h
@@ -1524,7 +1524,6 @@ HELICS_EXPORT void helicsQuerySetTarget(helics_query query, const char* target, 
  */
 HELICS_EXPORT void helicsQuerySetQueryString(helics_query query, const char* queryString, helics_error* err);
 
-
 /**
  * Update the ordering mode of the query, fast runs on priority channels, ordered goes on normal channels but goes in sequence
  *

--- a/src/helics/shared_api_library/helics.h
+++ b/src/helics/shared_api_library/helics.h
@@ -1524,6 +1524,19 @@ HELICS_EXPORT void helicsQuerySetTarget(helics_query query, const char* target, 
  */
 HELICS_EXPORT void helicsQuerySetQueryString(helics_query query, const char* queryString, helics_error* err);
 
+
+/**
+ * Update the ordering mode of the query, fast runs on priority channels, ordered goes on normal channels but goes in sequence
+ *
+ * @param query The query object to change the order for.
+ * @param mode 0 for fast, 1 for ordered
+ *
+ * @forcpponly
+ * @param[in,out] err An error object that will contain an error code and string if any error occurred during the execution of the function.
+ * @endforcpponly
+ */
+HELICS_EXPORT void helicsQuerySetOrdering(helics_query query, int32_t mode, helics_error* err);
+
 /**
  * Free the memory associated with a query object.
  */

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -854,9 +854,9 @@ const char* helicsQueryExecute(helics_query query, helics_federate fed, helics_e
         return invalidStringConst;
     }
     if (queryObj->target.empty()) {
-        queryObj->response = fedObj->query(queryObj->query);
+        queryObj->response = fedObj->query(queryObj->query, queryObj->mode);
     } else {
-        queryObj->response = fedObj->query(queryObj->target, queryObj->query);
+        queryObj->response = fedObj->query(queryObj->target, queryObj->query, queryObj->mode);
     }
 
     return queryObj->response.c_str();
@@ -873,7 +873,7 @@ const char* helicsQueryCoreExecute(helics_query query, helics_core core, helics_
         return invalidStringConst;
     }
     try {
-        queryObj->response = coreObj->query(queryObj->target, queryObj->query);
+        queryObj->response = coreObj->query(queryObj->target, queryObj->query, queryObj->mode);
         return queryObj->response.c_str();
     }
     // LCOV_EXCL_START
@@ -896,7 +896,7 @@ const char* helicsQueryBrokerExecute(helics_query query, helics_broker broker, h
         return invalidStringConst;
     }
     try {
-        queryObj->response = brokerObj->query(queryObj->target, queryObj->query);
+        queryObj->response = brokerObj->query(queryObj->target, queryObj->query, queryObj->mode);
         return queryObj->response.c_str();
     }
     // LCOV_EXCL_START

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -979,6 +979,15 @@ void helicsQuerySetQueryString(helics_query query, const char* queryString, heli
     queryObj->query = AS_STRING(queryString);
 }
 
+void helicsQuerySetOrdering(helics_query query, int32_t mode, helics_error* err)
+{
+    auto* queryObj = getQueryObj(query, err);
+    if (queryObj == nullptr) {
+        return;
+    }
+    queryObj->mode = (mode == 0) ? helics_query_mode_fast : helics_query_mode_ordered;
+}
+
 void helicsQueryFree(helics_query query)
 {
     auto* queryObj = getQueryObj(query, nullptr);

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -141,7 +141,7 @@ class QueryObject {
     std::string response;  //!< the response to the query
     std::shared_ptr<Federate> activeFed;  //!< pointer to the fed with the active Query
     bool activeAsync{false};
-    query_synch_mode mode{helics_query_mode_fast};  //!< the ordering mode used for the query
+    helics_query_mode mode{helics_query_mode_fast};  //!< the ordering mode used for the query
     query_id_t asyncIndexCode;  //!< the index to use for the queryComplete call
     int valid{0};
 };

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -140,8 +140,9 @@ class QueryObject {
     std::string query;  //!< the actual query itself
     std::string response;  //!< the response to the query
     std::shared_ptr<Federate> activeFed;  //!< pointer to the fed with the active Query
-    query_id_t asyncIndexCode;  //!< the index to use for the queryComplete call
     bool activeAsync{false};
+    query_synch_mode mode{helics_query_mode_fast}; //!< the ordering mode used for the query
+    query_id_t asyncIndexCode;  //!< the index to use for the queryComplete call
     int valid{0};
 };
 

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -141,7 +141,7 @@ class QueryObject {
     std::string response;  //!< the response to the query
     std::shared_ptr<Federate> activeFed;  //!< pointer to the fed with the active Query
     bool activeAsync{false};
-    query_synch_mode mode{helics_query_mode_fast}; //!< the ordering mode used for the query
+    query_synch_mode mode{helics_query_mode_fast};  //!< the ordering mode used for the query
     query_id_t asyncIndexCode;  //!< the index to use for the queryComplete call
     int valid{0};
 };

--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -1056,7 +1056,7 @@ TEST_P(federate_global_files, core_global_file_ci_skip)
     EXPECT_EQ(str1, "this is a global1 value");
     str1 = Fed2->query("global", "global1");
     EXPECT_EQ(str1, "this is a global1 value");
-    str1 = cr->query("global", "global1",helics_query_mode_fast);
+    str1 = cr->query("global", "global1", helics_query_mode_fast);
     EXPECT_EQ(str1, "this is a global1 value");
     str1 = brk->query("global", "global1");
     EXPECT_EQ(str1, "this is a global1 value");

--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -1056,7 +1056,7 @@ TEST_P(federate_global_files, core_global_file_ci_skip)
     EXPECT_EQ(str1, "this is a global1 value");
     str1 = Fed2->query("global", "global1");
     EXPECT_EQ(str1, "this is a global1 value");
-    str1 = cr->query("global", "global1");
+    str1 = cr->query("global", "global1",helics_query_mode_fast);
     EXPECT_EQ(str1, "this is a global1 value");
     str1 = brk->query("global", "global1");
     EXPECT_EQ(str1, "this is a global1 value");
@@ -1065,7 +1065,7 @@ TEST_P(federate_global_files, core_global_file_ci_skip)
     EXPECT_EQ(str1, "this is another global value");
     str1 = Fed2->query("global", "global2");
     EXPECT_EQ(str1, "this is another global value");
-    str1 = cr->query("global", "global2");
+    str1 = cr->query("global", "global2", helics_query_mode_fast);
     EXPECT_EQ(str1, "this is another global value");
     str1 = brk->query("global", "global2");
     EXPECT_EQ(str1, "this is another global value");

--- a/tests/helics/shared_library/QueryTests.cpp
+++ b/tests/helics/shared_library/QueryTests.cpp
@@ -40,6 +40,7 @@ TEST_P(query_tests, publication_queries)
     EXPECT_EQ(res, "[pub1;fed0/pub2]");
     helicsQueryFree(q1);
     q1 = helicsCreateQuery(nullptr, "publications");
+    CE(helicsQuerySetOrdering(q1, 1, &err));
     CE(std::string res2 = helicsQueryExecute(q1, vFed2, &err));
     EXPECT_EQ(res2, "[fed1/pub3]");
 

--- a/tests/helics/shared_library/QueryTests_cpp.cpp
+++ b/tests/helics/shared_library/QueryTests_cpp.cpp
@@ -39,7 +39,7 @@ TEST_F(query_tests, exists)
 
     auto core1 = helicscpp::Core(mFed1->getCore());
 
-    res = mFed1->query(core1.getIdentifier(), "exists");
+    res = mFed1->query(core1.getIdentifier(), "exists", helics_query_mode_ordered);
     EXPECT_EQ(res, "true");
 
     res = mFed1->query(helicscpp::Core(mFed2->getCore()).getIdentifier(), "exists");
@@ -52,7 +52,7 @@ TEST_F(query_tests, exists)
     res = brk->query(mFed1->getName(), "exists");
     EXPECT_EQ(res, "true");
 
-    res = brk->query(mFed2->getName(), "exists");
+    res = brk->query(mFed2->getName(), "exists", helics_query_mode_ordered);
     EXPECT_EQ(res, "true");
 
     res = brk->query("root", "exists");
@@ -67,7 +67,7 @@ TEST_F(query_tests, exists)
     res = core1.query(brk->getIdentifier(), "exists");
     EXPECT_EQ(res, "true");
 
-    res = core1.query(mFed1->getName(), "exists");
+    res = core1.query(mFed1->getName(), "exists",helics_query_mode_ordered);
     EXPECT_EQ(res, "true");
 
     res = core1.query(mFed2->getName(), "exists");
@@ -76,7 +76,7 @@ TEST_F(query_tests, exists)
     res = core1.query("root", "exists");
     EXPECT_EQ(res, "true");
 
-    res = core1.query(core1.getIdentifier(), "exists");
+    res = core1.query(core1.getIdentifier(), "exists", helics_query_mode_ordered);
     EXPECT_EQ(res, "true");
 
     res = core1.query(helicscpp::Core(mFed2->getCore()).getIdentifier(), "exists");

--- a/tests/helics/shared_library/QueryTests_cpp.cpp
+++ b/tests/helics/shared_library/QueryTests_cpp.cpp
@@ -67,7 +67,7 @@ TEST_F(query_tests, exists)
     res = core1.query(brk->getIdentifier(), "exists");
     EXPECT_EQ(res, "true");
 
-    res = core1.query(mFed1->getName(), "exists",helics_query_mode_ordered);
+    res = core1.query(mFed1->getName(), "exists", helics_query_mode_ordered);
     EXPECT_EQ(res, "true");
 
     res = core1.query(mFed2->getName(), "exists");

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -917,7 +917,7 @@ TEST_F(query, concurrent_callback)
 
     vFed1->enterExecutingModeAsync();
     auto core = vFed1->getCorePointer();
-    auto res = core->query(vFed1->getName(), "abc",helics_query_mode_fast);
+    auto res = core->query(vFed1->getName(), "abc", helics_query_mode_fast);
     EXPECT_EQ(res, "AAAA");
     vFed2->enterExecutingMode();
     vFed1->enterExecutingModeComplete();

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -42,7 +42,7 @@ TEST_P(query_type, publication_queries)
     vFed1->enterInitializingModeComplete();
 
     auto core = vFed1->getCorePointer();
-    auto res = core->query("fed0", "publications");
+    auto res = core->query("fed0", "publications", helics_query_mode_fast);
     EXPECT_EQ(res, "[pub1;fed0/pub2]");
     auto rvec = helics::vectorizeQueryResult(res);
 
@@ -65,7 +65,7 @@ TEST_P(query_type, broker_queries)
     auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
     auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "federates");
+    auto res = core->query("root", "federates", helics_query_mode_fast);
     std::string str("[");
     str.append(vFed1->getName());
     str.push_back(';');
@@ -117,7 +117,7 @@ TEST_F(query, federate_map)
     auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
     auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "federate_map");
+    auto res = core->query("root", "federate_map", helics_query_mode_fast);
     vFed1->enterInitializingModeAsync();
     vFed2->enterInitializingMode();
     vFed1->enterInitializingModeComplete();
@@ -139,7 +139,7 @@ TEST_F(query, federate_map2)
     auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
     auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "federate_map");
+    auto res = core->query("root", "federate_map", helics_query_mode_fast);
     vFed1->enterInitializingModeAsync();
     vFed2->enterInitializingMode();
     vFed1->enterInitializingModeComplete();
@@ -161,7 +161,7 @@ TEST_F(query, federate_map3)
     auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
     auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "federate_map");
+    auto res = core->query("root", "federate_map", helics_query_mode_fast);
     vFed1->enterInitializingModeAsync();
     vFed2->enterInitializingMode();
     vFed1->enterInitializingModeComplete();
@@ -188,7 +188,7 @@ TEST_F(query, dependency_graph)
     auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
     auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "dependency_graph");
+    auto res = core->query("root", "dependency_graph", helics_query_mode_fast);
     vFed1->enterInitializingModeAsync();
     vFed2->enterInitializingMode();
     vFed1->enterInitializingModeComplete();
@@ -211,12 +211,12 @@ TEST_F(query, dependency_graph_reset)
     auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
     vFed1->registerGlobalPublication<double>("test1");
     auto core = vFed1->getCorePointer();
-    auto res1 = core->query("root", "dependency_graph");
+    auto res1 = core->query("root", "dependency_graph", helics_query_mode_fast);
     vFed2->registerSubscription("test1");
     vFed1->enterInitializingModeAsync();
     vFed2->enterInitializingMode();
     vFed1->enterInitializingModeComplete();
-    auto res2 = core->query("root", "dependency_graph");
+    auto res2 = core->query("root", "dependency_graph", helics_query_mode_fast);
     EXPECT_NE(res1, res2);
     vFed1->finalize();
     vFed2->finalize();
@@ -234,7 +234,7 @@ TEST_F(query, global_time)
     vFed2->enterExecutingMode();
     vFed1->enterExecutingModeComplete();
 
-    auto res = core->query("root", "global_time");
+    auto res = core->query("root", "global_time", helics_query_mode_fast);
 
     auto val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 0U);
@@ -249,7 +249,7 @@ TEST_F(query, global_time)
     vFed1->requestTime(1.0);
     vFed2->requestTimeComplete();
 
-    res = core->query("root", "global_time");
+    res = core->query("root", "global_time", helics_query_mode_fast);
 
     val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 0U);
@@ -389,7 +389,7 @@ TEST_F(query, exists)
     res = brk->query("unknown_fed", "exists");
     EXPECT_EQ(res, "false");
 
-    res = mFed1->getCorePointer()->query("unknown_fed", "exists");
+    res = mFed1->getCorePointer()->query("unknown_fed", "exists", helics_query_mode_fast);
 
     mFed1->finalize();
     mFed2->finalize();
@@ -406,7 +406,7 @@ TEST_F(query, current_state)
     vFed2->enterExecutingMode();
     vFed1->enterExecutingModeComplete();
 
-    auto res = core->query("root", "current_state");
+    auto res = core->query("root", "current_state", helics_query_mode_fast);
 
     auto val = loadJsonStr(res);
     EXPECT_EQ(val["federates"].size(), 2U);
@@ -416,7 +416,7 @@ TEST_F(query, current_state)
     vFed1->localError(-3, "test error");
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    res = core->query("root", "current_state");
+    res = core->query("root", "current_state", helics_query_mode_fast);
 
     val = loadJsonStr(res);
     EXPECT_EQ(val["federates"].size(), 2U);
@@ -428,7 +428,7 @@ TEST_F(query, current_state)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    res = core->query("root", "current_state");
+    res = core->query("root", "current_state", helics_query_mode_fast);
 
     val = loadJsonStr(res);
     EXPECT_EQ(val["federates"].size(), 2U);
@@ -451,7 +451,7 @@ TEST_F(query, global_state)
     vFed2->enterExecutingMode();
     vFed1->enterExecutingModeComplete();
 
-    auto res = core->query("root", "global_state");
+    auto res = core->query("root", "global_state", helics_query_mode_fast);
 
     auto val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 2U);
@@ -461,7 +461,7 @@ TEST_F(query, global_state)
     vFed1->localError(-3, "test error");
 
     EXPECT_THROW(vFed1->requestTime(2.0), helics::HelicsException);
-    res = core->query("root", "global_state");
+    res = core->query("root", "global_state", helics_query_mode_fast);
 
     val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 2U);
@@ -476,7 +476,7 @@ TEST_F(query, global_state)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    res = core->query("root", "global_state");
+    res = core->query("root", "global_state", helics_query_mode_fast);
 
     val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 2U);
@@ -533,7 +533,40 @@ TEST_F(query, data_flow_graph)
     vFed2->enterInitializingMode();
     vFed1->enterInitializingModeComplete();
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "data_flow_graph");
+    auto res = core->query("root", "data_flow_graph", helics_query_mode_fast);
+    auto val = loadJsonStr(res);
+    EXPECT_EQ(val["cores"].size(), 1U);
+    EXPECT_EQ(val["cores"][0]["federates"].size(), 2U);
+    EXPECT_EQ(val["cores"][0]["parent"].asInt(), val["id"].asInt());
+    auto v2 = val["cores"][0]["federates"][1];
+    auto v1 = val["cores"][0]["federates"][0];
+    EXPECT_EQ(v2["parent"].asInt(), val["cores"][0]["id"].asInt());
+    EXPECT_EQ(v2["publications"].size(), 1U);
+    EXPECT_EQ(v1["inputs"].size(), 1U);
+    EXPECT_EQ(v1["inputs"][0]["key"], "ipt1");
+    EXPECT_EQ(v2["publications"][0]["key"], "pub1");
+    EXPECT_EQ(v1["inputs"][0]["sources"].size(), 1U);
+    EXPECT_EQ(v2["publications"][0]["targets"].size(), 1U);
+    core = nullptr;
+    vFed1->finalize();
+    vFed2->finalize();
+    helics::cleanupHelicsLibrary();
+}
+
+TEST_F(query, data_flow_graph_ordered)
+{
+    SetupTest<helics::ValueFederate>("test", 2);
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
+
+    vFed1->registerGlobalInput<double>("ipt1");
+    auto& p1 = vFed2->registerGlobalPublication<double>("pub1");
+    p1.addTarget("ipt1");
+    vFed1->enterInitializingModeAsync();
+    vFed2->enterInitializingMode();
+    vFed1->enterInitializingModeComplete();
+    auto core = vFed1->getCorePointer();
+    auto res = core->query("root", "data_flow_graph", helics_query_mode_ordered);
     auto val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 1U);
     EXPECT_EQ(val["cores"][0]["federates"].size(), 2U);
@@ -568,7 +601,7 @@ TEST_F(query, data_flow_graph_concurrent)
 
     vFed1->enterExecutingModeAsync();
     auto core = vFed1->getCorePointer();
-    auto res = core->query("root", "data_flow_graph");
+    auto res = core->query("root", "data_flow_graph", helics_query_mode_fast);
     auto val = loadJsonStr(res);
     EXPECT_EQ(val["cores"].size(), 1U);
     EXPECT_EQ(val["cores"][0]["federates"].size(), 2U);
@@ -884,11 +917,11 @@ TEST_F(query, concurrent_callback)
 
     vFed1->enterExecutingModeAsync();
     auto core = vFed1->getCorePointer();
-    auto res = core->query(vFed1->getName(), "abc");
+    auto res = core->query(vFed1->getName(), "abc",helics_query_mode_fast);
     EXPECT_EQ(res, "AAAA");
     vFed2->enterExecutingMode();
     vFed1->enterExecutingModeComplete();
-    res = core->query(vFed1->getName(), "bca");
+    res = core->query(vFed1->getName(), "bca", helics_query_mode_fast);
     EXPECT_EQ(res, "BBBB");
     core = nullptr;
     vFed1->finalize();


### PR DESCRIPTION
 which are slower but have more guarantees of order since they travel on the normal priority paths
This is to fix some occasional failures in the app tests related to cloning which I think were caused by the queries getting to the destination before the other messages on occasion since they run on the priority channels.  This could potentially cause some missed endpoints to be loaded for some of the clones.  

