### PR TITLE
Add vcpkg manifest file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,10 @@ else()
     cmake_policy(VERSION 3.18)
 endif()
 
-# Install dependencies using vcpkg if VCPKG_ROOT is set and no CMake Toolchain file is given
-# vcpkg installation on a system doesn't set VCPKG_ROOT, so setting it should be like an opt-in for users
+# Install dependencies using vcpkg if VCPKG_ROOT is set and no CMake Toolchain file is given vcpkg
+# installation on a system doesn't set VCPKG_ROOT, so setting it should be like an opt-in for users
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-        CACHE STRING ""
-    )
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 endif()
 
 project(HELICS VERSION 2.6.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ else()
     cmake_policy(VERSION 3.18)
 endif()
 
+# Install dependencies using vcpkg if VCPKG_ROOT is set and no CMake Toolchain file is given
+# vcpkg installation on a system doesn't set VCPKG_ROOT, so setting it should be like an opt-in for users
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING ""
+    )
+endif()
+
 project(HELICS VERSION 2.6.1)
 
 # -----------------------------------------------------------------------------

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -26,6 +26,12 @@ To set up your environment:
    sudo apt-get install libzmq5-dev
    ```
 
+   As an alternative, you can use [vcpkg](https://github.com/microsoft/vcpkg#getting-started) -- it is slower
+   because it builds all dependencies from source but could have newer versions of dependencies than apt-get.
+   To use it, follow the vcpkg getting started directions to install vcpkg and then run `cmake` using
+   `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake`, or by setting the environment
+   variable `VCPKG_ROOT=[path to vcpkg]` prior to running `cmake`.
+
 2. Make sure _CMake_ and _git_ are available in the Command Prompt. If they aren't, add them to the system PATH variable.
 
 Getting and building from source:

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -35,7 +35,13 @@ To set up your environment:
    the [homebrew](https://brew.sh/) package manager. These directions
    assume this approach, so unless you prefer to track these
    libraries and dependencies down yourself, install it if you don't
-   have it yet.
+   have it yet. As an alternative package manager, you can use
+   [vcpkg](https://github.com/microsoft/vcpkg#getting-started) -- it
+   is slower because it builds all dependencies for source, but instead
+   of following step below you could either run `cmake` using
+   `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake`
+   as shown in the vcpkg getting started instructions, or by setting the
+   environment variable `VCPKG_ROOT=[path to vcpkg]` prior to running `cmake`.
 3. (if needed) Setup a command-line compile environment
 
    a) Install a C++11 compiler (C++14 preferred). e.g. `clang`

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -36,6 +36,7 @@ To set up your environment:
     To use it, follow the vcpkg getting started directions to install vcpkg and then run `cmake` using
     `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake`, or by setting the environment
     variable `VCPKG_ROOT=[path to vcpkg]` prior to running `cmake`.
+
 3.  _Optional_ Only if you need a global Install of ZeroMQ [ZeroMQ](http://zeromq.org/build:_start).
     We **highly recommend skipping** this step and running CMake with the
     `HELICS_ZMQ_SUBPROJECT=ON` option enabled(which is default on windows) to automatically set up a project-only

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -30,6 +30,12 @@ To set up your environment:
     Building with Visual Studio 2017 will require boost 1.65.1 or newer and CMake 3.9
     or newer. Use 14.0 versions for Visual Studio 2015, 14.1 files for Visual studio 2017. Visual studio 2019 will require CMake 3.14 or later.
     Boost 1.70 with CMake 3.14+ is the current recommended configuration.
+
+    As an (experimental) alternative for installing Boost (and ZeroMQ), you can use [vcpkg](https://github.com/microsoft/vcpkg#getting-started) -- it is slower
+    because it builds all dependencies but handles getting the right install paths to dependencies set correctly.
+    To use it, follow the vcpkg getting started directions to install vcpkg and then run `cmake` using
+    `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake`, or by setting the environment
+    variable `VCPKG_ROOT=[path to vcpkg]` prior to running `cmake`.
 3.  _Optional_ Only if you need a global Install of ZeroMQ [ZeroMQ](http://zeromq.org/build:_start).
     We **highly recommend skipping** this step and running CMake with the
     `HELICS_ZMQ_SUBPROJECT=ON` option enabled(which is default on windows) to automatically set up a project-only

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,39 @@
+{
+	"name": "helics",
+	"version-string": "2.7.0",
+	"description": "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)",
+	"homepage": "https://helics.org/",
+	"default-features": [ "zeromq", "ipc", "webserver" ],
+	"dependencies": [
+		"boost-core"
+	],
+	"features": {
+		"zeromq": {
+			"description": "Build ZeroMQ core",
+			"dependencies": [
+				{
+					"name": "zeromq",
+					"features": [ "sodium" ]
+				}
+			]
+		},
+		"ipc": {
+			"description": "Build IPC core",
+			"dependencies": [
+				"boost-interprocess"
+			]
+		},
+		"mpi": {
+			"description": "Build MPI core",
+			"dependencies": [
+				"mpi"
+			]
+		},
+		"webserver": {
+			"description": "Build webserver in broker_server",
+			"dependencies": [
+				"boost-beast"
+			]
+		}
+	}
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,39 +1,31 @@
 {
-	"name": "helics",
-	"version-string": "2.7.0",
-	"description": "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)",
-	"homepage": "https://helics.org/",
-	"default-features": [ "zeromq", "ipc", "webserver" ],
-	"dependencies": [
-		"boost-core"
-	],
-	"features": {
-		"zeromq": {
-			"description": "Build ZeroMQ core",
-			"dependencies": [
-				{
-					"name": "zeromq",
-					"features": [ "sodium" ]
-				}
-			]
-		},
-		"ipc": {
-			"description": "Build IPC core",
-			"dependencies": [
-				"boost-interprocess"
-			]
-		},
-		"mpi": {
-			"description": "Build MPI core",
-			"dependencies": [
-				"mpi"
-			]
-		},
-		"webserver": {
-			"description": "Build webserver in broker_server",
-			"dependencies": [
-				"boost-beast"
-			]
-		}
-	}
+  "name": "helics",
+  "version-string": "2.7.0",
+  "description": "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)",
+  "homepage": "https://helics.org/",
+  "default-features": ["zeromq", "ipc", "webserver"],
+  "dependencies": ["boost-core"],
+  "features": {
+    "zeromq": {
+      "description": "Build ZeroMQ core",
+      "dependencies": [
+        {
+          "name": "zeromq",
+          "features": ["sodium"]
+        }
+      ]
+    },
+    "ipc": {
+      "description": "Build IPC core",
+      "dependencies": ["boost-interprocess"]
+    },
+    "mpi": {
+      "description": "Build MPI core",
+      "dependencies": ["mpi"]
+    },
+    "webserver": {
+      "description": "Build webserver in broker_server",
+      "dependencies": ["boost-beast"]
+    }
+  }
 }


### PR DESCRIPTION
### Summary

If merged this pull request will enable vcpgk to be used as a dependency manager for HELICS dependencies when building from source.

### Proposed changes

- Adds vcpkg.json manifest file
- Add some info on using vcpkg to manage dependencies to docs on building HELICS from source
