### PR TITLE
CI/workflow changes from develop to helics3

### DIFF
--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
   - name: uname
-    image: alpine
+    image: alpine:3.12
     commands:
       - uname -a
 
@@ -18,7 +18,7 @@ steps:
       - git submodule update --init --recursive
 
   - name: build
-    image: alpine
+    image: alpine:3.12
     commands:
       - apk update
       - apk add --no-cache build-base git bash cmake ninja boost-dev zeromq-dev

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -31,6 +31,16 @@ steps:
       - cmake --build .
       - ctest -L Continuous --output-on-failure
 
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/heads/master
+      - refs/heads/develop
+      - refs/heads/helics3
+      - 'refs/pull/**'
+      - 'refs/tags/**'
+
 ---
 kind: pipeline
 name: arm64
@@ -64,3 +74,13 @@ steps:
       - cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
       - cmake --build .
       - ctest -L Continuous --output-on-failure
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/heads/master
+      - refs/heads/develop
+      - refs/heads/helics3
+      - 'refs/pull/**'
+      - 'refs/tags/**'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -2,6 +2,11 @@ trigger:
   branches:
     exclude:
       - pre-commit/*
+pr:
+  - main
+  - master
+  - develop
+  - helics3
 
 jobs:
   - job: Linux

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -105,11 +105,29 @@ jobs:
           extraFlags: ''
     pool:
       vmImage: $(imageName)
+    variables:
+      BOOST_ROOT: $(Pipeline.Workspace)/ci-libs/boost
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2/download
 
     steps:
       # -----------------------
       # Install dependencies
       # -----------------------
+      - task: Cache@2
+        inputs:
+          path: $(BOOST_ROOT)
+          key: boost
+          cacheHitVar: BOOST_CACHE_RESTORED
+        displayName: Restore Boost cache
+      - bash: |
+          cd $(mktemp -d)
+          curl --location --output "download.tar.bz2" "$BOOST_URL"
+          tar xfvj "download.tar.bz2"
+          mkdir -p "$BOOST_ROOT"
+          cp -r boost_*/* "$BOOST_ROOT"
+        condition: ne(variables.BOOST_CACHE_RESTORED, 'true')
+        displayName: Install Boost
+
       - bash: choco install swig --yes --limit-output
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
         displayName: Install swig
@@ -127,7 +145,9 @@ jobs:
       # Configure HELICS
       # -----------------------
       - bash: |
-          echo "##vso[task.setvariable variable=BOOST_ROOT]$BOOST_ROOT_1_72_0"
+          echo "BOOST_ROOT=$BOOST_ROOT"
+          env
+        displayName: Show environment info
       - task: CMake@1
         inputs:
           cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON $(extraFlags) ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,12 +160,30 @@ workflows:
   version: 2
   helics_test:
     jobs:
-      - helicsMSan
-      - helicsASan
-      - helicsInstall1
-      - helicsInstall2
-      - helicsgccTSan
-      - helicsoctave
+      - helicsMSan:
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
+      - helicsASan:
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
+      - helicsInstall1:
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
+      - helicsInstall2:
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
+      - helicsgccTSan:
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
+      - helicsoctave:
+          filters:
+            branches:
+              ignore: /pre-commit\/.*/
 
   nightly:
     triggers:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,7 @@ freebsd_instance:
   image_family: freebsd-12-1
 
 task:
+  skip: $CIRRUS_BRANCH == 'pre-commit/.*'
   install_script: |
     pkg install -y cmake libzmq4 ninja git
   build_script: |

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -4,13 +4,20 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
-export BOOST_ROOT
+
+# Install Boost
+COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
+# shellcheck source=../common/Windows/install-boost.sh
+source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/actions/common/Windows/install-boost.sh
+++ b/.github/actions/common/Windows/install-boost.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Install Boost
+BOOST_VERSION="1.74.0"
+BOOST_ROOT="/c/boost"
+BOOST_URL="https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download"
+(
+    cd "$(mktemp -d)" || exit
+    curl --location --output "download.tar.bz2" "$BOOST_URL"
+    tar xfj "download.tar.bz2"
+    mkdir -p "$BOOST_ROOT"
+    cp -r boost_*/* "$BOOST_ROOT"
+) || exit
+export BOOST_ROOT

--- a/.github/actions/linux-release-builder/Dockerfile
+++ b/.github/actions/linux-release-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/holy-build-box-64:latest
+FROM phusion/holy-build-box-64:2.1.0
 
 # Install a copy of git and the Boost headers
 # curl -L follows redirects and -k ignores SSL certificate warnings

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -4,14 +4,23 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install SWIG
 choco install -y swig
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
-export BOOST_ROOT
+
+# Install Boost
+COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
+# shellcheck source=../common/Windows/install-boost.sh
+source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_JAVA_INTERFACE=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "${CPACK_GEN}" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -5,11 +5,20 @@
 # 3. moving the generated installer with a rename to add msvcYYYY to the file name
 
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install SWIG
 choco install -y swig
+
+# Install Boost
+COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
+# shellcheck source=../common/Windows/install-boost.sh
+source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
-export BOOST_ROOT
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Debug -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=ON -DHELICS_DISABLE_C_SHARED_LIB=ON ..
 cmake --build . --config Debug

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -4,14 +4,23 @@
 # 2. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
+
+# Install SWIG
 choco install -y swig
-BOOST_ROOT="${BOOST_ROOT_1_72_0}"
-export BOOST_ROOT
+
+# Install Boost
+COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
+# shellcheck source=../common/Windows/install-boost.sh
+source "${COMMON_SCRIPTS}/install-boost.sh"
+
+# Find cpack command (chocolatey has a command with the same name)
+cpack_dir="$(command -v cmake)"
+cpack_dir="${cpack_dir%/cmake}"
+
+# Build
 mkdir build && cd build || exit
 cmake -G "${BUILD_GEN}" -A "${BUILD_ARCH/x86/Win32}" -DCMAKE_BUILD_TYPE=Release -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_USE_ZMQ_STATIC_LIBRARY=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
-cpack_dir="$(command -v cmake)"
-cpack_dir="${cpack_dir%/cmake}"
 "${cpack_dir}/cpack" -G "TGZ" -C Release -B "$(pwd)/../artifact"
 cd ../artifact || exit
 rm -rf _CPack_Packages

--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -1,0 +1,36 @@
+name: Compress Images
+on:
+  pull_request:
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+  push:
+    branches:
+      - !develop
+      - !master
+      - !helics3
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@master
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # For PR builds from this repository, automatically add the compressed images; otherwise just compress images
+          compressOnly: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      # If steps.calibre.outputs.markdown != '' then images were compressed.
+      # An additional enhancement would be to check if the PR was from a fork and post a message saying how much space can be saved with compression.
+      # For pushes to some branches, opening a PR with the compressed files could be good (ideally before the images have been merged into the main branch).

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,11 +3,13 @@ on:
   push:
     branches:
       - develop
+      - main
       - master
       - helics3
   pull_request:
     branches:
       - develop
+      - main
       - master
       - helics3
 
@@ -31,15 +33,15 @@ jobs:
     - uses: pre-commit/action@v1.1.0
     - name: Create/update a file update PR with changed files
       if: failure() && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository
-      uses: gmlc-tdc/create-pr-action@v0.1
+      uses: gmlc-tdc/create-pr-action@v0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         COMMIT_MSG: "Automated formatting of repo files"
-        PR_TITLE: "Automated formatting of repo files"
+        PR_TITLE: "Automated formatting of repo files [skip ci]"
         PR_BODY: "Automated formatting of repo files in commit https://github.com/${{ github.event.pull_request.head.repo.full_name }}/commit/${{ github.sha }} from ${{ github.ref }}."
-        GIT_EMAIL: "HELICS-bot@users.noreply.github.com"
-        GIT_NAME: "HELICS-bot"
+        GIT_NAME: "github-actions[bot]"
+        GIT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         BRANCH_PREFIX: "pre-commit/"
         NO_HASH: "true"
         REPLACE_BRANCH: "true"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
+      if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -147,7 +147,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
+      if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2
@@ -234,7 +234,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
+      if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
       uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: prettier
         exclude: ^(docs/user-guide/examples/user_guide_examples)
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.0.2
+    rev: 2.1.5
     hooks:
       - id: markdownlint
         args: [-s, ./config/.markdownlintrc]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,12 @@
 clone_depth: 1
 
+branches:
+  only:
+    - main
+    - master
+    - develop
+    - helics3
+
 version: 3.0.0.{build}
 
 image: Visual Studio 2019

--- a/benchmarks/helics/messageLookupBenchmarks.cpp
+++ b/benchmarks/helics/messageLookupBenchmarks.cpp
@@ -38,7 +38,7 @@ class messageGenerator {
   public:
     messageGenerator() = default;
 
-    void run(const std::function<void()> &callOnReady = {})
+    void run(const std::function<void()>& callOnReady = {})
     {
         if (!readyToRun) {
             makeReady();

--- a/docs/user-guide/logging.md
+++ b/docs/user-guide/logging.md
@@ -99,6 +99,7 @@ when specifying log levels through the command line or through config files it i
 - "trace" : all internal messages
 
 ALL CAPS and the Enum value name will also work for converting the string
+
 ```json
 {
   //example json configuration file for a value federate all arguments are optional

--- a/examples/BrokerServerTestCase/brokerServerTest.cpp
+++ b/examples/BrokerServerTestCase/brokerServerTest.cpp
@@ -10,10 +10,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api.hpp"
 #include "helics/core/CoreFactory.hpp"
 
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
-#include <iostream>
 
 int main(int argc, char** argv)
 {
@@ -54,8 +54,8 @@ int main(int argc, char** argv)
     std::chrono::seconds timeout(30);
     if (argc >= 2) {
         char* eptr{nullptr};
-        auto res = std::strtol(argv[1],&eptr,0);
-        if (eptr - argv[1]>0) {
+        auto res = std::strtol(argv[1], &eptr, 0);
+        if (eptr - argv[1] > 0) {
             timeout = std::chrono::seconds(res);
         }
         std::cout << "value for timeout is not recognized(" << argv[1] << ")" << std::endl;

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -47,7 +47,7 @@ static const std::string emptyStr;
 #    define LOG_SUMMARY(message)                                                                   \
         do {                                                                                       \
             if (logLevel >= HELICS_LOG_LEVEL_SUMMARY) {                                            \
-                logMessage(HELICS_LOG_LEVEL_SUMMARY, emptyStr, message);                          \
+                logMessage(HELICS_LOG_LEVEL_SUMMARY, emptyStr, message);                           \
             }                                                                                      \
         } while (false)
 


### PR DESCRIPTION
### Summary

If merged this pull request will cherry-pick changes to CI builds and workflows from the develop branch to helics3.

### Proposed changes

- Pinning various docker images and build tools to particular versions
- Fixing build issues such as Boost being removed from Windows on AZP/GHA
- Reducing the number of CI builds triggered for automated  formatting PRs
- Automated formatting for a previous PR that had failed