### PR TITLE
Switch HELICS 2 develop branch CI from Travis to Azure Pipelines

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           MAKEFLAGS: '-j 4'
           CMAKE_GENERATOR: 'Unix Makefiles'
+          DISABLE_INTERFACES: 'Python'
           USE_SWIG: 'true'
           USE_MPI: 'true'
           ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
@@ -72,7 +73,6 @@ jobs:
         condition: ne(variables['xcode_path'],'')
       - bash: |
           brew install swig zeromq boost
-          python3 -m pip install pytest
         displayName: 'Install dependencies'
       - bash: |
           source scripts/setup-helics-ci-options.sh
@@ -81,6 +81,7 @@ jobs:
         env:
           MAKEFLAGS: '-j 4'
           CMAKE_GENERATOR: 'Unix Makefiles'
+          DISABLE_INTERFACES: 'Python'
           USE_SWIG: 'true'
         displayName: 'Build HELICS'
 

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -9,6 +9,87 @@ pr:
   - helics3
 
 jobs:
+  - job: Linux
+    strategy:
+      matrix:
+        ubuntuDefault:
+          containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
+          test_config: 'ci'
+        gcc10:
+          containerImage: 'helics/buildenv:gcc10-builder'
+          test_config: 'ci'
+        clang10:
+          containerImage: 'helics/buildenv:clang10-builder'
+          test_config: 'ci'
+        clang5:
+          containerImage: 'helics/buildenv:clang5-builder'
+          test_config: 'ci'
+
+    pool:
+      vmImage: 'ubuntu-latest'
+    container: $[ variables['containerImage'] ]
+    timeoutInMinutes: 90
+
+    steps:
+      - bash: |
+          source scripts/setup-helics-ci-options.sh
+          mkdir -p build && cd build
+          ../scripts/ci-build.sh
+        env:
+          MAKEFLAGS: '-j 4'
+          CMAKE_GENERATOR: 'Unix Makefiles'
+          USE_SWIG: 'true'
+          USE_MPI: 'true'
+          ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
+          ZMQ_FORCE_SUBPROJECT: $[variables['zmq_subproject']]
+        displayName: 'Build HELICS'
+
+      - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
+        env:
+          TEST_CONFIG: $[variables['test_config']]
+        workingDirectory: 'build'
+        displayName: 'Test HELICS'
+
+  - job: macOS
+    strategy:
+      matrix:
+        XCode-latest:
+          test_config: 'ci'
+          vmImage: 'macOS-latest'
+        XCode-oldest:
+          test_config: 'ci'
+          vmImage: 'macOS-10.14'
+          xcode_path: '/Applications/Xcode_10.1.app'
+    pool:
+      vmImage: $[ variables['vmImage'] ]
+    timeoutInMinutes: 90
+
+    steps:
+      - bash: sudo xcode-select --switch "${XCODE_PATH}/Contents/Developer"
+        env:
+          XCODE_PATH: $[variables['xcode_path']]
+        displayName: 'Set XCode Path'
+        condition: ne(variables['xcode_path'],'')
+      - bash: |
+          brew install swig zeromq boost
+          python3 -m pip install pytest
+        displayName: 'Install dependencies'
+      - bash: |
+          source scripts/setup-helics-ci-options.sh
+          mkdir -p build && cd build
+          ../scripts/ci-build.sh
+        env:
+          MAKEFLAGS: '-j 4'
+          CMAKE_GENERATOR: 'Unix Makefiles'
+          USE_SWIG: 'true'
+        displayName: 'Build HELICS'
+
+      - bash: ../scripts/run-ci-tests.sh "$TEST_CONFIG"
+        env:
+          TEST_CONFIG: $[variables['test_config']]
+        workingDirectory: 'build'
+        displayName: 'Test HELICS'
+
   - job: Windows
     strategy:
       matrix:
@@ -16,14 +97,17 @@ jobs:
           imageName: 'vs2017-win2016'
           langArch: 'x86'
           vsArch: 'Win32'
+          extraFlags: '-DHELICS_DISABLE_WEBSERVER=ON'
         VS2017-64bit:
           imageName: 'vs2017-win2016'
           langArch: 'x64'
           vsArch: 'x64'
