### PR TITLE
Update HELICS 2 FreeBSD CI build to 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1
+  image_family: freebsd-12-2
 
 task:
   skip: $CIRRUS_BRANCH == 'pre-commit/.*'


### PR DESCRIPTION
### Summary

If merged this pull request will update the FreeBSD CI build to 12.2, which seems to resolve the zmq related build error.

### Proposed changes

- Update FreeBSD CI build to 12.2