+          extraFlags: ''
         VS2019-64bit:
           imageName: 'windows-2019'
           langArch: 'x64'
           vsArch: 'x64'
+          extraFlags: ''
     pool:
       vmImage: $(imageName)
     variables:
@@ -71,15 +155,9 @@ jobs:
         displayName: Show environment info
       - task: CMake@1
         inputs:
-          cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
+          cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON $(extraFlags) ..
         displayName: 'Configure HELICS'
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
-
-      #  - task: CMake@1
-      #    inputs:
-      #      cmakeArgs: -DBUILD_PYTHON_INTERFACE=ON .
-      #    displayName: 'Configure Python interface'
-      #    condition: and(ne( variables['imageName'], 'vs2015-win2012r2' ), eq( variables['langArch'], 'x64' ))
 
       #  - task: CMake@1
       #    inputs:
@@ -126,3 +204,9 @@ jobs:
       - bash: ctest --output-on-failure --timeout 480 -C Release -L "PackagingFast"
         displayName: 'Test HELICS packaging'
         workingDirectory: build
+
+      - task: PublishBuildArtifacts@1
+        condition: failed()
+        inputs:
+          pathtoPublish: '$(Build.SourcesDirectory)/build'
+          artifactName: buildDirContents

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,54 +38,18 @@ _basic_env:
           - valgrind
           - lcov
           - libzmq3-dev
-  - &daily_osx
-    if: type = cron
-    os: osx
-    compiler: clang
   - &linux_base
     os: linux
     compiler: gcc
-  - &osx_base
-    os: osx
-    compiler: clang
-
-# Install macOS dependencies using Homebrew
-addons:
-  homebrew:
-    brewfile: .ci/Brewfile.travis
-    update: true
 
 jobs:
   # On weekdays, the backlog for waiting OS X builds is huge
   fast_finish: true
   allow_failures:
-    - os: osx
     - name: 'Clang 5 Thread Sanitizer'
     - script: scripts/trigger-dependent-ci-builds.sh
 
   include:
-    # XCode 10.2, OS X 10.14
-    - <<: *osx_base
-      name: 'XCode 10.2, OS X 10.14'
-      env:
-        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=102"
-        - HOMEBREW_NO_AUTO_UPDATE=1
-        - CI_TEST_EXCLUDE="application-api-ci-tests|system-ci-tests"
-      osx_image: xcode10.2
-
-    # XCode 9.4, OS X 10.13
-    - <<: *osx_base
-      name: 'XCode 9.4, macOS 10.13'
-      if: (branch = develop AND type IN (cron)) OR (branch = master AND type IN (push, pull_request))
-      env:
-        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=94"
-        - HOMEBREW_NO_AUTO_UPDATE=1
-        - USE_SWIG=false
-      osx_image: xcode9.4
-      addons:
-        homebrew:
-          brewfile: .ci/Brewfile-minimal.travis
-          update: true
 
     - <<: *linux_base
       name: 'GCC 6'
@@ -269,9 +233,6 @@ script:
 
   # Setup counters for coverage
   - if [[ "$BUILD_TYPE" == "Coverage" ]]; then pushd .. && scripts/lcov-helper.sh setup-counters && popd ; fi
-
-  - if [[ "TRAVIS_OS_NAME" == "osx" ]]; then python ../scripts/fix_install_names.py ; fi
-  - if [[ "TRAVIS_OS_NAME" == "osx" ]]; then make ${MAKEFLAGS} install ; fi
 
   # Run CI tests
   - export CTEST_OPTIONS="--output-on-failure"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,49 +45,8 @@ _basic_env:
 jobs:
   # On weekdays, the backlog for waiting OS X builds is huge
   fast_finish: true
-  allow_failures:
-    - name: 'Clang 5 Thread Sanitizer'
-    - script: scripts/trigger-dependent-ci-builds.sh
 
   include:
-
-    - <<: *linux_base
-      name: 'GCC 6'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-            - libzmq3-dev
-      env:
-        - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"
-        - USE_SWIG=true
-        - USE_CMAKE_VERSION=3.7.2
-        - BUILD_BENCHMARKS=true
-        - USE_MPI=mpich
-
-    # Clang 5 build
-    - <<: *linux_base
-      name: 'Clang 5'
-      compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - libstdc++-6-dev
-            - clang-5.0
-            - libzmq3-dev
-      env:
-        - MATRIX_EVAL="COMPILER=clang && CC='clang-5.0' && CXX='clang++-5.0'"
-        - CCACHE_CPP2=yes
-        - USE_SWIG=true
-        - BUILD_BENCHMARKS=true
-        - USE_CMAKE_VERSION=3.14.5
-        - CXX_STANDARD=17
-
     - <<: *linux_base
       name: 'GCC 4.9 (No SWIG, Packaging)'
       if: (branch = develop AND type IN (pull_request, cron)) OR (branch != develop)
@@ -183,17 +142,8 @@ jobs:
         - ZMQ_FORCE_SUBPROJECT=true
 
     # ------------------------------------------------
-    # Jobs for daily valgrind and code coverage tests
+    # Jobs for daily code coverage tests
     # ------------------------------------------------
-    # Valgrind build
-    - <<: *daily_linux
-      name: 'GCC 6 Valgrind'
-      env:
-        - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"
-        - USE_SWIG=true
-        - RUN_VALGRIND=true
-        - DISABLE_INTERFACES="Python,Java"
-        - BUILD_TYPE=RelWithDebInfo
     # Code coverage build
     - <<: *daily_linux
       if: (type = cron) OR (branch =~ /(codecov)/) OR (commit_message =~ /(codecov)/)
@@ -207,12 +157,6 @@ jobs:
         - GCOV_TOOL=gcov-6
         - USE_MPI=mpich
         - CTEST_VERBOSE=true
-
-    - stage: trigger dependent repositories
-      if: branch IN (master, develop)
-      before_install: true
-      install: true
-      script: scripts/trigger-dependent-ci-builds.sh
 
 branches:
   except:

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -32,7 +32,17 @@ if [[ "${DISABLE_INTERFACES}" != *"Java"* ]]; then
     OPTION_FLAGS_ARR+=("-DBUILD_JAVA_INTERFACE=ON")
 fi
 if [[ "${DISABLE_INTERFACES}" != *"Python"* ]]; then
-    OPTION_FLAGS_ARR+=("-DBUILD_PYTHON_INTERFACE=ON" "-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}" "-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH} -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
+    OPTION_FLAGS_ARR+=("-DBUILD_PYTHON_INTERFACE=ON")
+
+    if [[ "$PYTHON_LIB_PATH" ]]; then
+        OPTION_FLAGS_ARR+=("-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}")
+    fi
+    if [[ "$PYTHON_INCLUDE_PATH" ]]; then
+        OPTION_FLAGS_ARR+=("-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH}")
+    fi
+    if [[ "$PYTHON_EXECUTABLE" ]]; then
+        OPTION_FLAGS_ARR+=("-DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
+    fi
 fi
 if [[ "$USE_SWIG" == 'true' ]]; then
     OPTION_FLAGS_ARR+=("-DHELICS_ENABLE_SWIG=ON")
@@ -67,9 +77,9 @@ fi
 # MPI options
 if [[ "$USE_MPI" ]]; then
     OPTION_FLAGS_ARR+=("-DENABLE_MPI_CORE=ON")
-    CC=${CI_DEPENDENCY_DIR}/mpi/bin/mpicc
+    CC=mpicc
     export CC
-    CXX=${CI_DEPENDENCY_DIR}/mpi/bin/mpic++
+    CXX=mpic++
     export CXX
 fi
 


### PR DESCRIPTION
### Summary

If merged this pull request will add the Linux and macOS builds on Azure Pipelines from HELICS 3 to the HELICS 2 develop branch. Deprecated Python SWIG interface build+test doesn't run on the Linux or macOS builds.

### Proposed changes

- Backport Azure Pipelines Linux and macOS builds for each commit from HELICS 3 to HELICS 2
- Remove macOS builds and most of the Linux builds from the HELICS 2 Travis CI config