### PR TITLE
revert the change the error_code field in helics3 to prevent major is…

### DIFF
--- a/interfaces/java/java_maps.i
+++ b/interfaces/java/java_maps.i
@@ -76,7 +76,7 @@
 
 %typemap(freearg) HelicsError *
 {
-    if ($1->errorCode!=HELICS_OK)
+    if ($1->error_code!=HELICS_OK)
     {
         jclass clazz = (*jenv)->FindClass(jenv, "java/lang/Exception");
         (*jenv)->ThrowNew(jenv, clazz, $1->message);

--- a/interfaces/octave/octave_maps.i
+++ b/interfaces/octave/octave_maps.i
@@ -6,7 +6,7 @@
 
 /* throw a helics error */
 static octave_value Helics_ErrorType(HelicsError *err) {
-switch (err->errorCode)
+switch (err->error_code)
   {
   case HELICS_ERROR_REGISTRATION_FAILURE:
     return "helics:registration_failure";
@@ -52,7 +52,7 @@ static octave_value throwHelicsOctaveError(HelicsError *err) {
 
 %typemap(freearg) HelicsError *
 {
-    if ($1->errorCode!=HELICS_OK)
+    if ($1->error_code!=HELICS_OK)
     {
         throwHelicsOctaveError($1);
     }

--- a/src/helics/cpp98/helicsExceptions.hpp
+++ b/src/helics/cpp98/helicsExceptions.hpp
@@ -44,8 +44,8 @@ class hThrowOnError {
     exception */
     ~hThrowOnError() HELICS_THROWS_EXCEPTION
     {
-        if (eObj.errorCode != 0) {
-            throw HelicsException(eObj.errorCode, eObj.message);
+        if (eObj.error_code != 0) {
+            throw HelicsException(eObj.error_code, eObj.message);
         }
     }
     /** this is an implicit conversion operation for use with HelicsError*/

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -137,7 +137,7 @@ static const char* invalidFedInfoString = "helics Federate info object was not v
 
 static helics::FederateInfo* getFedInfo(HelicsFederateInfo fi, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     if (fi == nullptr) {
@@ -256,7 +256,7 @@ void helicsFederateInfoSetCoreTypeFromString(HelicsFederateInfo fi, const char* 
     auto ctype = helics::core::coreTypeFromString(coretype);
     if (ctype == helics::CoreType::UNRECOGNIZED) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(std::string(coretype) + " is not a valid core type");
             return;
         }

--- a/src/helics/shared_api_library/MessageFiltersExport.cpp
+++ b/src/helics/shared_api_library/MessageFiltersExport.cpp
@@ -194,7 +194,7 @@ HelicsFilter helicsFederateGetFilter(HelicsFederate fed, const char* name, Helic
     try {
         auto& id = fedObj->getFilter(name);
         if (!id.isValid()) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = invalidFiltName;
             return nullptr;
         }
@@ -230,7 +230,7 @@ HelicsFilter helicsFederateGetFilterByIndex(HelicsFederate fed, int index, Helic
     try {
         auto& id = fedObj->getFilter(index);
         if (!id.isValid()) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = invalidFiltIndex;
             return nullptr;
         }

--- a/src/helics/shared_api_library/api-data.h
+++ b/src/helics/shared_api_library/api-data.h
@@ -158,7 +158,7 @@ typedef struct HelicsComplex {
  * otherwise it will be an empty string
  */
 typedef struct HelicsError {
-    int32_t errorCode; /*!< an error code associated with the error*/
+    int32_t error_code; /*!< an error code associated with the error*/
     const char* message; /*!< a message associated with the error*/
 } HelicsError;
 

--- a/src/helics/shared_api_library/backup/helics.h
+++ b/src/helics/shared_api_library/backup/helics.h
@@ -501,7 +501,7 @@ typedef struct HelicsComplex {
  * otherwise it will be an empty string
  */
 typedef struct HelicsError {
-    int32_t errorCode; /*!< an error code associated with the error*/
+    int32_t error_code; /*!< an error code associated with the error*/
     const char* message; /*!< a message associated with the error*/
 } HelicsError;
 

--- a/src/helics/shared_api_library/backup/helics_api.h
+++ b/src/helics/shared_api_library/backup/helics_api.h
@@ -9,151 +9,154 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <stdlib.h>
 
 typedef enum {
-    HELICS_CORE_TYPE_DEFAULT = 0,
-    HELICS_CORE_TYPE_ZMQ = 1,
-    HELICS_CORE_TYPE_MPI = 2,
-    HELICS_CORE_TYPE_TEST = 3,
-    HELICS_CORE_TYPE_INTERPROCESS = 4,
-    HELICS_CORE_TYPE_IPC = 5,
-    HELICS_CORE_TYPE_TCP = 6,
-    HELICS_CORE_TYPE_UDP = 7,
-    HELICS_CORE_TYPE_ZMQ_SS = 10,
-    HELICS_CORE_TYPE_NNG = 9,
-    HELICS_CORE_TYPE_TCP_SS = 11,
-    HELICS_CORE_TYPE_HTTP = 12,
-    HELICS_CORE_TYPE_WEBSOCKET = 14,
-    HELICS_CORE_TYPE_INPROC = 18,
-    HELICS_CORE_TYPE_NULL = 66
+   HELICS_CORE_TYPE_DEFAULT = 0,
+   HELICS_CORE_TYPE_ZMQ = 1,
+   HELICS_CORE_TYPE_MPI = 2,
+   HELICS_CORE_TYPE_TEST = 3,
+   HELICS_CORE_TYPE_INTERPROCESS = 4,
+   HELICS_CORE_TYPE_IPC = 5,
+   HELICS_CORE_TYPE_TCP = 6,
+   HELICS_CORE_TYPE_UDP = 7,
+   HELICS_CORE_TYPE_ZMQ_SS = 10,
+   HELICS_CORE_TYPE_NNG = 9,
+   HELICS_CORE_TYPE_TCP_SS = 11,
+   HELICS_CORE_TYPE_HTTP = 12,
+   HELICS_CORE_TYPE_WEBSOCKET = 14,
+   HELICS_CORE_TYPE_INPROC = 18,
+   HELICS_CORE_TYPE_NULL = 66
 } HelicsCoreTypes;
 
 typedef enum {
-    HELICS_DATA_TYPE_STRING = 0,
-    HELICS_DATA_TYPE_DOUBLE = 1,
-    HELICS_DATA_TYPE_INT = 2,
-    HELICS_DATA_TYPE_COMPLEX = 3,
-    HELICS_DATA_TYPE_VECTOR = 4,
-    HELICS_DATA_TYPE_COMPLEX_VECTOR = 5,
-    HELICS_DATA_TYPE_NAMED_POINT = 6,
-    HELICS_DATA_TYPE_BOOLEAN = 7,
-    HELICS_DATA_TYPE_TIME = 8,
-    HELICS_DATA_TYPE_RAW = 25,
-    HELICS_DATA_TYPE_MULTI = 33,
-    HELICS_DATA_TYPE_ANY = 25262
+   HELICS_DATA_TYPE_STRING = 0,
+   HELICS_DATA_TYPE_DOUBLE = 1,
+   HELICS_DATA_TYPE_INT = 2,
+   HELICS_DATA_TYPE_COMPLEX = 3,
+   HELICS_DATA_TYPE_VECTOR = 4,
+   HELICS_DATA_TYPE_COMPLEX_VECTOR = 5,
+   HELICS_DATA_TYPE_NAMED_POINT = 6,
+   HELICS_DATA_TYPE_BOOLEAN = 7,
+   HELICS_DATA_TYPE_TIME = 8,
+   HELICS_DATA_TYPE_RAW = 25,
+   HELICS_DATA_TYPE_MULTI = 33,
+   HELICS_DATA_TYPE_ANY = 25262
 } HelicsDataTypes;
 
 #define HELICS_DATA_TYPE_CHAR HELICS_DATA_TYPE_STRING
 
 typedef enum {
-    HELICS_FLAG_OBSERVER = 0,
-    HELICS_FLAG_UNINTERRUPTIBLE = 1,
-    HELICS_FLAG_INTERRUPTIBLE = 2,
-    HELICS_FLAG_SOURCE_ONLY = 4,
-    HELICS_FLAG_ONLY_TRANSMIT_ON_CHANGE = 6,
-    HELICS_FLAG_ONLY_UPDATE_ON_CHANGE = 8,
-    HELICS_FLAG_WAIT_FOR_CURRENT_TIME_UPDATE = 10,
-    HELICS_FLAG_RESTRICTIVE_TIME_POLICY = 11,
-    HELICS_FLAG_ROLLBACK = 12,
-    HELICS_FLAG_FORWARD_COMPUTE = 14,
-    HELICS_FLAG_REALTIME = 16,
-    HELICS_FLAG_SINGLE_THREAD_FEDERATE = 27,
-    HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS = 67,
-    HELICS_FLAG_STRICT_CONFIG_CHECKING = 75,
-    HELICS_FLAG_EVENT_TRIGGERED = 81
+   HELICS_FLAG_OBSERVER = 0,
+   HELICS_FLAG_UNINTERRUPTIBLE = 1,
+   HELICS_FLAG_INTERRUPTIBLE = 2,
+   HELICS_FLAG_SOURCE_ONLY = 4,
+   HELICS_FLAG_ONLY_TRANSMIT_ON_CHANGE = 6,
+   HELICS_FLAG_ONLY_UPDATE_ON_CHANGE = 8,
+   HELICS_FLAG_WAIT_FOR_CURRENT_TIME_UPDATE = 10,
+   HELICS_FLAG_RESTRICTIVE_TIME_POLICY = 11,
+   HELICS_FLAG_ROLLBACK = 12,
+   HELICS_FLAG_FORWARD_COMPUTE = 14,
+   HELICS_FLAG_REALTIME = 16,
+   HELICS_FLAG_SINGLE_THREAD_FEDERATE = 27,
+   HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS = 67,
+   HELICS_FLAG_STRICT_CONFIG_CHECKING = 75,
+   HELICS_FLAG_EVENT_TRIGGERED = 81
 } HelicsFederateFlags;
 
-typedef enum { HELICS_FLAG_DELAY_INIT_ENTRY = 45, HELICS_FLAG_ENABLE_INIT_ENTRY = 47 } HelicsCoreFlags;
+typedef enum {
+   HELICS_FLAG_DELAY_INIT_ENTRY = 45,
+   HELICS_FLAG_ENABLE_INIT_ENTRY = 47
+} HelicsCoreFlags;
 
 typedef enum {
-    HELICS_FLAG_SLOW_RESPONDING = 29,
-    HELICS_FLAG_DEBUGGING = 31,
-    HELICS_FLAG_TERMINATE_ON_ERROR = 72,
-    HELICS_FLAG_FORCE_LOGGING_FLUSH = 88,
-    HELICS_FLAG_DUMPLOG = 89
+   HELICS_FLAG_SLOW_RESPONDING = 29,
+   HELICS_FLAG_DEBUGGING = 31,
+   HELICS_FLAG_TERMINATE_ON_ERROR = 72,
+   HELICS_FLAG_FORCE_LOGGING_FLUSH = 88,
+   HELICS_FLAG_DUMPLOG = 89
 } HelicsFlags;
 
 typedef enum {
-    HELICS_LOG_LEVEL_NO_PRINT = -1,
-    HELICS_LOG_LEVEL_ERROR = 0,
-    HELICS_LOG_LEVEL_WARNING = 1,
-    HELICS_LOG_LEVEL_SUMMARY = 2,
-    HELICS_LOG_LEVEL_CONNECTIONS = 3,
-    HELICS_LOG_LEVEL_INTERFACES = 4,
-    HELICS_LOG_LEVEL_TIMING = 5,
-    HELICS_LOG_LEVEL_DATA = 6,
-    HELICS_LOG_LEVEL_TRACE = 7
+   HELICS_LOG_LEVEL_NO_PRINT = -1,
+   HELICS_LOG_LEVEL_ERROR = 0,
+   HELICS_LOG_LEVEL_WARNING = 1,
+   HELICS_LOG_LEVEL_SUMMARY = 2,
+   HELICS_LOG_LEVEL_CONNECTIONS = 3,
+   HELICS_LOG_LEVEL_INTERFACES = 4,
+   HELICS_LOG_LEVEL_TIMING = 5,
+   HELICS_LOG_LEVEL_DATA = 6,
+   HELICS_LOG_LEVEL_TRACE = 7
 } HelicsLogLevels;
 
 typedef enum {
-    HELICS_ERROR_FATAL = -404,
-    HELICS_ERROR_EXTERNAL_TYPE = -203,
-    HELICS_ERROR_OTHER = -101,
-    HELICS_ERROR_INSUFFICIENT_SPACE = -18,
-    HELICS_ERROR_EXECUTION_FAILURE = -14,
+   HELICS_ERROR_FATAL = -404,
+   HELICS_ERROR_EXTERNAL_TYPE = -203,
+   HELICS_ERROR_OTHER = -101,
+   HELICS_ERROR_INSUFFICIENT_SPACE = -18,
+   HELICS_ERROR_EXECUTION_FAILURE = -14,
 
-    HELICS_ERROR_INVALID_FUNCTION_CALL = -10,
-    HELICS_ERROR_INVALID_STATE_TRANSITION = -9,
-    HELICS_WARNING = -8,
-    HELICS_ERROR_SYSTEM_FAILURE = -6,
-    HELICS_ERROR_DISCARD = -5,
-    HELICS_ERROR_INVALID_ARGUMENT = -4,
-    HELICS_ERROR_INVALID_OBJECT = -3,
-    HELICS_ERROR_CONNECTION_FAILURE = -2,
-    HELICS_ERROR_REGISTRATION_FAILURE = -1,
-    HELICS_OK = 0
+   HELICS_ERROR_INVALID_FUNCTION_CALL = -10,
+   HELICS_ERROR_INVALID_STATE_TRANSITION = -9,
+   HELICS_WARNING = -8,
+   HELICS_ERROR_SYSTEM_FAILURE = -6,
+   HELICS_ERROR_DISCARD = -5,
+   HELICS_ERROR_INVALID_ARGUMENT = -4,
+   HELICS_ERROR_INVALID_OBJECT = -3,
+   HELICS_ERROR_CONNECTION_FAILURE = -2,
+   HELICS_ERROR_REGISTRATION_FAILURE = -1,
+   HELICS_OK = 0
 } HelicsErrorTypes;
 
 typedef enum {
-    HELICS_PROPERTY_TIME_DELTA = 137,
-    HELICS_PROPERTY_TIME_PERIOD = 140,
-    HELICS_PROPERTY_TIME_OFFSET = 141,
-    HELICS_PROPERTY_TIME_RT_LAG = 143,
-    HELICS_PROPERTY_TIME_RT_LEAD = 144,
-    HELICS_PROPERTY_TIME_RT_TOLERANCE = 145,
-    HELICS_PROPERTY_TIME_INPUT_DELAY = 148,
-    HELICS_PROPERTY_TIME_OUTPUT_DELAY = 150,
-    HELICS_PROPERTY_INT_MAX_ITERATIONS = 259,
-    HELICS_PROPERTY_INT_LOG_LEVEL = 271,
-    HELICS_PROPERTY_INT_FILE_LOG_LEVEL = 272,
-    HELICS_PROPERTY_INT_CONSOLE_LOG_LEVEL = 274
+   HELICS_PROPERTY_TIME_DELTA = 137,
+   HELICS_PROPERTY_TIME_PERIOD = 140,
+   HELICS_PROPERTY_TIME_OFFSET = 141,
+   HELICS_PROPERTY_TIME_RT_LAG = 143,
+   HELICS_PROPERTY_TIME_RT_LEAD = 144,
+   HELICS_PROPERTY_TIME_RT_TOLERANCE = 145,
+   HELICS_PROPERTY_TIME_INPUT_DELAY = 148,
+   HELICS_PROPERTY_TIME_OUTPUT_DELAY = 150,
+   HELICS_PROPERTY_INT_MAX_ITERATIONS = 259,
+   HELICS_PROPERTY_INT_LOG_LEVEL = 271,
+   HELICS_PROPERTY_INT_FILE_LOG_LEVEL = 272,
+   HELICS_PROPERTY_INT_CONSOLE_LOG_LEVEL = 274
 } HelicsProperties;
 
 typedef enum {
-    HELICS_MULTI_INPUT_NO_OP = 0,
-    HELICS_MULTI_INPUT_VECTORIZE_OPERATION = 1,
-    HELICS_MULTI_INPUT_AND_OPERATION = 2,
-    HELICS_MULTI_INPUT_OR_OPERATION = 3,
-    HELICS_MULTI_INPUT_SUM_OPERATION = 4,
-    HELICS_MULTI_INPUT_DIFF_OPERATION = 5,
-    HELICS_MULTI_INPUT_MAX_OPERATION = 6,
-    HELICS_MULTI_INPUT_MIN_OPERATION = 7,
-    HELICS_MULTI_INPUT_AVERAGE_OPERATION = 8
+   HELICS_MULTI_INPUT_NO_OP = 0,
+   HELICS_MULTI_INPUT_VECTORIZE_OPERATION = 1,
+   HELICS_MULTI_INPUT_AND_OPERATION = 2,
+   HELICS_MULTI_INPUT_OR_OPERATION = 3,
+   HELICS_MULTI_INPUT_SUM_OPERATION = 4,
+   HELICS_MULTI_INPUT_DIFF_OPERATION = 5,
+   HELICS_MULTI_INPUT_MAX_OPERATION = 6,
+   HELICS_MULTI_INPUT_MIN_OPERATION = 7,
+   HELICS_MULTI_INPUT_AVERAGE_OPERATION = 8
 } HelicsMultiInputModes;
 
 typedef enum {
-    HELICS_HANDLE_OPTION_CONNECTION_REQUIRED = 397,
-    HELICS_HANDLE_OPTION_CONNECTION_OPTIONAL = 402,
-    HELICS_HANDLE_OPTION_SINGLE_CONNECTION_ONLY = 407,
-    HELICS_HANDLE_OPTION_MULTIPLE_CONNECTIONS_ALLOWED = 409,
-    HELICS_HANDLE_OPTION_BUFFER_DATA = 411,
-    HELICS_HANDLE_OPTION_STRICT_TYPE_CHECKING = 414,
-    HELICS_HANDLE_OPTION_IGNORE_UNIT_MISMATCH = 447,
-    HELICS_HANDLE_OPTION_ONLY_TRANSMIT_ON_CHANGE = 452,
-    HELICS_HANDLE_OPTION_ONLY_UPDATE_ON_CHANGE = 454,
-    HELICS_HANDLE_OPTION_IGNORE_INTERRUPTS = 475,
-    HELICS_HANDLE_OPTION_MULTI_INPUT_HANDLING_METHOD = 507,
-    HELICS_HANDLE_OPTION_INPUT_PRIORITY_LOCATION = 510,
-    HELICS_HANDLE_OPTION_CLEAR_PRIORITY_LIST = 512,
-    HELICS_HANDLE_OPTION_CONNECTIONS = 522
+   HELICS_HANDLE_OPTION_CONNECTION_REQUIRED = 397,
+   HELICS_HANDLE_OPTION_CONNECTION_OPTIONAL = 402,
+   HELICS_HANDLE_OPTION_SINGLE_CONNECTION_ONLY = 407,
+   HELICS_HANDLE_OPTION_MULTIPLE_CONNECTIONS_ALLOWED = 409,
+   HELICS_HANDLE_OPTION_BUFFER_DATA = 411,
+   HELICS_HANDLE_OPTION_STRICT_TYPE_CHECKING = 414,
+   HELICS_HANDLE_OPTION_IGNORE_UNIT_MISMATCH = 447,
+   HELICS_HANDLE_OPTION_ONLY_TRANSMIT_ON_CHANGE = 452,
+   HELICS_HANDLE_OPTION_ONLY_UPDATE_ON_CHANGE = 454,
+   HELICS_HANDLE_OPTION_IGNORE_INTERRUPTS = 475,
+   HELICS_HANDLE_OPTION_MULTI_INPUT_HANDLING_METHOD = 507,
+   HELICS_HANDLE_OPTION_INPUT_PRIORITY_LOCATION = 510,
+   HELICS_HANDLE_OPTION_CLEAR_PRIORITY_LIST = 512,
+   HELICS_HANDLE_OPTION_CONNECTIONS = 522
 } HelicsHandleOptions;
 
 typedef enum {
-    HELICS_FILTER_TYPE_CUSTOM = 0,
-    HELICS_FILTER_TYPE_DELAY = 1,
-    HELICS_FILTER_TYPE_RANDOM_DELAY = 2,
-    HELICS_FILTER_TYPE_RANDOM_DROP = 3,
-    HELICS_FILTER_TYPE_REROUTE = 4,
-    HELICS_FILTER_TYPE_CLONE = 5,
-    HELICS_FILTER_TYPE_FIREWALL = 6
+   HELICS_FILTER_TYPE_CUSTOM = 0,
+   HELICS_FILTER_TYPE_DELAY = 1,
+   HELICS_FILTER_TYPE_RANDOM_DELAY = 2,
+   HELICS_FILTER_TYPE_RANDOM_DROP = 3,
+   HELICS_FILTER_TYPE_REROUTE = 4,
+   HELICS_FILTER_TYPE_CLONE = 5,
+   HELICS_FILTER_TYPE_FIREWALL = 6
 } HelicsFilterTypes;
 
 typedef enum { HELICS_QUERY_MODE_FAST = 0, HELICS_QUERY_MODE_ORDERED = 1 } HelicsQueryModes;
@@ -193,41 +196,41 @@ const HelicsBool HELICS_TRUE = 1;
 const HelicsBool HELICS_FALSE = 0;
 
 typedef enum {
-    HELICS_ITERATION_REQUEST_NO_ITERATION,
-    HELICS_ITERATION_REQUEST_FORCE_ITERATION,
-    HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+   HELICS_ITERATION_REQUEST_NO_ITERATION,
+   HELICS_ITERATION_REQUEST_FORCE_ITERATION,
+   HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
 } HelicsIterationRequest;
 
 typedef enum {
-    HELICS_ITERATION_RESULT_NEXT_STEP,
-    HELICS_ITERATION_RESULT_ERROR,
-    HELICS_ITERATION_RESULT_HALTED,
-    HELICS_ITERATION_RESULT_ITERATING
+   HELICS_ITERATION_RESULT_NEXT_STEP,
+   HELICS_ITERATION_RESULT_ERROR,
+   HELICS_ITERATION_RESULT_HALTED,
+   HELICS_ITERATION_RESULT_ITERATING
 } HelicsIterationResult;
 
 typedef enum {
-    HELICS_STATE_STARTUP = 0,
-    HELICS_STATE_INITIALIZATION,
-    HELICS_STATE_EXECUTION,
-    HELICS_STATE_FINALIZE,
-    HELICS_STATE_ERROR,
+   HELICS_STATE_STARTUP = 0,
+   HELICS_STATE_INITIALIZATION,
+   HELICS_STATE_EXECUTION,
+   HELICS_STATE_FINALIZE,
+   HELICS_STATE_ERROR,
 
-    HELICS_STATE_PENDING_INIT,
-    HELICS_STATE_PENDING_EXEC,
-    HELICS_STATE_PENDING_TIME,
-    HELICS_STATE_PENDING_ITERATIVE_TIME,
-    HELICS_STATE_PENDING_FINALIZE,
-    HELICS_STATE_FINISHED
+   HELICS_STATE_PENDING_INIT,
+   HELICS_STATE_PENDING_EXEC,
+   HELICS_STATE_PENDING_TIME,
+   HELICS_STATE_PENDING_ITERATIVE_TIME,
+   HELICS_STATE_PENDING_FINALIZE,
+   HELICS_STATE_FINISHED
 } HelicsFederateState;
 
 typedef struct HelicsComplex {
-    double real;
-    double imag;
+   double real;
+   double imag;
 } HelicsComplex;
 
 typedef struct HelicsError {
-    int32_t errorCode;
-    const char* message;
+   int32_t errorCode;
+   const char* message;
 } HelicsError;
 
 const char* helicsGetVersion(void);
@@ -241,13 +244,15 @@ HelicsCore helicsCreateCoreFromArgs(const char* type, const char* name, int argc
 HelicsCore helicsCoreClone(HelicsCore core, HelicsError* err);
 HelicsBool helicsCoreIsValid(HelicsCore core);
 HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString, HelicsError* err);
-HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
+HelicsBroker
+    helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
 HelicsBroker helicsBrokerClone(HelicsBroker broker, HelicsError* err);
 HelicsBool helicsBrokerIsValid(HelicsBroker broker);
 HelicsBool helicsBrokerIsConnected(HelicsBroker broker);
 void helicsBrokerDataLink(HelicsBroker broker, const char* source, const char* target, HelicsError* err);
 void helicsBrokerAddSourceFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
-void helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
+void
+    helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
 void helicsBrokerMakeConnections(HelicsBroker broker, const char* file, HelicsError* err);
 HelicsBool helicsCoreWaitForDisconnect(HelicsCore core, int msToWait, HelicsError* err);
 HelicsBool helicsBrokerWaitForDisconnect(HelicsBroker broker, int msToWait, HelicsError* err);
@@ -316,7 +321,9 @@ void helicsFederateEnterInitializingModeComplete(HelicsFederate fed, HelicsError
 void helicsFederateEnterExecutingMode(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeAsync(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeComplete(HelicsFederate fed, HelicsError* err);
-HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
+HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed,
+                                                                             HelicsIterationRequest iterate,
+                                                                             HelicsError* err);
 void helicsFederateEnterExecutingModeIterativeAsync(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 HelicsIterationResult helicsFederateEnterExecutingModeIterativeComplete(HelicsFederate fed, HelicsError* err);
 HelicsFederateState helicsFederateGetState(HelicsFederate fed, HelicsError* err);
@@ -325,14 +332,17 @@ HelicsTime helicsFederateRequestTime(HelicsFederate fed, HelicsTime requestTime,
 HelicsTime helicsFederateRequestTimeAdvance(HelicsFederate fed, HelicsTime timeDelta, HelicsError* err);
 HelicsTime helicsFederateRequestNextStep(HelicsFederate fed, HelicsError* err);
 HelicsTime helicsFederateRequestTimeIterative(HelicsFederate fed,
-                                              HelicsTime requestTime,
-                                              HelicsIterationRequest iterate,
-                                              HelicsIterationResult* outIteration,
-                                              HelicsError* err);
+                                                           HelicsTime requestTime,
+                                                           HelicsIterationRequest iterate,
+                                                           HelicsIterationResult* outIteration,
+                                                           HelicsError* err);
 void helicsFederateRequestTimeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsError* err);
 HelicsTime helicsFederateRequestTimeComplete(HelicsFederate fed, HelicsError* err);
-void helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
-HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed, HelicsIterationResult* outIterate, HelicsError* err);
+void
+    helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
+HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed,
+                                                                   HelicsIterationResult* outIterate,
+                                                                   HelicsError* err);
 const char* helicsFederateGetName(HelicsFederate fed);
 void helicsFederateSetTimeProperty(HelicsFederate fed, int timeProperty, HelicsTime time, HelicsError* err);
 void helicsFederateSetFlagOption(HelicsFederate fed, int flag, HelicsBool flagValue, HelicsError* err);
@@ -384,8 +394,10 @@ HelicsPublication
     helicsFederateRegisterGlobalPublication(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalTypePublication(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
-HelicsInput helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
-HelicsInput helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
+HelicsInput
+    helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
+HelicsInput
+    helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
@@ -427,7 +439,8 @@ HelicsComplex helicsInputGetComplexObject(HelicsInput ipt, HelicsError* err);
 void helicsInputGetComplex(HelicsInput ipt, double* real, double* imag, HelicsError* err);
 int helicsInputGetVectorSize(HelicsInput ipt);
 void helicsInputGetVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
-void helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
+void
+    helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
 
 void helicsInputSetDefaultBytes(HelicsInput ipt, const void* data, int inputDataLength, HelicsError* err);
 void helicsInputSetDefaultString(HelicsInput ipt, const char* str, HelicsError* err);
@@ -469,22 +482,30 @@ int helicsFederateGetInputCount(HelicsFederate fed);
 
 HelicsEndpoint helicsFederateRegisterEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateRegisterGlobalEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
+HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed,
+                                                                   const char* name,
+                                                                   const char* type,
+                                                                   HelicsError* err);
+HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed,
+                                                                         const char* name,
+                                                                         const char* type,
+                                                                         HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpoint(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpointByIndex(HelicsFederate fed, int index, HelicsError* err);
 HelicsBool helicsEndpointIsValid(HelicsEndpoint endpoint);
 void helicsEndpointSetDefaultDestination(HelicsEndpoint endpoint, const char* dst, HelicsError* err);
 const char* helicsEndpointGetDefaultDestination(HelicsEndpoint endpoint);
 void helicsEndpointSendBytes(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsError* err);
-void helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
+void
+    helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
 void helicsEndpointSendBytesToAt(HelicsEndpoint endpoint,
-                                 const void* data,
-                                 int inputDataLength,
-                                 const char* dst,
-                                 HelicsTime time,
-                                 HelicsError* err);
-void helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
+                                              const void* data,
+                                              int inputDataLength,
+                                              const char* dst,
+                                              HelicsTime time,
+                                              HelicsError* err);
+void
+    helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
 void helicsEndpointSendMessage(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSendMessageZeroCopy(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSubscribe(HelicsEndpoint endpoint, const char* key, HelicsError* err);
@@ -541,7 +562,10 @@ void helicsMessageFree(HelicsMessage message);
 void helicsMessageClear(HelicsMessage message, HelicsError* err);
 
 HelicsFilter helicsFederateRegisterFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
-HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
+HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed,
+                                                             HelicsFilterTypes type,
+                                                             const char* name,
+                                                             HelicsError* err);
 HelicsFilter helicsFederateRegisterCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterGlobalCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsCoreRegisterFilter(HelicsCore core, HelicsFilterTypes type, const char* name, HelicsError* err);
@@ -565,23 +589,26 @@ void helicsFilterSetOption(HelicsFilter filt, int option, int value, HelicsError
 int helicsFilterGetOption(HelicsFilter filt, int option);
 
 void helicsBrokerSetLoggingCallback(HelicsBroker broker,
+                                                 void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                                 void* userdata,
+                                                 HelicsError* err);
+void helicsCoreSetLoggingCallback(HelicsCore core,
+                                               void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                               void* userdata,
+                                               HelicsError* err);
+void
+    helicsFederateSetLoggingCallback(HelicsFederate fed,
                                     void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
                                     void* userdata,
                                     HelicsError* err);
-void helicsCoreSetLoggingCallback(HelicsCore core,
-                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+void helicsFilterSetCustomCallback(HelicsFilter filter,
+                                                void (*filtCall)(HelicsMessage message, void* userData),
+                                                void* userdata,
+                                                HelicsError* err);
+void
+    helicsFederateSetQueryCallback(HelicsFederate fed,
+                                  void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
                                   void* userdata,
                                   HelicsError* err);
-void helicsFederateSetLoggingCallback(HelicsFederate fed,
-                                      void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                      void* userdata,
-                                      HelicsError* err);
-void helicsFilterSetCustomCallback(HelicsFilter filter,
-                                   void (*filtCall)(HelicsMessage message, void* userData),
-                                   void* userdata,
-                                   HelicsError* err);
-void helicsFederateSetQueryCallback(HelicsFederate fed,
-                                    void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
-                                    void* userdata,
-                                    HelicsError* err);
 void helicsQueryBufferFill(HelicsQueryBuffer buffer, const char* str, int strSize, HelicsError* err);
+

--- a/src/helics/shared_api_library/backup/helics_api.h
+++ b/src/helics/shared_api_library/backup/helics_api.h
@@ -229,7 +229,7 @@ typedef struct HelicsComplex {
 } HelicsComplex;
 
 typedef struct HelicsError {
-   int32_t errorCode;
+   int32_t error_code;
    const char* message;
 } HelicsError;
 

--- a/src/helics/shared_api_library/helicsCallbacks.cpp
+++ b/src/helics/shared_api_library/helicsCallbacks.cpp
@@ -126,7 +126,7 @@ void helicsQueryBufferFill(HelicsQueryBuffer buffer, const char* string, int str
 {
     static const char* invalidBuffer = "The given buffer is not valid";
 
-    if (((err) != nullptr) && ((err)->errorCode != 0)) {
+    if (((err) != nullptr) && ((err)->error_code != 0)) {
         return;
     }
     if (buffer == nullptr) {

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -45,7 +45,7 @@ const std::string emptyStr;
 HelicsError helicsErrorInitialize(void)
 {
     HelicsError err;
-    err.errorCode = 0;
+    err.error_code = 0;
     err.message = nullstrPtr;
     return err;
 }
@@ -54,7 +54,7 @@ HelicsError helicsErrorInitialize(void)
 void helicsErrorClear(HelicsError* err)
 {
     if (err != nullptr) {
-        err->errorCode = 0;
+        err->error_code = 0;
         err->message = nullstrPtr;
     }
 }
@@ -98,55 +98,55 @@ void helicsErrorHandler(HelicsError* err) noexcept
                 std::rethrow_exception(eptr);
             } else {
                 // LCOV_EXCL_START
-                err->errorCode = HELICS_ERROR_EXTERNAL_TYPE;
+                err->error_code = HELICS_ERROR_EXTERNAL_TYPE;
                 err->message = unknown_err_string;
                 // LCOV_EXCL_STOP
             }
         }
         catch (const helics::InvalidFunctionCall& ifc) {
-            err->errorCode = HELICS_ERROR_INVALID_FUNCTION_CALL;
+            err->error_code = HELICS_ERROR_INVALID_FUNCTION_CALL;
             err->message = getMasterHolder()->addErrorString(ifc.what());
         }
         catch (const helics::InvalidParameter& ip) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(ip.what());
         }
         catch (const helics::RegistrationFailure& rf) {
-            err->errorCode = HELICS_ERROR_REGISTRATION_FAILURE;
+            err->error_code = HELICS_ERROR_REGISTRATION_FAILURE;
             err->message = getMasterHolder()->addErrorString(rf.what());
         }
         catch (const helics::ConnectionFailure& cf) {
-            err->errorCode = HELICS_ERROR_CONNECTION_FAILURE;
+            err->error_code = HELICS_ERROR_CONNECTION_FAILURE;
             err->message = getMasterHolder()->addErrorString(cf.what());
         }
         // LCOV_EXCL_START
         catch (const helics::InvalidIdentifier& iid) {
-            err->errorCode = HELICS_ERROR_INVALID_OBJECT;
+            err->error_code = HELICS_ERROR_INVALID_OBJECT;
             err->message = getMasterHolder()->addErrorString(iid.what());
         }
         catch (const helics::HelicsSystemFailure& ht) {
-            err->errorCode = HELICS_ERROR_SYSTEM_FAILURE;
+            err->error_code = HELICS_ERROR_SYSTEM_FAILURE;
             err->message = getMasterHolder()->addErrorString(ht.what());
         }
         // LCOV_EXCL_STOP
         catch (const helics::HelicsException& he) {
-            err->errorCode = HELICS_ERROR_OTHER;
+            err->error_code = HELICS_ERROR_OTHER;
             err->message = getMasterHolder()->addErrorString(he.what());
         }
         catch (const std::exception& exc) {
-            err->errorCode = HELICS_ERROR_EXTERNAL_TYPE;
+            err->error_code = HELICS_ERROR_EXTERNAL_TYPE;
             err->message = getMasterHolder()->addErrorString(exc.what());
         }
         // LCOV_EXCL_START
         catch (...) {
-            err->errorCode = HELICS_ERROR_EXTERNAL_TYPE;
+            err->error_code = HELICS_ERROR_EXTERNAL_TYPE;
             err->message = unknown_err_string;
         }
         // LCOV_EXCL_STOP
     }
     // LCOV_EXCL_START
     catch (...) {
-        err->errorCode = HELICS_ERROR_EXTERNAL_TYPE;
+        err->error_code = HELICS_ERROR_EXTERNAL_TYPE;
         err->message = unknown_err_string;
     }
     // LCOV_EXCL_STOP
@@ -158,7 +158,7 @@ static constexpr char invalidBrokerString[] = "broker object is not valid";
 namespace helics {
 CoreObject* getCoreObject(HelicsCore core, HelicsError* err) noexcept
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     if (core == nullptr) {
@@ -175,7 +175,7 @@ CoreObject* getCoreObject(HelicsCore core, HelicsError* err) noexcept
 
 BrokerObject* getBrokerObject(HelicsBroker broker, HelicsError* err) noexcept
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     if (broker == nullptr) {
@@ -220,7 +220,7 @@ helics::Broker* getBroker(HelicsBroker broker, HelicsError* err)
 
 HelicsCore helicsCreateCore(const char* type, const char* name, const char* initString, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
 
@@ -228,7 +228,7 @@ HelicsCore helicsCreateCore(const char* type, const char* name, const char* init
 
     if (ct == helics::CoreType::UNRECOGNIZED) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(std::string("core type ") + type + " is not recognized");
         }
         return nullptr;
@@ -255,14 +255,14 @@ HelicsCore helicsCreateCore(const char* type, const char* name, const char* init
 
 HelicsCore helicsCreateCoreFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     helics::CoreType ct = (type != nullptr) ? helics::core::coreTypeFromString(type) : helics::CoreType::DEFAULT;
 
     if (ct == helics::CoreType::UNRECOGNIZED) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(std::string("core type ") + type + " is not recognized");
         }
         return nullptr;
@@ -314,12 +314,12 @@ HelicsBool helicsCoreIsValid(HelicsCore core)
 
 HelicsFederate helicsGetFederateByName(const char* fedName, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     if (fedName == nullptr) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString("fedName is empty");
         }
         return nullptr;
@@ -328,7 +328,7 @@ HelicsFederate helicsGetFederateByName(const char* fedName, HelicsError* err)
     auto* fed = mob->findFed(fedName);
     if (fed == nullptr) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(std::string(fedName) + " is not an active federate identifier");
         }
         return nullptr;
@@ -338,14 +338,14 @@ HelicsFederate helicsGetFederateByName(const char* fedName, HelicsError* err)
 
 HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     helics::CoreType ct = (type != nullptr) ? helics::core::coreTypeFromString(type) : helics::CoreType::DEFAULT;
 
     if (ct == helics::CoreType::UNRECOGNIZED) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(std::string("core type ") + type + " is not recognized");
         }
         return nullptr;
@@ -366,14 +366,14 @@ HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* 
 
 HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     helics::CoreType ct = (type != nullptr) ? helics::core::coreTypeFromString(type) : helics::CoreType::DEFAULT;
 
     if (ct == helics::CoreType::UNRECOGNIZED) {
         if (err != nullptr) {
-            err->errorCode = HELICS_ERROR_INVALID_ARGUMENT;
+            err->error_code = HELICS_ERROR_INVALID_ARGUMENT;
             err->message = getMasterHolder()->addErrorString(std::string("core type ") + type + " is not recognized");
         }
         return nullptr;
@@ -834,7 +834,7 @@ static const int validQueryIdentifier = 0x2706'3885;
 
 static helics::QueryObject* getQueryObj(HelicsQuery query, HelicsError* err)
 {
-    if ((err != nullptr) && (err->errorCode != 0)) {
+    if ((err != nullptr) && (err->error_code != 0)) {
         return nullptr;
     }
     if (query == nullptr) {

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -153,7 +153,7 @@ class QueryObject {
 /** definitions to simplify error returns if an error already exists*/
 #define HELICS_ERROR_CHECK(err, retval)                                                                                                    \
     do {                                                                                                                                   \
-        if (((err) != nullptr) && ((err)->error_code != 0)) {                                                                               \
+        if (((err) != nullptr) && ((err)->error_code != 0)) {                                                                              \
             return (retval);                                                                                                               \
         }                                                                                                                                  \
     } while (false)

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -153,16 +153,16 @@ class QueryObject {
 /** definitions to simplify error returns if an error already exists*/
 #define HELICS_ERROR_CHECK(err, retval)                                                                                                    \
     do {                                                                                                                                   \
-        if (((err) != nullptr) && ((err)->errorCode != 0)) {                                                                               \
+        if (((err) != nullptr) && ((err)->error_code != 0)) {                                                                               \
             return (retval);                                                                                                               \
         }                                                                                                                                  \
     } while (false)
 
 /** assign an error string and code to an error object if it exists*/
-inline void assignError(HelicsError* err, int errorCode, const char* string)
+inline void assignError(HelicsError* err, int error_code, const char* string)
 {
     if (err != nullptr) {
-        err->errorCode = errorCode;
+        err->error_code = error_code;
         err->message = string;
     }
 }

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -37,7 +37,7 @@ TEST_P(filter_simple_type_tests, registration)
 
     helicsFederateRegisterGlobalEndpoint(mFed, "port1", "", &err);
     helicsFederateRegisterGlobalEndpoint(mFed, "port2", nullptr, &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(auto f1 = helicsFederateRegisterFilter(fFed, HELICS_FILTER_TYPE_CUSTOM, "filter1", &err));
     CE(helicsFilterAddSourceTarget(f1, "port1", &err));
     EXPECT_TRUE(f1 != nullptr);
@@ -61,7 +61,7 @@ TEST_P(filter_simple_type_tests, registration)
     EXPECT_STREQ(tmp, "filter0/c4");
 
     auto f1_n = helicsFederateGetFilterByIndex(fFed, -2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(f1_n, nullptr);
     helicsErrorClear(&err);
 
@@ -171,10 +171,10 @@ TEST_P(filter_simple_type_tests, message_filter_function)
         mFed, HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, HELICS_TRUE, &err));
     auto p1 = helicsFederateRegisterGlobalEndpoint(mFed, "port1", nullptr, &err);
     auto p2 = helicsFederateRegisterGlobalEndpoint(mFed, "port2", "", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
 
     auto f1 = helicsFederateRegisterFilter(fFed, HELICS_FILTER_TYPE_DELAY, "filter1", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFilterAddSourceTarget(f1, "port1", &err));
     EXPECT_TRUE(f1 != nullptr);
     CE(helicsFilterSet(f1, "delay", 2.5, &err));
@@ -234,10 +234,10 @@ TEST_P(filter_simple_type_tests, function_mObj)
         mFed, HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, HELICS_TRUE, &err));
     auto p1 = helicsFederateRegisterGlobalEndpoint(mFed, "port1", nullptr, &err);
     auto p2 = helicsFederateRegisterGlobalEndpoint(mFed, "port2", "", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
 
     auto f1 = helicsFederateRegisterFilter(fFed, HELICS_FILTER_TYPE_DELAY, "filter1", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFilterAddSourceTarget(f1, "port1", &err));
     EXPECT_TRUE(f1 != nullptr);
     CE(helicsFilterSet(f1, "delay", 2.5, &err));
@@ -300,10 +300,10 @@ TEST_P(filter_simple_type_tests, function_two_stage)
 
     auto p1 = helicsFederateRegisterGlobalEndpoint(mFed, "port1", "", &err);
     auto p2 = helicsFederateRegisterGlobalEndpoint(mFed, "port2", "", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
 
     auto f1 = helicsFederateRegisterFilter(fFed, HELICS_FILTER_TYPE_DELAY, "filter1", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFilterAddSourceTarget(f1, "port1", &err));
 
     EXPECT_TRUE(f1 != nullptr);
@@ -382,7 +382,7 @@ TEST_P(filter_simple_type_tests, function2)
 
     auto p1 = helicsFederateRegisterGlobalEndpoint(mFed, "port1", "", &err);
     auto p2 = helicsFederateRegisterGlobalEndpoint(mFed, "port2", "", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
 
     CE(auto f1 = helicsFederateRegisterFilter(fFed, HELICS_FILTER_TYPE_DELAY, "filter1", &err));
     helicsFilterAddSourceTarget(f1, "port1", nullptr);
@@ -395,7 +395,7 @@ TEST_P(filter_simple_type_tests, function2)
     CE(helicsFilterSet(f2, "delay", 2.5, &err));
     // this is expected to fail since a regular filter doesn't have a delivery endpoint
     helicsFilterAddDeliveryEndpoint(f2, "port1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     CE(helicsFederateEnterExecutingModeAsync(fFed, &err));
@@ -453,7 +453,7 @@ TEST_P(filter_simple_type_tests, message_filter_function3)
 
     auto p1 = helicsFederateRegisterGlobalEndpoint(mFed, "port1", "", &err);
     auto p2 = helicsFederateRegisterGlobalEndpoint(mFed, "port2", "random", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
 
     CE(auto f1 =
            helicsFederateRegisterGlobalFilter(fFed, HELICS_FILTER_TYPE_CUSTOM, "filter1", &err));
@@ -530,7 +530,7 @@ TEST_F(filter_tests, clone_test)
 
     auto f1 = helicsFederateRegisterCloningFilter(dcFed, nullptr, &err);
     CE(helicsFilterAddDeliveryEndpoint(f1, "cm", &err));
-    EXPECT_TRUE(err.errorCode == HELICS_OK);
+    EXPECT_TRUE(err.error_code == HELICS_OK);
     CE(helicsFilterAddSourceTarget(f1, "src", &err));
 
     CE(helicsFederateEnterExecutingModeAsync(sFed, &err));
@@ -600,7 +600,7 @@ TEST_F(filter_tests, clone_test_connections)
 
     auto f1 = helicsFederateRegisterGlobalCloningFilter(dcFed, "filt1", &err);
     CE(helicsFilterAddDeliveryEndpoint(f1, "cm", &err));
-    EXPECT_TRUE(err.errorCode == HELICS_OK);
+    EXPECT_TRUE(err.error_code == HELICS_OK);
 
     auto cr = helicsFederateGetCore(sFed, &err);
 
@@ -608,7 +608,7 @@ TEST_F(filter_tests, clone_test_connections)
 
     // error test
     helicsCoreAddSourceFilterToEndpoint(cr, nullptr, "src", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     CE(helicsFederateEnterExecutingModeAsync(sFed, &err));
@@ -686,13 +686,13 @@ TEST_F(filter_tests, clone_test_broker_connections)
 
     auto f1 = helicsFederateRegisterGlobalCloningFilter(dcFed, "filt1", &err);
     CE(helicsFilterAddDeliveryEndpoint(f1, "cm", &err));
-    EXPECT_TRUE(err.errorCode == HELICS_OK);
+    EXPECT_TRUE(err.error_code == HELICS_OK);
 
     CE(helicsBrokerAddSourceFilterToEndpoint(brokers[0], "filt1", "src", &err));
 
     // error test
     helicsBrokerAddSourceFilterToEndpoint(brokers[0], nullptr, "src", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     CE(helicsFederateEnterExecutingModeAsync(sFed, &err));
@@ -762,7 +762,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
 
     auto f1 = helicsFederateRegisterGlobalCloningFilter(dcFed, "filt1", &err);
     CE(helicsFilterAddDeliveryEndpoint(f1, "cm", &err));
-    EXPECT_TRUE(err.errorCode == HELICS_OK);
+    EXPECT_TRUE(err.error_code == HELICS_OK);
 
     auto cr = helicsFederateGetCore(sFed, &err);
 
@@ -771,7 +771,7 @@ TEST_F(filter_tests, clone_test_dest_connections)
     // error test
     helicsCoreAddDestinationFilterToEndpoint(cr, nullptr, "dest", &err);
 
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsCoreFree(cr);
 
@@ -851,13 +851,13 @@ TEST_F(filter_tests, clone_test_broker_dest_connections)
 
     auto f1 = helicsFederateRegisterGlobalCloningFilter(dcFed, "filt1", &err);
     CE(helicsFilterAddDeliveryEndpoint(f1, "cm", &err));
-    EXPECT_TRUE(err.errorCode == HELICS_OK);
+    EXPECT_TRUE(err.error_code == HELICS_OK);
 
     CE(helicsBrokerAddDestinationFilterToEndpoint(brokers[0], "filt1", "dest", &err));
 
     // error test
     helicsBrokerAddDestinationFilterToEndpoint(brokers[0], nullptr, "dest", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     CE(helicsFederateEnterExecutingModeAsync(sFed, &err));
@@ -930,17 +930,17 @@ TEST_F(filter_tests, multi_clone_test)
     auto dcFed = GetFederateAt(3);
 
     auto p1 = helicsFederateRegisterGlobalEndpoint(sFed, "src", "", &err);
-    ASSERT_EQ(err.errorCode, 0);
+    ASSERT_EQ(err.error_code, 0);
     auto p2 = helicsFederateRegisterGlobalEndpoint(sFed2, "src2", "", &err);
-    ASSERT_EQ(err.errorCode, 0);
+    ASSERT_EQ(err.error_code, 0);
     auto p3 = helicsFederateRegisterGlobalEndpoint(dFed, "dest", "", &err);
-    ASSERT_EQ(err.errorCode, 0);
+    ASSERT_EQ(err.error_code, 0);
     auto p4 = helicsFederateRegisterGlobalEndpoint(dcFed, "cm", "", &err);
-    ASSERT_EQ(err.errorCode, 0);
+    ASSERT_EQ(err.error_code, 0);
 
     auto f1 = helicsFederateRegisterCloningFilter(dcFed, "", &err);
     helicsFilterAddDeliveryEndpoint(f1, "cm", nullptr);
-    ASSERT_EQ(err.errorCode, 0);
+    ASSERT_EQ(err.error_code, 0);
     CE(helicsFilterAddSourceTarget(f1, "src", &err));
     CE(helicsFilterAddSourceTarget(f1, "src2", &err));
 
@@ -1069,18 +1069,18 @@ TEST_F(filter_tests, callback_test)
         mFed, HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, HELICS_TRUE, &err));
     auto p1 = helicsFederateRegisterGlobalEndpoint(mFed, "port1", nullptr, &err);
     auto p2 = helicsFederateRegisterGlobalEndpoint(mFed, "port2", "", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
 
     auto f1 = helicsFederateRegisterFilter(fFed, HELICS_FILTER_TYPE_CUSTOM, "filter1", &err);
     auto f2 = helicsFederateRegisterFilter(mFed, HELICS_FILTER_TYPE_DELAY, "dfilter", &err);
 
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFilterAddSourceTarget(f1, "port1", &err));
     CE(helicsFilterSetCustomCallback(f1, filterFunc1, nullptr, &err));
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFilterSetCustomCallback(f2, filterFunc1, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     CE(helicsFederateEnterExecutingModeAsync(fFed, &err));

--- a/tests/helics/shared_library/SystemTests.cpp
+++ b/tests/helics/shared_library/SystemTests.cpp
@@ -30,22 +30,22 @@ TEST(other_tests, broker_global_value)
     EXPECT_EQ(res, globalVal2);
 
     res = helicsQueryBrokerExecute(nullptr, brk, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
 
     res = helicsQueryBrokerExecute(q, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
 
     res = helicsQueryBrokerExecute(nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
 
     helicsBrokerSetGlobal(brk, nullptr, "v2", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsBrokerDisconnect(brk, &err);
@@ -62,10 +62,10 @@ TEST(other_tests, core_global_value)
     auto brk = helicsCreateBroker("test", "gbrokerc", "--root", &err);
 
     auto cr = helicsCreateCore("test", "gcore", "--broker=gbrokerc", &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     auto connected = helicsCoreConnect(cr, &err);
     EXPECT_EQ(connected, HELICS_TRUE);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(helicsCoreIsConnected(cr), HELICS_TRUE);
     std::string globalVal = "this is a string constant that functions as a global";
     std::string globalVal2 = "this is a second string constant that functions as a global";
@@ -79,19 +79,19 @@ TEST(other_tests, core_global_value)
     res = helicsQueryCoreExecute(q, cr, &err);
     EXPECT_EQ(res, globalVal2);
     res = helicsQueryCoreExecute(nullptr, cr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
     res = helicsQueryCoreExecute(q, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
     res = helicsQueryCoreExecute(nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
     helicsCoreSetGlobal(cr, nullptr, "v2", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsBrokerDisconnect(brk, &err);
     helicsCoreDisconnect(cr, &err);
@@ -118,17 +118,17 @@ TEST(other_tests, federate_global_value)
 
     auto fi = helicsCreateFederateInfo();
     helicsFederateInfoLoadFromArgs(fi, 4, argv, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     auto fed = helicsCreateValueFederate("fed0", fi, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     argv[3] = "--period=frogs";  // this is meant to generate an error in command line processing
 
     auto fi2 = helicsFederateInfoClone(fi, &err);
     EXPECT_NE(fi2, nullptr);
     helicsFederateInfoLoadFromArgs(fi2, 4, argv, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateInfoFree(fi2);
@@ -160,30 +160,30 @@ TEST(other_tests, federate_global_value)
 
     // a series of invalid query calls
     res = helicsQueryExecute(nullptr, fed, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
 
     res = helicsQueryExecute(q, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
 
     res = helicsQueryExecute(nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_STREQ("#invalid", res);
 
     helicsFederateSetGlobal(fed, nullptr, "v2", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsQueryExecuteAsync(q, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsQueryExecuteAsync(nullptr, fed, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(fed, &err);
@@ -217,7 +217,7 @@ TEST(other_tests, federate_add_dependency)
     helicsFederateInfoSetFlagOption(fi, HELICS_FLAG_SOURCE_ONLY, HELICS_TRUE, &err);
 
     auto fed1 = helicsCreateMessageFederate("fed1", fi, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     auto fi2 = helicsCreateFederateInfo();
     helicsFederateInfoLoadFromArgs(fi2, 4, argv, &err);
@@ -227,7 +227,7 @@ TEST(other_tests, federate_add_dependency)
     helicsFederateRegisterGlobalEndpoint(fed1, "ept1", nullptr, &err);
 
     helicsFederateAddDependency(fed1, "fed2", &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateEnterExecutingModeAsync(fed1, &err);
     helicsFederateEnterExecutingMode(fed2, &err);
@@ -254,14 +254,14 @@ TEST(other_tests, core_creation)
     argv[3] = "--broker=gbrokerc";
 
     auto cr = helicsCreateCoreFromArgs("test", nullptr, 4, argv, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_STREQ(helicsCoreGetIdentifier(cr), "gcore");
 
     argv[1] = "--name=gcore2";
     argv[2] = "--log_level=what_logs?";
 
     auto cr2 = helicsCreateCoreFromArgs("test", nullptr, 4, argv, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(cr2, nullptr);
 
@@ -283,14 +283,14 @@ TEST(other_tests, broker_creation)
     argv[3] = "--root";
 
     auto brk = helicsCreateBrokerFromArgs("test", nullptr, 4, argv, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_STREQ(helicsBrokerGetIdentifier(brk), "gbrokerc");
 
     argv[1] = "--name=gbrokerc2";
     argv[2] = "--log_level=what_logs?";
 
     auto brk2 = helicsCreateBrokerFromArgs("test", nullptr, 4, argv, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(brk2, nullptr);
 
@@ -313,7 +313,7 @@ TEST(federate_tests, federateGeneratedLocalError)
 
     auto err = helicsErrorInitialize();
     helicsFederateRequestTime(fed1, 3.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     auto cr = helicsFederateGetCore(fed1, nullptr);
     helicsCoreDisconnect(cr, nullptr);
@@ -337,7 +337,7 @@ TEST(federate_tests, federateGeneratedGlobalError)
 
     auto err = helicsErrorInitialize();
     helicsFederateRequestTime(fed1, 3.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     helicsFederateDestroy(fed1);
 }

--- a/tests/helics/shared_library/TimingTests.cpp
+++ b/tests/helics/shared_library/TimingTests.cpp
@@ -106,7 +106,7 @@ TEST_F(timing_tests, simple_timing_test_message)
 
     auto ept1 = helicsFederateRegisterGlobalEndpoint(vFed1, "e1", "", &err);
     helicsFederateRegisterGlobalEndpoint(vFed2, "e2", "", &err);
-    ASSERT_EQ(err.errorCode, 0);
+    ASSERT_EQ(err.error_code, 0);
     CE(helicsFederateEnterExecutingModeAsync(vFed1, &err));
     CE(helicsFederateEnterExecutingMode(vFed2, &err));
     CE(helicsFederateEnterExecutingModeComplete(vFed1, &err));

--- a/tests/helics/shared_library/badInputTests.cpp
+++ b/tests/helics/shared_library/badInputTests.cpp
@@ -24,17 +24,17 @@ TEST_F(bad_input_tests, test_bad_fed)
 
     CE(helicsFederateEnterInitializingMode(vFed1, &err));
     helicsFederateEnterInitializingMode(vFed2, &err);
-    EXPECT_EQ(err.errorCode, HELICS_ERROR_INVALID_OBJECT);
+    EXPECT_EQ(err.error_code, HELICS_ERROR_INVALID_OBJECT);
     helicsErrorClear(&err);
     // auto core = helicsFederateGetCoreObject(vFed1);
 
     CE(helicsFederateFinalize(vFed1, &err));
     helicsFederateFinalize(vFed2, &err);
-    EXPECT_EQ(err.errorCode, HELICS_ERROR_INVALID_OBJECT);
+    EXPECT_EQ(err.error_code, HELICS_ERROR_INVALID_OBJECT);
 
     helicsFederateFree(vFed1);
     helicsFederateGetCurrentTime(vFed1, &err);
-    EXPECT_EQ(err.errorCode, HELICS_ERROR_INVALID_OBJECT);
+    EXPECT_EQ(err.error_code, HELICS_ERROR_INVALID_OBJECT);
     helicsErrorClear(&err);
     // just make sure this doesn't crash
     helicsFederateFree(vFed1);
@@ -72,7 +72,7 @@ TEST_F(bad_input_tests, test_mistaken_finalize)
     CE(helicsFederateEnterInitializingMode(vFed1, &err));
     helicsFederateFinalize(fi, &err);
 
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     helicsFederateInfoFree(vFed1);  // this is totally wrong but we are testing it
     helicsFederateFree(fi);  // this is also backwards
@@ -90,7 +90,7 @@ TEST_F(bad_input_tests, test_creation)
     SetupTest(helicsCreateValueFederate, "zmq", 1);
 
     auto fed2 = helicsCreateValueFederate("fed3", nullptr, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_TRUE(helicsFederateIsValid(fed2) == HELICS_TRUE);
 }
 
@@ -98,10 +98,10 @@ TEST(error_tests, unavailable_CoreType)
 {
     auto err = helicsErrorInitialize();
     auto core = helicsCreateCore("nullcore", "test", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     auto brk = helicsCreateBroker("null", "test", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     EXPECT_EQ(helicsIsCoreTypeAvailable("null"), HELICS_FALSE);
     EXPECT_EQ(helicsIsCoreTypeAvailable(nullptr), HELICS_FALSE);
@@ -124,12 +124,12 @@ TEST_F(function_tests, execution_iteration_test)
         vFed1, "pub1", HELICS_DATA_TYPE_DOUBLE, "", nullptr);
     auto pubid2 =
         helicsFederateRegisterGlobalPublication(vFed1, "pub1", HELICS_DATA_TYPE_DOUBLE, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(pubid2, nullptr);
     auto subid = helicsFederateRegisterSubscription(vFed1, "pub1", "", nullptr);
     helicsErrorClear(&err);
     helicsFederateSetTimeProperty(vFed1, HELICS_PROPERTY_TIME_DELTA, -1.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsFederateSetTimeProperty(vFed1, HELICS_PROPERTY_TIME_DELTA, 1.0, nullptr);
 
     helicsFederateEnterInitializingMode(vFed1, nullptr);
@@ -168,7 +168,7 @@ TEST_F(function_tests, input_test)
     auto subid2 = helicsFederateRegisterInput(vFed1, "inp1", HELICS_DATA_TYPE_DOUBLE, "", &err);
 
     EXPECT_EQ(subid2, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsInputAddTarget(subid, "pub1", nullptr);
@@ -181,7 +181,7 @@ TEST_F(function_tests, input_test)
 
     auto ept1 = helicsFederateRegisterEndpoint(vFed1, "ept1", "", &err);
     EXPECT_EQ(ept1, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateEnterInitializingMode(vFed1, nullptr);
@@ -207,17 +207,17 @@ TEST_F(function_tests, input_test)
     EXPECT_EQ(val2, val);
     // expect error entering initializing Mode again
     helicsFederateEnterInitializingMode(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     // expect error entering initializing Mode again
     helicsFederateEnterInitializingModeAsync(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     // expect error entering initializing Mode again
     helicsFederateEnterInitializingModeComplete(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -235,7 +235,7 @@ TEST_F(function_tests, raw)
 
     auto pubid2 = helicsFederateRegisterGlobalPublication(
         vFed1, "pub2", static_cast<HelicsDataTypes>(6985), "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(pubid2, nullptr);
 
@@ -244,7 +244,7 @@ TEST_F(function_tests, raw)
     // this is just a random bad data type
     auto subid3 =
         helicsFederateRegisterInput(vFed1, "inp3", static_cast<HelicsDataTypes>(-6985), "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(subid3, nullptr);
     helicsErrorClear(&err);
 
@@ -259,18 +259,18 @@ TEST_F(function_tests, raw)
     // doubles and ints are not recognized
     auto val = helicsInputGetDouble(subid, &err);
     EXPECT_NE(val, 0.0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     auto val2 = helicsInputGetInteger(subid, &err);
     EXPECT_NE(val2, 0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     char loc[50] = "";
     int sz{0};
     // named point can generate a string
     helicsInputGetNamedPoint(subid, loc, 50, &sz, &val, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateFinalize(vFed1, nullptr);
 }
@@ -287,20 +287,20 @@ TEST_F(function_tests, raw2)
 
     auto pubid2 = helicsFederateRegisterPublication(
         vFed1, "pub2", static_cast<HelicsDataTypes>(-6985), "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(pubid2, nullptr);
 
     auto subid =
         helicsFederateRegisterGlobalInput(vFed1, "inp1", HELICS_DATA_TYPE_RAW, "", nullptr);
     auto subid2 = helicsFederateRegisterGlobalInput(vFed1, "inp1", HELICS_DATA_TYPE_RAW, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(subid2, nullptr);
     helicsErrorClear(&err);
 
     auto subid3 = helicsFederateRegisterGlobalInput(
         vFed1, "inp3", static_cast<HelicsDataTypes>(-6985), "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(subid3, nullptr);
     helicsErrorClear(&err);
 
@@ -314,7 +314,7 @@ TEST_F(function_tests, raw2)
     helicsFederateRequestNextStep(vFed1, nullptr);
     // we are just making sure these don't blow up and cause a seg fault
     helicsInputGetBytes(subid, nullptr, 5, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsInputGetString(subid, nullptr, 5, nullptr, nullptr);
@@ -326,7 +326,7 @@ TEST_F(function_tests, raw2)
     HelicsIterationResult res;
     helicsFederateRequestTimeIterative(
         vFed1, 1.0, HELICS_ITERATION_REQUEST_NO_ITERATION, &res, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(res, HELICS_ITERATION_RESULT_HALTED);
 }
@@ -343,7 +343,7 @@ TEST_F(function_tests, string)
 
     auto pubid2 =
         helicsFederateRegisterPublication(vFed1, "pub1", HELICS_DATA_TYPE_STRING, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(pubid2, nullptr);
 
@@ -351,7 +351,7 @@ TEST_F(function_tests, string)
         helicsFederateRegisterGlobalInput(vFed1, "inp1", HELICS_DATA_TYPE_STRING, "", nullptr);
     auto subid2 =
         helicsFederateRegisterGlobalInput(vFed1, "inp1", HELICS_DATA_TYPE_STRING, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(subid2, nullptr);
     helicsErrorClear(&err);
 
@@ -382,19 +382,19 @@ TEST_F(function_tests, typePub)
     auto pubid = helicsFederateRegisterTypePublication(vFed1, "pub1", "string", "", nullptr);
 
     auto pubid2 = helicsFederateRegisterTypePublication(vFed1, "pub1", "string", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(pubid2, nullptr);
 
     auto subid = helicsFederateRegisterGlobalTypeInput(vFed1, "inp1", "string", "", nullptr);
     auto subid2 = helicsFederateRegisterGlobalTypeInput(vFed1, "inp1", "string", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(subid2, nullptr);
     helicsErrorClear(&err);
 
     // value federate can't register endpoints
     auto ept = helicsFederateRegisterEndpoint(vFed1, "ept1", nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(ept, nullptr);
 
@@ -428,25 +428,25 @@ TEST_F(function_tests, typePub2)
     auto pubid = helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "string", "", nullptr);
 
     auto pubid2 = helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "string", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(pubid2, nullptr);
 
     helicsFederateRegisterFromPublicationJSON(vFed1, "unknownfile.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRegisterInterfaces(vFed1, "unknownfile.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRegisterInterfaces(vFed1, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     auto subid = helicsFederateRegisterTypeInput(vFed1, "inp1", "string", "", nullptr);
     auto subid2 = helicsFederateRegisterTypeInput(vFed1, "inp1", "string", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(subid2, nullptr);
     helicsErrorClear(&err);
 
@@ -463,7 +463,7 @@ TEST_F(function_tests, typePub2)
     helicsPublicationPublishTime(pubid, 27.0, nullptr);
 
     helicsFederatePublishJSON(vFed1, "unknownfile.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRequestNextStep(vFed1, nullptr);
@@ -477,43 +477,43 @@ TEST_F(function_tests, typePub2)
     helicsFederateFinalize(vFed1, nullptr);
     // run a bunch of publish fails
     helicsPublicationPublishBytes(pubid, str, actLen, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationPublishString(pubid, str, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationPublishInteger(pubid, 5, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationPublishBoolean(pubid, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationPublishDouble(pubid, 39.2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationPublishTime(pubid, 19.2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsPublicationPublishChar(pubid, 'a', &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsPublicationPublishComplex(pubid, 2.5, -9.8, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     double r[2] = {1.3, 2.9};
     helicsPublicationPublishVector(pubid, r, 2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsPublicationPublishVector(pubid, nullptr, 2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsPublicationPublishNamedPoint(pubid, nullptr, 2.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 }
 // the init error tests use a mismatch in the publication and input to
@@ -537,26 +537,26 @@ TEST_F(function_tests, initError)
 
     // we are still in init mode so the next series of call should all fail
     auto tm = helicsFederateRequestTime(vFed1, 2.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(tm, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
 
     helicsFederateRequestTimeAsync(vFed1, 2.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     tm = helicsFederateRequestTimeComplete(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(tm, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
 
     // this one will generate an error from the mismatch types
     helicsFederateEnterExecutingMode(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRequestNextStep(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -576,13 +576,13 @@ TEST_F(function_tests, initError2)
 
     // check some other calls
     auto inp2 = helicsFederateGetInput(vFed1, "inp1", &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     auto k2 = helicsInputGetKey(inp2);
 
     EXPECT_STREQ(k1, k2);
 
     auto inp3 = helicsFederateGetInputByIndex(vFed1, 0, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     auto k3 = helicsInputGetKey(inp3);
 
     EXPECT_STREQ(k1, k3);
@@ -593,28 +593,28 @@ TEST_F(function_tests, initError2)
 
     // unknown publication
     auto pub3 = helicsFederateGetPublication(vFed1, "unknown", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(pub3, nullptr);
 
     // error in this call from the mismatch
     helicsFederateEnterInitializingMode(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRequestTimeAdvance(vFed1, 0.1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     // unknown input
     auto inp4 = helicsFederateGetInput(vFed1, "unknown", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(inp4, nullptr);
 
     // invalid input index
     auto inp5 = helicsFederateGetInputByIndex(vFed1, 4, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(inp5, nullptr);
 
@@ -635,16 +635,16 @@ TEST_F(function_tests, initError3)
     helicsInputAddTarget(subid, "pub1", nullptr);
 
     auto inp3 = helicsFederateGetSubscription(vFed1, "unknown", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(inp3, nullptr);
 
     helicsFederateSetTimeProperty(vFed1, HELICS_PROPERTY_TIME_PERIOD, 1.0, nullptr);
 
     helicsFederateEnterInitializingModeAsync(vFed1, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsFederateEnterInitializingModeComplete(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -665,32 +665,32 @@ TEST_F(function_tests, initError4)
     helicsFederateSetTimeProperty(vFed1, HELICS_PROPERTY_TIME_PERIOD, 1.0, nullptr);
 
     helicsFederateEnterExecutingModeAsync(vFed1, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateEnterExecutingModeComplete(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateIsAsyncOperationCompleted(vFed1, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     HelicsIterationResult res;
     helicsFederateRequestTimeIterative(
         vFed1, 1.0, HELICS_ITERATION_REQUEST_NO_ITERATION, &res, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(res, HELICS_ITERATION_RESULT_ERROR);
 
     helicsFederateFinalize(vFed1, nullptr);
 
     helicsFederateEnterExecutingModeAsync(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateEnterExecutingModeIterativeAsync(vFed1,
                                                    HELICS_ITERATION_REQUEST_FORCE_ITERATION,
                                                    &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST_F(function_tests, version)
@@ -717,14 +717,14 @@ TEST_F(function_tests, initError5)
                                                            HELICS_ITERATION_REQUEST_NO_ITERATION,
                                                            &err);
     EXPECT_EQ(resIt, HELICS_ITERATION_RESULT_ERROR);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRequestTimeIterativeAsync(vFed1,
                                             1.0,
                                             HELICS_ITERATION_REQUEST_NO_ITERATION,
                                             &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -748,20 +748,20 @@ TEST_F(function_tests, initError6)
     helicsFederateEnterExecutingModeIterativeAsync(vFed1,
                                                    HELICS_ITERATION_REQUEST_NO_ITERATION,
                                                    &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsFederateEnterExecutingModeIterativeComplete(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRequestTimeIterativeAsync(vFed1,
                                             1.0,
                                             HELICS_ITERATION_REQUEST_NO_ITERATION,
                                             &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     HelicsIterationResult ires = HELICS_ITERATION_RESULT_NEXT_STEP;
     helicsFederateRequestTimeIterativeComplete(vFed1, &ires, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_TRUE(ires == HELICS_ITERATION_RESULT_ERROR);
     helicsErrorClear(&err);
 
@@ -780,26 +780,26 @@ TEST_F(function_tests, CoreLink)
     helicsFederateRegisterTypeInput(vFed1, "inp1", "custom2", "", nullptr);
 
     auto fed2 = helicsGetFederateByName(helicsFederateGetName(vFed1), &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_NE(fed2, nullptr);
     EXPECT_STREQ(helicsFederateGetName(fed2), helicsFederateGetName(vFed1));
 
     auto fed3 = helicsGetFederateByName("fed_unknown", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(fed3, nullptr);
     helicsErrorClear(&err);
     auto cr = helicsFederateGetCore(vFed1, &err);
     EXPECT_NE(cr, nullptr);
     helicsCoreDataLink(cr, "pub1", "fed0/inp1", &err);
 
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsCoreMakeConnections(cr, "non-file.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsCoreDataLink(cr, "pub1", nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     auto cr2 = helicsCoreClone(cr, &err);
@@ -807,7 +807,7 @@ TEST_F(function_tests, CoreLink)
     EXPECT_STREQ(helicsCoreGetAddress(cr2), helicsCoreGetAddress(cr));
 
     helicsFederateEnterExecutingMode(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -829,18 +829,18 @@ TEST_F(function_tests, BrokerLink)
 
     helicsBrokerDataLink(br, "pub1", "fed0/inp1", &err);
 
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsBrokerDataLink(br, "pub1", nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsBrokerMakeConnections(br, "non-file.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateEnterExecutingMode(vFed1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateFinalize(vFed1, nullptr);
@@ -856,23 +856,23 @@ TEST_F(function_tests, messageFed)
     auto ept1 = helicsFederateRegisterEndpoint(mFed1, "ept1", "", nullptr);
     EXPECT_NE(ept1, nullptr);
     auto ept2 = helicsFederateRegisterEndpoint(mFed1, "ept1", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(ept2, nullptr);
     helicsErrorClear(&err);
     // not a valid endpoint
     auto ept3 = helicsFederateGetEndpoint(mFed1, "invalid", &err);
     EXPECT_EQ(ept3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     auto ept4 = helicsFederateGetEndpointByIndex(mFed1, 5, &err);
     EXPECT_EQ(ept4, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     // can't register a publication on a message federate
     auto subid = helicsFederateRegisterPublication(mFed1, "key", HELICS_DATA_TYPE_DOUBLE, "", &err);
     EXPECT_EQ(subid, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsEndpointSetDefaultDestination(ept1, "fed0/ept1", nullptr);
     helicsFederateEnterExecutingMode(mFed1, nullptr);
@@ -893,7 +893,7 @@ TEST_F(function_tests, messageFed)
 
     helicsFederateFinalize(mFed1, nullptr);
     helicsEndpointSendBytesTo(ept1, nullptr, 0, "fed0/ept1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST_F(function_tests, messageFed_event)
@@ -904,7 +904,7 @@ TEST_F(function_tests, messageFed_event)
     auto ept1 = helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", nullptr);
     EXPECT_NE(ept1, nullptr);
     auto ept2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(ept2, nullptr);
     helicsErrorClear(&err);
     // send events without destinations
@@ -924,7 +924,7 @@ TEST_F(function_tests, messageFed_event)
     helicsFederateFinalize(mFed1, nullptr);
     //  can't send an event after the federate is finalized
     helicsEndpointSendBytesAt(ept1, data, 4, 0.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST_F(function_tests, messageFed_messageObject)
@@ -935,7 +935,7 @@ TEST_F(function_tests, messageFed_messageObject)
     auto ept1 = helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", nullptr);
     EXPECT_NE(ept1, nullptr);
     auto ept2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(ept2, nullptr);
     helicsErrorClear(&err);
     helicsEndpointSetDefaultDestination(ept1, "ept1", nullptr);
@@ -944,7 +944,7 @@ TEST_F(function_tests, messageFed_messageObject)
 
     // if we are sending a message it can't be null
     helicsEndpointSendMessage(ept1, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     HelicsMessage mess0 = helicsEndpointGetMessage(ept1);
@@ -978,7 +978,7 @@ TEST_F(function_tests, messageFed_messageObject)
     helicsFederateFinalize(mFed1, nullptr);
     // can't send a message after the federate is finalized
     helicsEndpointSendMessage(ept1, mess1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // test different paths for sending message objects
@@ -990,7 +990,7 @@ TEST_F(function_tests, messageFed_message_object)
     auto ept1 = helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", nullptr);
     EXPECT_NE(ept1, nullptr);
     auto ept2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(ept2, nullptr);
     helicsErrorClear(&err);
 
@@ -1004,7 +1004,7 @@ TEST_F(function_tests, messageFed_message_object)
     EXPECT_EQ(helicsMessageGetByteCount(mess0), 0);
 
     helicsEndpointSendMessage(ept1, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     auto mess1 = helicsFederateCreateMessage(mFed1, nullptr);
@@ -1021,7 +1021,7 @@ TEST_F(function_tests, messageFed_message_object)
     helicsFederateFinalize(mFed1, nullptr);
 
     helicsEndpointSendMessage(ept1, mess1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     helicsFederateClearMessages(mFed1);
 }
@@ -1036,7 +1036,7 @@ TEST_F(function_tests, filter_tests)
     auto filt1 = helicsFederateRegisterFilter(mFed1, HELICS_FILTER_TYPE_DELAY, "filt1", nullptr);
     EXPECT_NE(filt1, nullptr);
     auto filt2 = helicsFederateRegisterFilter(mFed1, HELICS_FILTER_TYPE_DELAY, "filt1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(filt2, nullptr);
 
     helicsFederateFinalize(mFed1, nullptr);
@@ -1053,16 +1053,16 @@ TEST_F(function_tests, filter_tests2)
         helicsFederateRegisterGlobalFilter(mFed1, HELICS_FILTER_TYPE_DELAY, "filt1", nullptr);
     EXPECT_NE(filt1, nullptr);
     auto filt2 = helicsFederateRegisterGlobalFilter(mFed1, HELICS_FILTER_TYPE_DELAY, "filt1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(filt2, nullptr);
     helicsErrorClear(&err);
 
     auto f3 = helicsFederateGetFilter(mFed1, "unknown", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(f3, nullptr);
 
     auto f4 = helicsFederateGetFilterByIndex(mFed1, 10, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(f4, nullptr);
 
     helicsErrorClear(&err);
@@ -1079,7 +1079,7 @@ TEST_F(function_tests, filter_tests3)
     auto filt1 = helicsFederateRegisterGlobalCloningFilter(mFed1, "filt1", nullptr);
     EXPECT_NE(filt1, nullptr);
     auto filt2 = helicsFederateRegisterGlobalCloningFilter(mFed1, "filt1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(filt2, nullptr);
 
     helicsFederateFinalize(mFed1, nullptr);
@@ -1094,25 +1094,25 @@ TEST_F(function_tests, filter_tests4)
     auto filt1 = helicsFederateRegisterCloningFilter(mFed1, "filt1", nullptr);
     EXPECT_NE(filt1, nullptr);
     auto filt2 = helicsFederateRegisterCloningFilter(mFed1, "filt1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(filt2, nullptr);
     helicsErrorClear(&err);
     helicsFilterSetString(filt1, "unknown", "string", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "", nullptr);
 
     helicsFilterAddDeliveryEndpoint(filt1, "ept1", nullptr);
     helicsFilterAddSourceTarget(filt1, "ept1", &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsFilterAddDestinationTarget(filt1, "ept1", &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsFilterRemoveTarget(filt1, "ept1", &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFilterSet(filt1, "unknown", 10.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFederateFinalize(mFed1, nullptr);
 }
@@ -1129,13 +1129,13 @@ TEST_F(function_tests, filter_core_tests)
     auto filt1 = helicsCoreRegisterFilter(cr, HELICS_FILTER_TYPE_DELAY, "filt1", nullptr);
     EXPECT_NE(filt1, nullptr);
     auto filt2 = helicsCoreRegisterFilter(cr, HELICS_FILTER_TYPE_DELAY, "filt1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(filt2, nullptr);
     helicsErrorClear(&err);
     helicsFilterSetOption(filt1, HELICS_HANDLE_OPTION_CONNECTION_OPTIONAL, HELICS_TRUE, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsFilterGetOption(filt1, HELICS_HANDLE_OPTION_CONNECTION_OPTIONAL);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsFederateFinalize(mFed1, nullptr);
     helicsCoreDestroy(cr);
 }
@@ -1152,7 +1152,7 @@ TEST_F(function_tests, filter_core_tests2)
     auto filt1 = helicsCoreRegisterCloningFilter(cr, "filt1", nullptr);
     EXPECT_NE(filt1, nullptr);
     auto filt2 = helicsCoreRegisterCloningFilter(cr, "filt1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(filt2, nullptr);
 
     helicsFederateFinalize(mFed1, nullptr);

--- a/tests/helics/shared_library/ctestFixtures.cpp
+++ b/tests/helics/shared_library/ctestFixtures.cpp
@@ -158,13 +158,13 @@ void FederateTestFixture::AddFederates(FedCreator ctor,
             auto core = helicsCreateCore(CoreType_name.c_str(), NULL, init.c_str(), &err);
 
             helicsFederateInfoSetCoreName(fi, helicsCoreGetIdentifier(core), &err);
-            assert(err.errorCode == 0);
+            assert(err.error_code == 0);
             size_t offset = federates.size();
             federates.resize(count + offset);
             for (int ii = 0; ii < count; ++ii) {
                 auto name = name_prefix + std::to_string(ii + offset);
                 auto fed = ctor(name.c_str(), fi, &err);
-                assert(err.errorCode == 0);
+                assert(err.error_code == 0);
                 federates[ii + offset] = fed;
             }
             helicsCoreFree(core);
@@ -177,10 +177,10 @@ void FederateTestFixture::AddFederates(FedCreator ctor,
                 auto core = helicsCreateCore(CoreType_name.c_str(), NULL, init.c_str(), &err);
 
                 helicsFederateInfoSetCoreName(fi, helicsCoreGetIdentifier(core), &err);
-                assert(err.errorCode == 0);
+                assert(err.error_code == 0);
                 auto name = name_prefix + std::to_string(ii + offset);
                 auto fed = ctor(name.c_str(), fi, &err);
-                assert(err.errorCode == 0);
+                assert(err.error_code == 0);
                 federates[ii + offset] = fed;
                 helicsCoreFree(core);
             }

--- a/tests/helics/shared_library/ctestFixtures.cpp
+++ b/tests/helics/shared_library/ctestFixtures.cpp
@@ -28,9 +28,9 @@ static auto StartBrokerImp(const std::string& CoreType_name, std::string initial
     }
     if (hasIndexCode(CoreType_name)) {
         std::string new_type(CoreType_name.begin(), CoreType_name.end() - 2);
-        return helicsCreateBroker(new_type.c_str(), NULL, initialization_string.c_str(), nullptr);
+        return helicsCreateBroker(new_type.c_str(), nullptr, initialization_string.c_str(), nullptr);
     }
-    return helicsCreateBroker(CoreType_name.c_str(), NULL, initialization_string.c_str(), nullptr);
+    return helicsCreateBroker(CoreType_name.c_str(), nullptr, initialization_string.c_str(), nullptr);
 }
 
 bool FederateTestFixture::hasIndexCode(const std::string& type_name)
@@ -62,7 +62,7 @@ FederateTestFixture::~FederateTestFixture()
                 helicsFederateFinalize(fed, nullptr);
             }
             helicsFederateFree(fed);
-            if (helicsCoreIsValid(core)!=HELICS_FALSE) {
+            if (helicsCoreIsValid(core) != HELICS_FALSE) {
                 helicsCoreDisconnect(core, nullptr);
             }
             helicsCoreFree(core);
@@ -114,13 +114,13 @@ HelicsBroker FederateTestFixture::AddBroker(const std::string& CoreType_name,
 void FederateTestFixture::SetupTest(FedCreator ctor,
                                     const std::string& CoreType_name,
                                     int count,
-                                    HelicsTime time_delta,
+                                    HelicsTime timeDelta,
                                     const std::string& name_prefix)
 {
     ctype = CoreType_name;
     HelicsBroker broker = AddBroker(CoreType_name, count);
     assert(helicsBrokerIsValid(broker) == HELICS_TRUE);
-    AddFederates(ctor, CoreType_name, count, broker, time_delta, name_prefix);
+    AddFederates(ctor, CoreType_name, count, broker, timeDelta, name_prefix);
 }
 
 void FederateTestFixture::AddFederates(FedCreator ctor,

--- a/tests/helics/shared_library/ctestFixtures.cpp
+++ b/tests/helics/shared_library/ctestFixtures.cpp
@@ -28,9 +28,9 @@ static auto StartBrokerImp(const std::string& CoreType_name, std::string initial
     }
     if (hasIndexCode(CoreType_name)) {
         std::string new_type(CoreType_name.begin(), CoreType_name.end() - 2);
-        return helicsCreateBroker(new_type.c_str(), NULL, initialization_string.c_str(), 0);
+        return helicsCreateBroker(new_type.c_str(), NULL, initialization_string.c_str(), nullptr);
     }
-    return helicsCreateBroker(CoreType_name.c_str(), NULL, initialization_string.c_str(), 0);
+    return helicsCreateBroker(CoreType_name.c_str(), NULL, initialization_string.c_str(), nullptr);
 }
 
 bool FederateTestFixture::hasIndexCode(const std::string& type_name)
@@ -55,14 +55,14 @@ FederateTestFixture::FederateTestFixture()
 FederateTestFixture::~FederateTestFixture()
 {
     for (auto& fed : federates) {
-        if (fed) {
+        if (fed != nullptr) {
             HelicsFederateState state = helicsFederateGetState(fed, nullptr);
             HelicsCore core = helicsFederateGetCore(fed, nullptr);
             if (state != HELICS_STATE_FINALIZE) {
                 helicsFederateFinalize(fed, nullptr);
             }
             helicsFederateFree(fed);
-            if (helicsCoreIsValid(core)) {
+            if (helicsCoreIsValid(core)!=HELICS_FALSE) {
                 helicsCoreDisconnect(core, nullptr);
             }
             helicsCoreFree(core);
@@ -155,7 +155,7 @@ void FederateTestFixture::AddFederates(FedCreator ctor,
         case 1:
         default: {
             auto init = initString + " --federates " + std::to_string(count);
-            auto core = helicsCreateCore(CoreType_name.c_str(), NULL, init.c_str(), &err);
+            auto core = helicsCreateCore(CoreType_name.c_str(), nullptr, init.c_str(), &err);
 
             helicsFederateInfoSetCoreName(fi, helicsCoreGetIdentifier(core), &err);
             assert(err.error_code == 0);
@@ -174,7 +174,7 @@ void FederateTestFixture::AddFederates(FedCreator ctor,
             federates.resize(count + offset);
             for (int ii = 0; ii < count; ++ii) {
                 auto init = initString + " --federates 1";
-                auto core = helicsCreateCore(CoreType_name.c_str(), NULL, init.c_str(), &err);
+                auto core = helicsCreateCore(CoreType_name.c_str(), nullptr, init.c_str(), &err);
 
                 helicsFederateInfoSetCoreName(fi, helicsCoreGetIdentifier(core), &err);
                 assert(err.error_code == 0);

--- a/tests/helics/shared_library/ctestFixtures.hpp
+++ b/tests/helics/shared_library/ctestFixtures.hpp
@@ -53,6 +53,6 @@ struct FederateTestFixture {
     std::string ctype;
 
   private:
-    bool hasIndexCode(const std::string& type_name);
-    int getIndexCode(const std::string& type_name);
+    static bool hasIndexCode(const std::string& type_name);
+    static int getIndexCode(const std::string& type_name);
 };

--- a/tests/helics/shared_library/ctestFixtures.hpp
+++ b/tests/helics/shared_library/ctestFixtures.hpp
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #define CE(command)                                                                                \
     helicsErrorClear(&err);                                                                        \
     command;                                                                                       \
-    EXPECT_TRUE(err.errorCode == HELICS_OK) << err.message
+    EXPECT_TRUE(err.error_code == HELICS_OK) << err.message
 
 #define HELICS_SIZE_MAX 512
 

--- a/tests/helics/shared_library/evilInputTests.cpp
+++ b/tests/helics/shared_library/evilInputTests.cpp
@@ -16,7 +16,7 @@ TEST(evil_general_test, helicsErrorInitialize)
 {
     // HelicsError helicsErrorInitialize(void);
     auto E = helicsErrorInitialize();
-    EXPECT_EQ(E.errorCode, 0);
+    EXPECT_EQ(E.error_code, 0);
     EXPECT_TRUE(std::string(E.message).empty());
 }
 
@@ -24,11 +24,11 @@ TEST(evil_general_test, helicsErrorClear)
 {
     // void helicsErrorClear(HelicsError* err);
     auto E = helicsErrorInitialize();
-    E.errorCode = 55;
+    E.error_code = 55;
     E.message = "this is a test";
 
     helicsErrorClear(&E);
-    EXPECT_EQ(E.errorCode, 0);
+    EXPECT_EQ(E.error_code, 0);
     EXPECT_TRUE(std::string(E.message).empty());
 }
 
@@ -42,13 +42,13 @@ TEST(evil_general_test, helicsGetFederateByName)
 {
     // HelicsFederate helicsGetFederateByName(const char* fedName, HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res = helicsGetFederateByName(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(helicsFederateIsValid(res), HELICS_FALSE);
 
     res = helicsGetFederateByName("bob", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(helicsFederateIsValid(res), HELICS_FALSE);
     helicsErrorClear(&err);
     res = helicsGetFederateByName(nullptr, &err);
@@ -97,9 +97,9 @@ TEST(evil_creation_test, helicsCreateCore)
     // HelicsCore helicsCreateCore(const char* type, const char* name, const char* initString,
     // HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateCore(nullptr, "name", "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_TRUE(helicsCoreIsValid(res1) == HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsCreateCore("invalid", "name", "", &err);
@@ -114,9 +114,9 @@ TEST(evil_creation_test, helicsCreateCoreFromArgs)
     // char* const* argv, HelicsError* err); HelicsCore helicsCreateCoreFromArgs(const char* type,
     // const char* name, int argc, const char* const* argv, HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateCoreFromArgs("bob", "bob", 0, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_TRUE(helicsCoreIsValid(res1) == HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsCreateCoreFromArgs("bob", "bob", 0, nullptr, &err);
@@ -130,9 +130,9 @@ TEST(evil_creation_test, helicsCreateBroker)
     // HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString,
     // HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateBroker(nullptr, "name", "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_TRUE(helicsBrokerIsValid(res1) == HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsCreateBroker("invalid", "name", "", &err);
@@ -146,9 +146,9 @@ TEST(evil_creation_test, helicsCreateBrokerFromArgs)
     // HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const
     // char* const* argv, HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateBrokerFromArgs("bob", "bob", 0, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_TRUE(helicsBrokerIsValid(res1) == HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsCreateBrokerFromArgs("bob", "bob", 0, nullptr, &err);
@@ -163,16 +163,16 @@ TEST(evil_creation_test, helicsCreateValueFederate)
     // HelicsError* err); HelicsFederate helicsCreateValueFederate(const char* fedName,
     // HelicsFederateInfo fi, HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateValueFederate("billy", nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(helicsFederateIsValid(res1), HELICS_FALSE);
     helicsErrorClear(&err);
 
     auto fi = helicsCreateFederateInfo();
     helicsFederateInfoSetCoreType(fi, HELICS_CORE_TYPE_NNG, nullptr);
     auto res2 = helicsCreateValueFederate("billy", fi, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(helicsFederateIsValid(res2), HELICS_FALSE);
     helicsErrorClear(&err);
     // auto res2=helicsCreateValueFederate(const char* fedName, HelicsFederateInfo fi, nullptr);
@@ -180,7 +180,7 @@ TEST(evil_creation_test, helicsCreateValueFederate)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto res3 = helicsCreateValueFederate("billy", evil_fi, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(helicsFederateIsValid(res3), HELICS_FALSE);
 }
 
@@ -189,9 +189,9 @@ TEST(evil_creation_test, helicsCreateValueFederateFromConfig)
     // HelicsFederate helicsCreateValueFederateFromConfig(const char* configFile, HelicsError*
     // err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateValueFederateFromConfig("unknownfile.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     EXPECT_EQ(helicsFederateIsValid(res1), HELICS_FALSE);
     auto res2 = helicsCreateValueFederateFromConfig("unknownfile.json", &err);
@@ -204,9 +204,9 @@ TEST(evil_creation_test, helicsCreateMessageFederate)
 {
     // auto res2=helicsCreateMessageFederate(const char* fedName, HelicsFederateInfo fi, nullptr);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateMessageFederate("billy", nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(helicsFederateIsValid(res1), HELICS_FALSE);
     helicsErrorClear(&err);
 
@@ -218,7 +218,7 @@ TEST(evil_creation_test, helicsCreateMessageFederate)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto res3 = helicsCreateMessageFederate("billy", evil_fi, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(helicsFederateIsValid(res3), HELICS_FALSE);
 }
 
@@ -227,9 +227,9 @@ TEST(evil_creation_test, helicsCreateMessageFederateFromConfig)
     // HelicsFederate helicsCreateMessageFederateFromConfig(const char* configFile, HelicsError*
     // err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateMessageFederateFromConfig("unknownfile.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     EXPECT_EQ(helicsFederateIsValid(res1), HELICS_FALSE);
     auto res2 = helicsCreateMessageFederateFromConfig("unknownfile.json", &err);
@@ -243,9 +243,9 @@ TEST(evil_creation_test, helicsCreateCombinationFederate)
     // HelicsFederate helicsCreateCombinationFederate(const char* fedName, HelicsFederateInfo fi,
     // HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateCombinationFederate("billy", nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(helicsFederateIsValid(res1), HELICS_FALSE);
     helicsErrorClear(&err);
 
@@ -257,7 +257,7 @@ TEST(evil_creation_test, helicsCreateCombinationFederate)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto res3 = helicsCreateCombinationFederate("billy", evil_fi, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(helicsFederateIsValid(res3), HELICS_FALSE);
 }
 
@@ -266,9 +266,9 @@ TEST(evil_creation_test, helicsCreateCombinationFederateFromConfig)
     // HelicsFederate helicsCreateCombinationFederateFromConfig(const char* configFile,
     // HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCreateCombinationFederateFromConfig("unknownfile.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     EXPECT_EQ(helicsFederateIsValid(res1), HELICS_FALSE);
     auto res2 = helicsCreateCombinationFederateFromConfig("unknownfile.json", &err);
@@ -299,16 +299,16 @@ TEST(evil_core_test, helicsCoreClone)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCoreClone(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_NE(helicsCoreIsValid(res1), HELICS_TRUE);
     helicsErrorClear(&err);
     auto res2 = helicsCoreClone(evil_core, nullptr);
     EXPECT_NE(helicsCoreIsValid(res2), HELICS_TRUE);
     auto res3 = helicsCoreClone(evil_core, &err);
     EXPECT_NE(helicsCoreIsValid(res3), HELICS_TRUE);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreIsValid)
@@ -326,9 +326,9 @@ TEST(evil_core_test, helicsCoreWaitForDisconnect)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCoreWaitForDisconnect(nullptr, 1, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_TRUE);
     helicsErrorClear(&err);
     auto res2 = helicsCoreWaitForDisconnect(nullptr, 1, nullptr);
@@ -355,14 +355,14 @@ TEST(evil_core_test, helicsCoreDataLink)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreDataLink(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsCoreDataLink(HelicsCore core, const char* source, const char* target,
     // nullptr);
     helicsCoreDataLink(evil_core, "source", "target", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreAddSourceFilterToEndpoint)
@@ -372,14 +372,14 @@ TEST(evil_core_test, helicsCoreAddSourceFilterToEndpoint)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreAddSourceFilterToEndpoint(nullptr, "filter", "ept", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsCoreAddSourceFilterToEndpoint(HelicsCore core, const char* filter, const
     // char* endpoint, nullptr);
     helicsCoreAddSourceFilterToEndpoint(evil_core, "filter", "ept", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreAddDestinationFilterToEndpoint)
@@ -389,14 +389,14 @@ TEST(evil_core_test, helicsCoreAddDestinationFilterToEndpoint)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreAddDestinationFilterToEndpoint(nullptr, "filter", "ept", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsCoreAddDestinationFilterToEndpoint(HelicsCore core, const char* filter,
     // const char* endpoint, nullptr);
     helicsCoreAddDestinationFilterToEndpoint(evil_core, "filter", "ept", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreMakeConnections)
@@ -405,13 +405,13 @@ TEST(evil_core_test, helicsCoreMakeConnections)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreMakeConnections(nullptr, "invalidfile.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsCoreMakeConnections(HelicsCore core, const char* file, nullptr);
     helicsCoreMakeConnections(evil_core, "invalidfile", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreGetIdentifier)
@@ -438,12 +438,12 @@ TEST(evil_core_test, helicsCoreSetReadyToInit)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreSetReadyToInit(nullptr, &err);
     helicsErrorClear(&err);
     // auto res2=helicsCoreSetReadyToInit(HelicsCore core, nullptr);
     helicsCoreSetReadyToInit(evil_core, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreConnect)
@@ -452,16 +452,16 @@ TEST(evil_core_test, helicsCoreConnect)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res = helicsCoreConnect(nullptr, &err);
     helicsErrorClear(&err);
     EXPECT_EQ(res, HELICS_FALSE);
     res = helicsCoreConnect(nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     EXPECT_EQ(res, HELICS_FALSE);
     res = helicsCoreConnect(evil_core, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(res, HELICS_FALSE);
 }
 
@@ -471,14 +471,14 @@ TEST(evil_core_test, helicsCoreDisconnect)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreDisconnect(nullptr, &err);
     helicsErrorClear(&err);
     helicsCoreDisconnect(nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsCoreDisconnect(evil_core, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreDestroy)
@@ -506,13 +506,13 @@ TEST(evil_core_test, helicsCoreSetGlobal)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreSetGlobal(nullptr, "value", "value", &err);
     helicsErrorClear(&err);
     // auto res2=helicsCoreSetGlobal(HelicsCore core, const char* valueName, const char* value,
     // nullptr);
     helicsCoreSetGlobal(evil_core, "value", "value", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreSetLogFile)
@@ -521,12 +521,12 @@ TEST(evil_core_test, helicsCoreSetLogFile)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreSetLogFile(nullptr, "unknownfile.log", &err);
     helicsErrorClear(&err);
     // auto res2=helicsCoreSetLogFile(HelicsCore core, const char* logFileName, nullptr);
     helicsCoreSetLogFile(evil_core, "unknownfile.log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreSetLoggingCallback)
@@ -537,16 +537,16 @@ TEST(evil_core_test, helicsCoreSetLoggingCallback)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsCoreSetLoggingCallback(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     // auto res2=helicsCoreSetLoggingCallback(     HelicsCore core,     void (*logger)(int
     // loglevel, const char* identifier, const char* message, void* userData),     void* userdata,
     // nullptr);
     helicsCoreSetLoggingCallback(evil_core, nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreRegisterFilter)
@@ -556,16 +556,16 @@ TEST(evil_core_test, helicsCoreRegisterFilter)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCoreRegisterFilter(nullptr, HELICS_FILTER_TYPE_DELAY, "delay", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsCoreRegisterFilter(nullptr, HELICS_FILTER_TYPE_DELAY, "delay", nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsCoreRegisterFilter(evil_core, HELICS_FILTER_TYPE_DELAY, "delay", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_core_test, helicsCoreRegisterCloningFilter)
@@ -575,16 +575,16 @@ TEST(evil_core_test, helicsCoreRegisterCloningFilter)
     char rdata[256];
     auto evil_core = reinterpret_cast<HelicsCore>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsCoreRegisterCloningFilter(nullptr, "delivery", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsCoreRegisterCloningFilter(nullptr, "delivery", nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsCoreRegisterCloningFilter(evil_core, "delivery", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Broker Functions
@@ -595,16 +595,16 @@ TEST(evil_broker_test, helicsBrokerClone)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsBrokerClone(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_NE(helicsBrokerIsValid(res1), HELICS_TRUE);
     helicsErrorClear(&err);
     auto res2 = helicsBrokerClone(evil_broker, nullptr);
     EXPECT_NE(helicsBrokerIsValid(res2), HELICS_TRUE);
     auto res3 = helicsBrokerClone(evil_broker, &err);
     EXPECT_NE(helicsBrokerIsValid(res3), HELICS_TRUE);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerIsValid)
@@ -634,13 +634,13 @@ TEST(evil_broker_test, helicsBrokerDataLink)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerDataLink(nullptr, nullptr, nullptr, &err);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerDataLink(HelicsCore core, const char* source, const char* target,
     // nullptr);
     helicsBrokerDataLink(evil_broker, "source", "target", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerAddSourceFilterToEndpoint)
@@ -650,14 +650,14 @@ TEST(evil_broker_test, helicsBrokerAddSourceFilterToEndpoint)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerAddSourceFilterToEndpoint(nullptr, "filter", "ept", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerAddSourceFilterToEndpoint(HelicsCore core, const char* filter, const
     // char* endpoint, nullptr);
     helicsBrokerAddSourceFilterToEndpoint(evil_broker, "filter", "ept", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerAddDestinationFilterToEndpoint)
@@ -667,14 +667,14 @@ TEST(evil_broker_test, helicsBrokerAddDestinationFilterToEndpoint)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerAddDestinationFilterToEndpoint(nullptr, "filter", "ept", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerAddDestinationFilterToEndpoint(HelicsCore core, const char* filter,
     // const char* endpoint, nullptr);
     helicsBrokerAddDestinationFilterToEndpoint(evil_broker, "filter", "ept", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerMakeConnections)
@@ -683,13 +683,13 @@ TEST(evil_broker_test, helicsBrokerMakeConnections)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerMakeConnections(nullptr, "invalidfile.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerMakeConnections(HelicsCore core, const char* file, nullptr);
     helicsBrokerMakeConnections(evil_broker, "invalidfile", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerWaitForDisconnect)
@@ -699,9 +699,9 @@ TEST(evil_broker_test, helicsBrokerWaitForDisconnect)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsBrokerWaitForDisconnect(nullptr, 1, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_TRUE);
     helicsErrorClear(&err);
     auto res2 = helicsBrokerWaitForDisconnect(nullptr, 1, nullptr);
@@ -734,16 +734,16 @@ TEST(evil_broker_test, helicsBrokerDisconnect)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerDisconnect(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsBrokerDisconnect(nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerDisconnect(HelicsCore core, nullptr);
     helicsBrokerDisconnect(evil_broker, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerDestroy)
@@ -771,14 +771,14 @@ TEST(evil_broker_test, helicsBrokerSetGlobal)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerSetGlobal(nullptr, "value", "value", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerSetGlobal(HelicsCore core, const char* valueName, const char* value,
     // nullptr);
     helicsBrokerSetGlobal(evil_broker, "value", "value", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerSetLogFile)
@@ -788,13 +788,13 @@ TEST(evil_broker_test, helicsBrokerSetLogFile)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerSetLogFile(nullptr, "unknownfile.log", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsBrokerSetLogFile(HelicsCore core, const char* logFileName, nullptr);
     helicsBrokerSetLogFile(evil_broker, "unknownfile.log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_broker_test, helicsBrokerSetLoggingCallback)
@@ -805,16 +805,16 @@ TEST(evil_broker_test, helicsBrokerSetLoggingCallback)
     char rdata[256];
     auto evil_broker = reinterpret_cast<HelicsBroker>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsBrokerSetLoggingCallback(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     // auto res2=helicsBrokerSetLoggingCallback(     HelicsCore core,     void (*logger)(int
     // loglevel, const char* identifier, const char* message, void* userData),     void* userdata,
     // nullptr);
     helicsBrokerSetLoggingCallback(evil_broker, nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Federate Info Functions
@@ -824,14 +824,14 @@ TEST(evil_fedInfo_test, helicsFederateInfoClone)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res = helicsFederateInfoClone(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateInfoClone(evil_fi, &err);
     EXPECT_EQ(res2, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoLoadFromArgs)
@@ -839,12 +839,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoLoadFromArgs)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoLoadFromArgs(nullptr, 0, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoLoadFromArgs(evil_fi, 0, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoFree)
@@ -860,12 +860,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetCoreName)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetCoreName(nullptr, "core", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetCoreName(evil_fi, "core", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetCoreInitString)
@@ -873,12 +873,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetCoreInitString)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetCoreInitString(nullptr, "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetCoreInitString(evil_fi, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetBrokerInitString)
@@ -886,16 +886,16 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetBrokerInitString)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetBrokerInitString(nullptr, "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerInitString(evil_fi, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerInitString(fi, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetCoreType)
@@ -903,12 +903,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetCoreType)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetCoreType(nullptr, -97, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetCoreType(evil_fi, -97, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetCoreTypeFromString)
@@ -916,19 +916,19 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetCoreTypeFromString)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetCoreTypeFromString(nullptr, "null", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetCoreTypeFromString(evil_fi, "nullcore", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetCoreTypeFromString(fi, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateInfoSetCoreTypeFromString(fi, "evil_core", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetBroker)
@@ -936,12 +936,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetBroker)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetBroker(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetBroker(evil_fi, "10.0.0.1", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetBrokerKey)
@@ -949,17 +949,17 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetBrokerKey)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetBrokerKey(nullptr, "broker_key", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerKey(evil_fi, "broker_key", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerKey(fi, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetBrokerPort)
@@ -967,20 +967,20 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetBrokerPort)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetBrokerPort(nullptr, 9999, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerPort(nullptr, 9999, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerPort(evil_fi, 9999, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetBrokerPort(fi, 9999, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetLocalPort)
@@ -988,20 +988,20 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetLocalPort)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetLocalPort(nullptr, "9999", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetLocalPort(nullptr, "9999", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFederateInfoSetLocalPort(evil_fi, "9999", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetLocalPort(fi, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetFlagOption)
@@ -1009,17 +1009,17 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetFlagOption)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetFlagOption(nullptr, 9, HELICS_FALSE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetFlagOption(evil_fi, 9, HELICS_FALSE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetFlagOption(fi, 0, HELICS_FALSE, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetSeparator)
@@ -1027,17 +1027,17 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetSeparator)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetSeparator(nullptr, '-', &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetSeparator(evil_fi, '-', &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     auto fi = helicsCreateFederateInfo();
     helicsErrorClear(&err);
     helicsFederateInfoSetSeparator(fi, '&', &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetTimeProperty)
@@ -1045,12 +1045,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetTimeProperty)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetTimeProperty(nullptr, 99, 4.35, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetTimeProperty(evil_fi, 99, 4.35, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_fedInfo_test, helicsFederateInfoSetIntegerProperty)
@@ -1058,12 +1058,12 @@ TEST(evil_fedInfo_test, helicsFederateInfoSetIntegerProperty)
     char rdata[256];
     auto evil_fi = reinterpret_cast<HelicsFederateInfo>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateInfoSetIntegerProperty(nullptr, 987, -54, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateInfoSetIntegerProperty(evil_fi, 987, -54, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Federate Functions
@@ -1083,9 +1083,9 @@ TEST(evil_federate_test, helicsFederateClone)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateClone(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateClone(nullptr, nullptr);
@@ -1093,7 +1093,7 @@ TEST(evil_federate_test, helicsFederateClone)
     helicsErrorClear(&err);
     auto res3 = helicsFederateClone(evil_federate, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateIsValid)
@@ -1112,13 +1112,13 @@ TEST(evil_federate_test, helicsFederateRegisterInterfaces)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateRegisterInterfaces(nullptr, "invalidfile.txt", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateRegisterInterfaces(HelicsFederate fed, const char* file, nullptr);
     helicsFederateRegisterInterfaces(evil_federate, "invalid_file.txt", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateLocalError)
@@ -1151,15 +1151,15 @@ TEST(evil_federate_test, helicsFederateFinalize)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateFinalize(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateFinalize(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFederateFinalize(nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateFinalizeAsync)
@@ -1168,12 +1168,12 @@ TEST(evil_federate_test, helicsFederateFinalizeAsync)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateFinalizeAsync(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFederateFinalizeAsync(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateFinalizeComplete)
@@ -1182,13 +1182,13 @@ TEST(evil_federate_test, helicsFederateFinalizeComplete)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateFinalizeComplete(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateFinalizeComplete(HelicsFederate fed, nullptr);
     helicsFederateFinalizeComplete(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateFree)
@@ -1206,13 +1206,13 @@ TEST(evil_federate_test, helicsFederateEnterInitializingMode)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterInitializingMode(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterInitializingMode(HelicsFederate fed, nullptr);
     helicsFederateEnterInitializingMode(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterInitializingModeAsync)
@@ -1221,13 +1221,13 @@ TEST(evil_federate_test, helicsFederateEnterInitializingModeAsync)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterInitializingModeAsync(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterInitializingModeAsync(HelicsFederate fed, nullptr);
     helicsFederateEnterInitializingModeAsync(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateIsAsyncOperationCompleted)
@@ -1236,16 +1236,16 @@ TEST(evil_federate_test, helicsFederateIsAsyncOperationCompleted)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateIsAsyncOperationCompleted(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsFederateIsAsyncOperationCompleted(nullptr, nullptr);
     EXPECT_EQ(res2, HELICS_FALSE);
     auto res3 = helicsFederateIsAsyncOperationCompleted(evil_federate, &err);
     EXPECT_EQ(res3, HELICS_FALSE);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterInitializingModeComplete)
@@ -1254,13 +1254,13 @@ TEST(evil_federate_test, helicsFederateEnterInitializingModeComplete)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterInitializingModeComplete(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterInitializingModeComplete(HelicsFederate fed, nullptr);
     helicsFederateEnterInitializingModeComplete(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterExecutingMode)
@@ -1269,13 +1269,13 @@ TEST(evil_federate_test, helicsFederateEnterExecutingMode)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterExecutingMode(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterExecutingMode(HelicsFederate fed, nullptr);
     helicsFederateEnterExecutingMode(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterExecutingModeAsync)
@@ -1284,13 +1284,13 @@ TEST(evil_federate_test, helicsFederateEnterExecutingModeAsync)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterExecutingModeAsync(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterExecutingModeAsync(HelicsFederate fed, nullptr);
     helicsFederateEnterExecutingModeAsync(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterExecutingModeComplete)
@@ -1299,13 +1299,13 @@ TEST(evil_federate_test, helicsFederateEnterExecutingModeComplete)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterExecutingModeComplete(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterExecutingModeComplete(HelicsFederate fed, nullptr);
     helicsFederateEnterExecutingModeComplete(evil_federate, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterExecutingModeIterative)
@@ -1315,11 +1315,11 @@ TEST(evil_federate_test, helicsFederateEnterExecutingModeIterative)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateEnterExecutingModeIterative(nullptr,
                                                           HELICS_ITERATION_REQUEST_NO_ITERATION,
                                                           &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_ITERATION_RESULT_ERROR);
     helicsErrorClear(&err);
     auto res2 = helicsFederateEnterExecutingModeIterative(nullptr,
@@ -1330,7 +1330,7 @@ TEST(evil_federate_test, helicsFederateEnterExecutingModeIterative)
                                                           HELICS_ITERATION_REQUEST_NO_ITERATION,
                                                           &err);
     EXPECT_EQ(res3, HELICS_ITERATION_RESULT_ERROR);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterExecutingModeIterativeAsync)
@@ -1340,18 +1340,18 @@ TEST(evil_federate_test, helicsFederateEnterExecutingModeIterativeAsync)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateEnterExecutingModeIterativeAsync(nullptr,
                                                    HELICS_ITERATION_REQUEST_NO_ITERATION,
                                                    &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateEnterExecutingModeIterativeAsync(HelicsFederate fed,
     // HelicsIterationRequest iterate, nullptr);
     helicsFederateEnterExecutingModeIterativeAsync(evil_federate,
                                                    HELICS_ITERATION_REQUEST_NO_ITERATION,
                                                    &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateEnterExecutingModeIterativeComplete)
@@ -1361,16 +1361,16 @@ TEST(evil_federate_test, helicsFederateEnterExecutingModeIterativeComplete)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateEnterExecutingModeIterativeComplete(nullptr, &err);
     EXPECT_EQ(res1, HELICS_ITERATION_RESULT_ERROR);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     auto res2 = helicsFederateEnterExecutingModeIterativeComplete(nullptr, nullptr);
     EXPECT_EQ(res2, HELICS_ITERATION_RESULT_ERROR);
     auto res3 = helicsFederateEnterExecutingModeIterativeComplete(evil_federate, &err);
     EXPECT_EQ(res3, HELICS_ITERATION_RESULT_ERROR);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateGetState)
@@ -1379,9 +1379,9 @@ TEST(evil_federate_test, helicsFederateGetState)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetState(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_STATE_ERROR);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetState(nullptr, nullptr);
@@ -1396,16 +1396,16 @@ TEST(evil_federate_test, helicsFederateGetCore)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetCore(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetCore(nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetCore(evil_federate, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTime)
@@ -1415,16 +1415,16 @@ TEST(evil_federate_test, helicsFederateRequestTime)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRequestTime(nullptr, 1.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     auto res2 = helicsFederateRequestTime(nullptr, 1.0, nullptr);
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateRequestTime(evil_federate, 1.0, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTimeAdvance)
@@ -1434,16 +1434,16 @@ TEST(evil_federate_test, helicsFederateRequestTimeAdvance)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRequestTimeAdvance(nullptr, 1.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRequestTimeAdvance(nullptr, 1.0, nullptr);
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateRequestTimeAdvance(evil_federate, 1.0, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestNextStep)
@@ -1452,16 +1452,16 @@ TEST(evil_federate_test, helicsFederateRequestNextStep)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRequestNextStep(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRequestNextStep(nullptr, nullptr);
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateRequestNextStep(evil_federate, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTimeIterative)
@@ -1472,11 +1472,11 @@ TEST(evil_federate_test, helicsFederateRequestTimeIterative)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     HelicsIterationResult iteration{HELICS_ITERATION_RESULT_ITERATING};
     auto res1 = helicsFederateRequestTimeIterative(
         nullptr, 1.0, HELICS_ITERATION_REQUEST_FORCE_ITERATION, &iteration, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     EXPECT_EQ(iteration, HELICS_ITERATION_RESULT_ERROR);
     helicsErrorClear(&err);
@@ -1488,7 +1488,7 @@ TEST(evil_federate_test, helicsFederateRequestTimeIterative)
     auto res3 = helicsFederateRequestTimeIterative(
         evil_federate, 1.0, HELICS_ITERATION_REQUEST_FORCE_ITERATION, nullptr, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTimeAsync)
@@ -1498,14 +1498,14 @@ TEST(evil_federate_test, helicsFederateRequestTimeAsync)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateRequestTimeAsync(nullptr, 1.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateRequestTimeAsync(HelicsFederate fed, HelicsTime requestTime,
     // nullptr);
     helicsFederateRequestTimeAsync(evil_federate, 1.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTimeComplete)
@@ -1514,16 +1514,16 @@ TEST(evil_federate_test, helicsFederateRequestTimeComplete)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRequestTimeComplete(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRequestTimeComplete(nullptr, nullptr);
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateRequestTimeComplete(evil_federate, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTimeIterativeAsync)
@@ -1533,12 +1533,12 @@ TEST(evil_federate_test, helicsFederateRequestTimeIterativeAsync)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateRequestTimeIterativeAsync(nullptr,
                                             1.0,
                                             HELICS_ITERATION_REQUEST_FORCE_ITERATION,
                                             &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateRequestTimeIterativeAsync(     HelicsFederate fed,     HelicsTime
     // requestTime,     HelicsIterationRequest iterate,     nullptr);
@@ -1546,7 +1546,7 @@ TEST(evil_federate_test, helicsFederateRequestTimeIterativeAsync)
                                             1.0,
                                             HELICS_ITERATION_REQUEST_FORCE_ITERATION,
                                             &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateRequestTimeIterativeComplete)
@@ -1556,10 +1556,10 @@ TEST(evil_federate_test, helicsFederateRequestTimeIterativeComplete)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     HelicsIterationResult iteration{HELICS_ITERATION_RESULT_ITERATING};
     auto res1 = helicsFederateRequestTimeIterativeComplete(nullptr, &iteration, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(iteration, HELICS_ITERATION_RESULT_ERROR);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     iteration = HELICS_ITERATION_RESULT_ITERATING;
@@ -1568,7 +1568,7 @@ TEST(evil_federate_test, helicsFederateRequestTimeIterativeComplete)
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateRequestTimeIterativeComplete(evil_federate, &iteration, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(iteration, HELICS_ITERATION_RESULT_ERROR);
 }
 
@@ -1590,14 +1590,14 @@ TEST(evil_federate_test, helicsFederateSetTimeProperty)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetTimeProperty(nullptr, 1, 4.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetTimeProperty(HelicsFederate fed, int timeProperty, HelicsTime
     // time, nullptr);
     helicsFederateSetTimeProperty(evil_federate, 4, 1.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateSetFlagOption)
@@ -1607,14 +1607,14 @@ TEST(evil_federate_test, helicsFederateSetFlagOption)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetFlagOption(nullptr, 99, HELICS_FALSE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetFlagOption(HelicsFederate fed, int flag, HelicsBool flagValue,
     // nullptr);
     helicsFederateSetFlagOption(evil_federate, 99, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateSetSeparator)
@@ -1623,13 +1623,13 @@ TEST(evil_federate_test, helicsFederateSetSeparator)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetSeparator(nullptr, '-', &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetSeparator(HelicsFederate fed, char separator, nullptr);
     helicsFederateSetSeparator(evil_federate, '-', &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateSetIntegerProperty)
@@ -1639,14 +1639,14 @@ TEST(evil_federate_test, helicsFederateSetIntegerProperty)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetIntegerProperty(nullptr, 0, 99, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetIntegerProperty(HelicsFederate fed, int intProperty, int
     // propertyVal, nullptr);
     helicsFederateSetIntegerProperty(evil_federate, 99, 99, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateGetTimeProperty)
@@ -1656,16 +1656,16 @@ TEST(evil_federate_test, helicsFederateGetTimeProperty)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetTimeProperty(nullptr, 99, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetTimeProperty(nullptr, 88, nullptr);
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateGetTimeProperty(evil_federate, 77, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateGetFlagOption)
@@ -1674,16 +1674,16 @@ TEST(evil_federate_test, helicsFederateGetFlagOption)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetFlagOption(nullptr, 1, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetFlagOption(nullptr, 1, nullptr);
     EXPECT_EQ(res2, HELICS_FALSE);
     auto res3 = helicsFederateGetFlagOption(evil_federate, 1, &err);
     EXPECT_EQ(res3, HELICS_FALSE);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateGetIntegerProperty)
@@ -1693,16 +1693,16 @@ TEST(evil_federate_test, helicsFederateGetIntegerProperty)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetIntegerProperty(nullptr, 99, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_LT(res1, 0);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetIntegerProperty(nullptr, 20, nullptr);
     EXPECT_LT(res2, 0);
     auto res3 = helicsFederateGetIntegerProperty(evil_federate, 20, &err);
     EXPECT_LT(res3, 0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateGetCurrentTime)
@@ -1711,16 +1711,16 @@ TEST(evil_federate_test, helicsFederateGetCurrentTime)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetCurrentTime(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_DOUBLE_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetCurrentTime(nullptr, nullptr);
     EXPECT_DOUBLE_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsFederateGetCurrentTime(evil_federate, &err);
     EXPECT_DOUBLE_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateSetGlobal)
@@ -1730,14 +1730,14 @@ TEST(evil_federate_test, helicsFederateSetGlobal)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetGlobal(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetGlobal(HelicsFederate fed, const char* valueName, const char*
     // value, nullptr);
     helicsFederateSetGlobal(evil_federate, "global", "glob", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateAddDependency)
@@ -1747,14 +1747,14 @@ TEST(evil_federate_test, helicsFederateAddDependency)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateAddDependency(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetGlobal(HelicsFederate fed, const char* valueName, const char*
     // value, nullptr);
     helicsFederateAddDependency(evil_federate, "fed", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateSetLogFile)
@@ -1763,13 +1763,13 @@ TEST(evil_federate_test, helicsFederateSetLogFile)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetLogFile(nullptr, "unknownfile.txt", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetLogFile(HelicsFederate fed, const char* logFile, nullptr);
     helicsFederateSetLogFile(evil_federate, "unknownfile.txt", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateLogErrorMessage)
@@ -1779,14 +1779,14 @@ TEST(evil_federate_test, helicsFederateLogErrorMessage)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateLogErrorMessage(nullptr, "null log", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateLogErrorMessage(HelicsFederate fed, const char* logmessage,
     // nullptr);
     helicsFederateLogErrorMessage(evil_federate, "null log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateLogWarningMessage)
@@ -1796,14 +1796,14 @@ TEST(evil_federate_test, helicsFederateLogWarningMessage)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateLogWarningMessage(nullptr, "null log", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateLogWarningMessage(HelicsFederate fed, const char* logmessage,
     // nullptr);
     helicsFederateLogWarningMessage(evil_federate, "null log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateLogInfoMessage)
@@ -1813,13 +1813,13 @@ TEST(evil_federate_test, helicsFederateLogInfoMessage)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateLogInfoMessage(nullptr, "null log", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateLogInfoMessage(HelicsFederate fed, "null log", nullptr);
     helicsFederateLogInfoMessage(evil_federate, "null log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateLogDebugMessage)
@@ -1829,14 +1829,14 @@ TEST(evil_federate_test, helicsFederateLogDebugMessage)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateLogDebugMessage(nullptr, "null log", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateLogDebugMessage(HelicsFederate fed, const char* logmessage,
     // nullptr);
     helicsFederateLogDebugMessage(evil_federate, "null log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateLogLevelMessage)
@@ -1846,14 +1846,14 @@ TEST(evil_federate_test, helicsFederateLogLevelMessage)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateLogLevelMessage(nullptr, 0, "null log", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateLogLevelMessage(HelicsFederate fed, int loglevel, const char*
     // logmessage, nullptr);
     helicsFederateLogLevelMessage(evil_federate, 0, "null log", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_federate_test, helicsFederateSetLoggingCallback)
@@ -1864,15 +1864,15 @@ TEST(evil_federate_test, helicsFederateSetLoggingCallback)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateSetLoggingCallback(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateSetLoggingCallback(     HelicsFederate fed,     void (*logger)(int
     // loglevel, const char* identifier, const char* message, void* userData),     void* userdata,
     // nullptr);
     helicsFederateSetLoggingCallback(evil_federate, nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Value Federate Functions
@@ -1885,16 +1885,16 @@ TEST(evil_value_federate_test, helicsFederateRegisterSubscription)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterSubscription(nullptr, "key", nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterSubscription(nullptr, nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterSubscription(evil_federate, "key", "pu", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterPublication)
@@ -1904,11 +1904,11 @@ TEST(evil_value_federate_test, helicsFederateRegisterPublication)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 =
         helicsFederateRegisterPublication(nullptr, "key", HELICS_DATA_TYPE_COMPLEX, nullptr, &err);
     EXPECT_EQ(res1, nullptr);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterPublication(
         nullptr, nullptr, HELICS_DATA_TYPE_COMPLEX, nullptr, nullptr);
@@ -1916,7 +1916,7 @@ TEST(evil_value_federate_test, helicsFederateRegisterPublication)
     auto res3 = helicsFederateRegisterPublication(
         evil_federate, "key", HELICS_DATA_TYPE_COMPLEX, nullptr, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterTypePublication)
@@ -1926,16 +1926,16 @@ TEST(evil_value_federate_test, helicsFederateRegisterTypePublication)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterTypePublication(nullptr, "key", "type", "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterTypePublication(nullptr, nullptr, nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterTypePublication(evil_federate, "key", "type", "", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterGlobalPublication)
@@ -1945,10 +1945,10 @@ TEST(evil_value_federate_test, helicsFederateRegisterGlobalPublication)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 =
         helicsFederateRegisterGlobalPublication(nullptr, "key", HELICS_DATA_TYPE_ANY, "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterGlobalPublication(
@@ -1957,7 +1957,7 @@ TEST(evil_value_federate_test, helicsFederateRegisterGlobalPublication)
     auto res3 = helicsFederateRegisterGlobalPublication(
         evil_federate, "key", HELICS_DATA_TYPE_ANY, "", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterGlobalTypePublication)
@@ -1967,9 +1967,9 @@ TEST(evil_value_federate_test, helicsFederateRegisterGlobalTypePublication)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterGlobalTypePublication(nullptr, "key", "type", "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 =
@@ -1986,9 +1986,9 @@ TEST(evil_value_federate_test, helicsFederateRegisterInput)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterInput(nullptr, "key", HELICS_DATA_TYPE_ANY, "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 =
@@ -1996,7 +1996,7 @@ TEST(evil_value_federate_test, helicsFederateRegisterInput)
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterInput(evil_federate, "key", HELICS_DATA_TYPE_ANY, "", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterTypeInput)
@@ -2006,16 +2006,16 @@ TEST(evil_value_federate_test, helicsFederateRegisterTypeInput)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterTypeInput(nullptr, "key", "type", "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterTypeInput(nullptr, nullptr, nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterTypeInput(evil_federate, "key", "type", "", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterGlobalInput)
@@ -2025,9 +2025,9 @@ TEST(evil_value_federate_test, helicsFederateRegisterGlobalInput)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterGlobalInput(nullptr, "key", HELICS_DATA_TYPE_ANY, "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 =
@@ -2036,7 +2036,7 @@ TEST(evil_value_federate_test, helicsFederateRegisterGlobalInput)
     auto res3 =
         helicsFederateRegisterGlobalInput(evil_federate, "key", HELICS_DATA_TYPE_ANY, "", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateRegisterGlobalTypeInput)
@@ -2046,16 +2046,16 @@ TEST(evil_value_federate_test, helicsFederateRegisterGlobalTypeInput)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterGlobalTypeInput(nullptr, "key", "type", "", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterGlobalTypeInput(nullptr, nullptr, nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterGlobalTypeInput(evil_federate, "key", "type", "", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateGetPublication)
@@ -2065,16 +2065,16 @@ TEST(evil_value_federate_test, helicsFederateGetPublication)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetPublication(nullptr, "key", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetPublication(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetPublication(evil_federate, "key", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateGetPublicationByIndex)
@@ -2084,16 +2084,16 @@ TEST(evil_value_federate_test, helicsFederateGetPublicationByIndex)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetPublicationByIndex(nullptr, 0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetPublicationByIndex(nullptr, 0, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetPublicationByIndex(evil_federate, 0, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateGetInput)
@@ -2102,16 +2102,16 @@ TEST(evil_value_federate_test, helicsFederateGetInput)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetInput(nullptr, "key", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetInput(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetInput(evil_federate, "key", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateGetInputByIndex)
@@ -2121,16 +2121,16 @@ TEST(evil_value_federate_test, helicsFederateGetInputByIndex)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetInputByIndex(nullptr, 0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetInputByIndex(nullptr, 0, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetInputByIndex(evil_federate, 0, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateGetSubscription)
@@ -2140,16 +2140,16 @@ TEST(evil_value_federate_test, helicsFederateGetSubscription)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetSubscription(nullptr, "key", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetSubscription(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetSubscription(evil_federate, "key", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateClearUpdates)
@@ -2167,14 +2167,14 @@ TEST(evil_value_federate_test, helicsFederateRegisterFromPublicationJSON)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederateRegisterFromPublicationJSON(nullptr, "json.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederateRegisterFromPublicationJSON(HelicsFederate fed, const char* json,
     // nullptr);
     helicsFederateRegisterFromPublicationJSON(evil_federate, "json.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederatePublishJSON)
@@ -2183,13 +2183,13 @@ TEST(evil_value_federate_test, helicsFederatePublishJSON)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFederatePublishJSON(nullptr, "json.json", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFederatePublishJSON(HelicsFederate fed, const char* json, nullptr);
     helicsFederatePublishJSON(evil_federate, "json.json", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_value_federate_test, helicsFederateGetPublicationCount)
@@ -2232,14 +2232,14 @@ TEST(evil_pub_test, helicsPublicationPublishBytes)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishBytes(nullptr, nullptr, 85, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishBytes(HelicsPublication pub, const void* data, int
     // inputDataLength, nullptr);
     helicsPublicationPublishBytes(evil_pub, nullptr, 14654181, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishString)
@@ -2249,13 +2249,13 @@ TEST(evil_pub_test, helicsPublicationPublishString)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishString(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishString(HelicsPublication pub, const char* str, nullptr);
     helicsPublicationPublishString(evil_pub, "String", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishInteger)
@@ -2264,13 +2264,13 @@ TEST(evil_pub_test, helicsPublicationPublishInteger)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishInteger(nullptr, 1, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishInteger(HelicsPublication pub, int64_t val, nullptr);
     helicsPublicationPublishInteger(evil_pub, 1, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishBoolean)
@@ -2280,13 +2280,13 @@ TEST(evil_pub_test, helicsPublicationPublishBoolean)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishBoolean(nullptr, 0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishBoolean(HelicsPublication pub, HelicsBool val, nullptr);
     helicsPublicationPublishBoolean(evil_pub, 99, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishDouble)
@@ -2295,13 +2295,13 @@ TEST(evil_pub_test, helicsPublicationPublishDouble)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishDouble(nullptr, 1.7, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishDouble(HelicsPublication pub, double val, nullptr);
     helicsPublicationPublishDouble(evil_pub, 2.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishTime)
@@ -2311,13 +2311,13 @@ TEST(evil_pub_test, helicsPublicationPublishTime)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishTime(nullptr, 4.3, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishTime(HelicsPublication pub, HelicsTime val, nullptr);
     helicsPublicationPublishTime(evil_pub, 5.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishChar)
@@ -2326,13 +2326,13 @@ TEST(evil_pub_test, helicsPublicationPublishChar)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishChar(nullptr, '\0', &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishChar(HelicsPublication pub, char val, nullptr);
     helicsPublicationPublishChar(evil_pub, 'c', &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishComplex)
@@ -2342,14 +2342,14 @@ TEST(evil_pub_test, helicsPublicationPublishComplex)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishComplex(nullptr, 2.0, -6.5, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishComplex(HelicsPublication pub, double real, double imag,
     // nullptr);
     helicsPublicationPublishComplex(evil_pub, 4.507, 11.3, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishVector)
@@ -2359,14 +2359,14 @@ TEST(evil_pub_test, helicsPublicationPublishVector)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishVector(nullptr, nullptr, 99, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishVector(HelicsPublication pub, const double* vectorInput,
     // int vectorLength, nullptr);
     helicsPublicationPublishVector(evil_pub, nullptr, 99, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationPublishNamedPoint)
@@ -2376,14 +2376,14 @@ TEST(evil_pub_test, helicsPublicationPublishNamedPoint)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationPublishNamedPoint(nullptr, "string", 5.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationPublishNamedPoint(HelicsPublication pub, const char* str, double
     // val, nullptr);
     helicsPublicationPublishNamedPoint(evil_pub, "string", 5.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationAddTarget)
@@ -2393,13 +2393,13 @@ TEST(evil_pub_test, helicsPublicationAddTarget)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationAddTarget(nullptr, "target", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationAddTarget(HelicsPublication pub, const char* target, nullptr);
     helicsPublicationAddTarget(evil_pub, "target", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationGetType)
@@ -2452,13 +2452,13 @@ TEST(evil_pub_test, helicsPublicationSetInfo)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationSetInfo(nullptr, "info", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationSetInfo(HelicsPublication pub, const char* info, nullptr);
     helicsPublicationSetInfo(evil_pub, "", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationSetMinimumChange)
@@ -2468,13 +2468,13 @@ TEST(evil_pub_test, helicsPublicationSetMinimumChange)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationSetMinimumChange(nullptr, 12.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationSetInfo(HelicsPublication pub, const char* info, nullptr);
     helicsPublicationSetMinimumChange(evil_pub, 1.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_pub_test, helicsPublicationGetOption)
@@ -2495,17 +2495,17 @@ TEST(evil_pub_test, helicsPublicationSetOption)
     char rdata[256];
     auto evil_pub = reinterpret_cast<HelicsPublication>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsPublicationSetOption(nullptr, -10, HELICS_TRUE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsPublicationSetOption(HelicsPublication pub, int option, HelicsBool val,
     // nullptr);
     helicsPublicationSetOption(evil_pub, 45, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsPublicationSetOption(nullptr, 45, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Input interface Functions
@@ -2525,13 +2525,13 @@ TEST(evil_input_test, helicsInputAddTarget)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputAddTarget(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputAddTarget(HelicsInput ipt, const char* target, nullptr);
     helicsInputAddTarget(evil_input, "target", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetByteCount)
@@ -2552,10 +2552,10 @@ TEST(evil_input_test, helicsInputGetBytes)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     int actLen = 99;
     helicsInputGetBytes(nullptr, nullptr, 87, &actLen, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actLen, 0);
     helicsErrorClear(&err);
     actLen = 99;
@@ -2563,7 +2563,7 @@ TEST(evil_input_test, helicsInputGetBytes)
     // actualSize, nullptr);
     helicsInputGetBytes(evil_input, rdata, 10, &actLen, &err);
     EXPECT_EQ(actLen, 0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetStringSize)
@@ -2584,10 +2584,10 @@ TEST(evil_input_test, helicsInputGetString)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     int actLen = 99;
     helicsInputGetString(nullptr, nullptr, 67, &actLen, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actLen, 0);
     helicsErrorClear(&err);
     // auto res2=helicsInputGetString(HelicsInput ipt, char* outputString, int maxStringLen, int*
@@ -2595,7 +2595,7 @@ TEST(evil_input_test, helicsInputGetString)
     actLen = 99;
     helicsInputGetString(evil_input, nullptr, 45, &actLen, &err);
     EXPECT_EQ(actLen, 0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetInteger)
@@ -2604,16 +2604,16 @@ TEST(evil_input_test, helicsInputGetInteger)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsInputGetInteger(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, -101);
     helicsErrorClear(&err);
     auto res2 = helicsInputGetInteger(nullptr, nullptr);
     EXPECT_EQ(res2, -101);
     auto res3 = helicsInputGetInteger(evil_input, &err);
     EXPECT_EQ(res3, -101);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetBoolean)
@@ -2622,16 +2622,16 @@ TEST(evil_input_test, helicsInputGetBoolean)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsInputGetBoolean(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_FALSE);
     helicsErrorClear(&err);
     auto res2 = helicsInputGetBoolean(nullptr, nullptr);
     EXPECT_EQ(res2, HELICS_FALSE);
     auto res3 = helicsInputGetBoolean(evil_input, &err);
     EXPECT_EQ(res3, HELICS_FALSE);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetDouble)
@@ -2640,16 +2640,16 @@ TEST(evil_input_test, helicsInputGetDouble)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsInputGetDouble(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsInputGetDouble(nullptr, nullptr);
     EXPECT_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsInputGetDouble(evil_input, &err);
     EXPECT_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetTime)
@@ -2658,16 +2658,16 @@ TEST(evil_input_test, helicsInputGetTime)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsInputGetTime(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsInputGetTime(nullptr, nullptr);
     EXPECT_EQ(res2, HELICS_TIME_INVALID);
     auto res3 = helicsInputGetTime(evil_input, &err);
     EXPECT_EQ(res3, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetChar)
@@ -2676,9 +2676,9 @@ TEST(evil_input_test, helicsInputGetChar)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     char res1 = helicsInputGetChar(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     char tc = '\x15';
     EXPECT_TRUE(res1 == tc);
     helicsErrorClear(&err);
@@ -2686,7 +2686,7 @@ TEST(evil_input_test, helicsInputGetChar)
     EXPECT_TRUE(res2 == tc);
     char res3 = helicsInputGetChar(evil_input, &err);
     EXPECT_TRUE(res3 == tc);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetComplexObject)
@@ -2695,16 +2695,16 @@ TEST(evil_input_test, helicsInputGetComplexObject)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsInputGetComplexObject(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1.real, HELICS_TIME_INVALID);
     helicsErrorClear(&err);
     auto res2 = helicsInputGetComplexObject(nullptr, nullptr);
     EXPECT_EQ(res2.real, HELICS_TIME_INVALID);
     auto res3 = helicsInputGetComplexObject(evil_input, &err);
     EXPECT_EQ(res3.real, HELICS_TIME_INVALID);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetComplex)
@@ -2713,9 +2713,9 @@ TEST(evil_input_test, helicsInputGetComplex)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputGetComplex(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     double v1 = 19.4;
     double v2 = 18.3;
@@ -2723,7 +2723,7 @@ TEST(evil_input_test, helicsInputGetComplex)
     helicsInputGetComplex(evil_input, &v1, &v2, &err);
     EXPECT_DOUBLE_EQ(v1, 19.4);
     EXPECT_DOUBLE_EQ(v2, 18.3);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetVectorSize)
@@ -2744,17 +2744,17 @@ TEST(evil_input_test, helicsInputGetVector)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     int actLen = -56;
     helicsInputGetVector(nullptr, nullptr, 99, &actLen, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actLen, 0);
     helicsErrorClear(&err);
     // auto res2=helicsInputGetVector(HelicsInput ipt, double data[], int maxlen, int* actualSize,
     // nullptr);
     helicsInputGetVector(evil_input, nullptr, 107, &actLen, &err);
     EXPECT_EQ(actLen, 0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetNamedPoint)
@@ -2764,11 +2764,11 @@ TEST(evil_input_test, helicsInputGetNamedPoint)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     int actLen = -56;
     double val = -15.0;
     helicsInputGetNamedPoint(nullptr, nullptr, 55, &actLen, &val, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actLen, 0);
     EXPECT_EQ(val, -15.0);
     helicsErrorClear(&err);
@@ -2777,7 +2777,7 @@ TEST(evil_input_test, helicsInputGetNamedPoint)
     helicsInputGetNamedPoint(evil_input, rdata, 256, &actLen, &val, &err);
     EXPECT_EQ(actLen, 0);
     EXPECT_EQ(val, -15.0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultBytes)
@@ -2787,14 +2787,14 @@ TEST(evil_input_test, helicsInputSetDefaultBytes)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultBytes(nullptr, nullptr, -87, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultBytes(HelicsInput ipt, const void* data, int inputDataLength,
     // nullptr);
     helicsInputSetDefaultBytes(evil_input, nullptr, 15, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultString)
@@ -2803,13 +2803,13 @@ TEST(evil_input_test, helicsInputSetDefaultString)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultString(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultString(HelicsInput ipt, const char* str, nullptr);
     helicsInputSetDefaultString(evil_input, "string", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultInteger)
@@ -2818,13 +2818,13 @@ TEST(evil_input_test, helicsInputSetDefaultInteger)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultInteger(nullptr, -1798524456525, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultInteger(HelicsInput ipt, int64_t val, nullptr);
     helicsInputSetDefaultInteger(evil_input, 99, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultBoolean)
@@ -2833,13 +2833,13 @@ TEST(evil_input_test, helicsInputSetDefaultBoolean)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultBoolean(nullptr, HELICS_FALSE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultBoolean(HelicsInput ipt, HelicsBool val, nullptr);
     helicsInputSetDefaultBoolean(evil_input, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultTime)
@@ -2848,13 +2848,13 @@ TEST(evil_input_test, helicsInputSetDefaultTime)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultTime(nullptr, 5.7, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultTime(HelicsInput ipt, HelicsTime val, nullptr);
     helicsInputSetDefaultTime(evil_input, HELICS_TIME_INVALID, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultChar)
@@ -2863,13 +2863,13 @@ TEST(evil_input_test, helicsInputSetDefaultChar)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultChar(nullptr, 'b', &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultChar(HelicsInput ipt, char val, nullptr);
     helicsInputSetDefaultChar(evil_input, 'a', &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultDouble)
@@ -2878,13 +2878,13 @@ TEST(evil_input_test, helicsInputSetDefaultDouble)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultDouble(nullptr, 1.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultDouble(HelicsInput ipt, double val, nullptr);
     helicsInputSetDefaultDouble(evil_input, 1.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultComplex)
@@ -2894,13 +2894,13 @@ TEST(evil_input_test, helicsInputSetDefaultComplex)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultComplex(nullptr, 1.0, 1.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultComplex(HelicsInput ipt, double real, double imag, nullptr);
     helicsInputSetDefaultComplex(evil_input, 1.0, 1.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultVector)
@@ -2910,14 +2910,14 @@ TEST(evil_input_test, helicsInputSetDefaultVector)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultVector(nullptr, nullptr, 28, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultVector(HelicsInput ipt, const double* vectorInput, int
     // vectorLength, nullptr);
     helicsInputSetDefaultVector(evil_input, nullptr, 87, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetDefaultNamedPoint)
@@ -2927,14 +2927,14 @@ TEST(evil_input_test, helicsInputSetDefaultNamedPoint)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetDefaultNamedPoint(nullptr, nullptr, 0.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetDefaultNamedPoint(HelicsInput ipt, const char* str, double val,
     // nullptr);
     helicsInputSetDefaultNamedPoint(evil_input, "string", 19, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetType)
@@ -3031,13 +3031,13 @@ TEST(evil_input_test, helicsInputSetInfo)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetInfo(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetInfo(HelicsInput inp, const char* info, nullptr);
     helicsInputSetInfo(evil_input, "info", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputSetMinimumChange)
@@ -3046,13 +3046,13 @@ TEST(evil_input_test, helicsInputSetMinimumChange)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetMinimumChange(nullptr, 12.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetInfo(HelicsInput inp, const char* info, nullptr);
     helicsInputSetMinimumChange(evil_input, 12.0, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputGetOption)
@@ -3073,16 +3073,16 @@ TEST(evil_input_test, helicsInputSetOption)
     char rdata[256];
     auto evil_input = reinterpret_cast<HelicsInput>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsInputSetOption(nullptr, 0, HELICS_TRUE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsInputSetOption(HelicsInput inp, int option, HelicsBool value, nullptr);
     helicsInputSetOption(evil_input, 45, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsInputSetOption(nullptr, 45, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_input_test, helicsInputIsUpdated)
@@ -3126,16 +3126,16 @@ TEST(evil_message_fed_test, helicsFederateRegisterEndpoint)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterEndpoint(nullptr, "name", "type", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterEndpoint(nullptr, nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterEndpoint(evil_federate, "name", "type", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_fed_test, helicsFederateRegisterGlobalEndpoint)
@@ -3145,16 +3145,16 @@ TEST(evil_message_fed_test, helicsFederateRegisterGlobalEndpoint)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterGlobalEndpoint(nullptr, "name", "type", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterGlobalEndpoint(nullptr, nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterGlobalEndpoint(evil_federate, "name", "type", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_fed_test, helicsFederateGetEndpoint)
@@ -3164,16 +3164,16 @@ TEST(evil_message_fed_test, helicsFederateGetEndpoint)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetEndpoint(nullptr, "name", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetEndpoint(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetEndpoint(evil_federate, "name", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_fed_test, helicsFederateGetEndpointByIndex)
@@ -3183,16 +3183,16 @@ TEST(evil_message_fed_test, helicsFederateGetEndpointByIndex)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetEndpointByIndex(nullptr, 0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetEndpointByIndex(nullptr, 0, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetEndpointByIndex(evil_federate, 0, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_fed_test, helicsFederateHasMessage)
@@ -3235,9 +3235,9 @@ TEST(evil_message_fed_test, helicsEndpointGetMessage)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateCreateMessage(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateCreateMessage(nullptr, nullptr);
@@ -3374,10 +3374,10 @@ TEST(evil_message_object_test, helicsMessageGetBytes)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     int actSize = 98;
     helicsMessageGetBytes(nullptr, nullptr, 55, &actSize, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(actSize, 0);
     helicsErrorClear(&err);
     actSize = 45;
@@ -3385,7 +3385,7 @@ TEST(evil_message_object_test, helicsMessageGetBytes)
     // nullptr);
     helicsMessageGetBytes(evil_mo, nullptr, 22, &actSize, &err);
     EXPECT_EQ(actSize, 0);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageIsValid)
@@ -3406,13 +3406,13 @@ TEST(evil_message_object_test, helicsMessageSetSource)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetSource(nullptr, "src", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetSource(nullptr, const char* src, nullptr);
     helicsMessageSetSource(evil_mo, "src", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageCopy)
@@ -3422,15 +3422,15 @@ TEST(evil_message_object_test, helicsMessageCopy)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageCopy(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsMessageCopy(nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 
     helicsMessageCopy(evil_mo, evil_mo, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetDestination)
@@ -3440,13 +3440,13 @@ TEST(evil_message_object_test, helicsMessageSetDestination)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetDestination(nullptr, "dest", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetDestination(nullptr, const char* dest, nullptr);
     helicsMessageSetDestination(evil_mo, "dest", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetOriginalSource)
@@ -3456,13 +3456,13 @@ TEST(evil_message_object_test, helicsMessageSetOriginalSource)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetOriginalSource(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetOriginalSource(nullptr, const char* src, nullptr);
     helicsMessageSetOriginalSource(evil_mo, "osrc", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetOriginalDestination)
@@ -3472,13 +3472,13 @@ TEST(evil_message_object_test, helicsMessageSetOriginalDestination)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetOriginalDestination(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetOriginalDestination(nullptr, const char* dest, nullptr);
     helicsMessageSetOriginalDestination(evil_mo, "odest", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetTime)
@@ -3488,13 +3488,13 @@ TEST(evil_message_object_test, helicsMessageSetTime)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetTime(nullptr, 1.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetTime(nullptr, HelicsTime time, nullptr);
     helicsMessageSetTime(evil_mo, HELICS_TIME_INVALID, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageResize)
@@ -3503,13 +3503,13 @@ TEST(evil_message_object_test, helicsMessageResize)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageResize(nullptr, 5, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageResize(nullptr, int newSize, nullptr);
     helicsMessageResize(evil_mo, 10, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageReserve)
@@ -3518,13 +3518,13 @@ TEST(evil_message_object_test, helicsMessageReserve)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageReserve(nullptr, 9999, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageReserve(nullptr, int reserveSize, nullptr);
     helicsMessageReserve(evil_mo, 9999, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetMessageID)
@@ -3534,13 +3534,13 @@ TEST(evil_message_object_test, helicsMessageSetMessageID)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetMessageID(nullptr, 1, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetMessageID(nullptr, int32_t messageID, nullptr);
     helicsMessageSetMessageID(evil_mo, 15, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageClearFlags)
@@ -3559,13 +3559,13 @@ TEST(evil_message_object_test, helicsMessageSetFlagOption)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetFlagOption(nullptr, 5, HELICS_FALSE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetFlagOption(nullptr, int flag, HelicsBool flagValue, nullptr);
     helicsMessageSetFlagOption(evil_mo, 7, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetString)
@@ -3575,13 +3575,13 @@ TEST(evil_message_object_test, helicsMessageSetString)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetString(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetString(nullptr, const char* str, nullptr);
     helicsMessageSetString(evil_mo, "string", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageSetData)
@@ -3591,13 +3591,13 @@ TEST(evil_message_object_test, helicsMessageSetData)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageSetData(nullptr, nullptr, 99, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageSetData(nullptr, nullptr, int inputDataLength, nullptr);
     helicsMessageSetData(evil_mo, rdata, 99, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_message_object_test, helicsMessageAppendData)
@@ -3607,13 +3607,13 @@ TEST(evil_message_object_test, helicsMessageAppendData)
     char rdata[256];
     auto evil_mo = reinterpret_cast<HelicsMessage>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsMessageAppendData(nullptr, nullptr, 89, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsMessageAppendData(nullptr, nullptr, int inputDataLength, nullptr);
     helicsMessageAppendData(evil_mo, rdata, 100, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Endpoint interface Functions
@@ -3638,13 +3638,13 @@ TEST(evil_endpoint_test, helicsEndpointSetDefaultDestination)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSetDefaultDestination(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSetDefaultDestination(nullptr, const char* dest, nullptr);
     helicsEndpointSetDefaultDestination(evil_ept, "dest", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointGetDefaultDestination)
@@ -3665,14 +3665,14 @@ TEST(evil_endpoint_test, helicsEndpointSendBytesTo)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSendBytesTo(nullptr, nullptr, 45, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSendMessage(nullptr, nullptr, nullptr, int inputDataLength,
     // nullptr);
     helicsEndpointSendBytesTo(evil_ept, rdata, 200, "dest", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointSendBytesToAt)
@@ -3682,12 +3682,12 @@ TEST(evil_endpoint_test, helicsEndpointSendBytesToAt)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSendBytesToAt(nullptr, nullptr, 45, nullptr, 0.0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsEndpointSendBytesToAt(evil_ept, rdata, 200, "dest", -15.7, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointSendBytesAt)
@@ -3697,14 +3697,14 @@ TEST(evil_endpoint_test, helicsEndpointSendBytesAt)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSendBytesAt(nullptr, nullptr, 25, 3.5, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSendBytesToAt(     nullptr,    nullptr,    nullptr,     int
     // inputDataLength,     HelicsTime time,     nullptr);
     helicsEndpointSendBytesAt(evil_ept, rdata, 56, 3.5, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointSendMessageObject)
@@ -3714,13 +3714,13 @@ TEST(evil_endpoint_test, helicsEndpointSendMessageObject)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSendMessage(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSendMessageObject(nullptr, nullptr, nullptr);
     helicsEndpointSendMessage(evil_ept, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointSubscribe)
@@ -3729,13 +3729,13 @@ TEST(evil_endpoint_test, helicsEndpointSubscribe)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSubscribe(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSubscribe(nullptr, nullptr, nullptr);
     helicsEndpointSubscribe(evil_ept, "key", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointHasMessage)
@@ -3810,17 +3810,17 @@ TEST(evil_endpoint_test, helicsEndpointSetInfo)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSetInfo(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSetInfo(nullptr, nullptr, nullptr);
     helicsEndpointSetInfo(evil_ept, "info", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsEndpointSetInfo(nullptr, "info", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointSetOption)
@@ -3830,13 +3830,13 @@ TEST(evil_endpoint_test, helicsEndpointSetOption)
     char rdata[256];
     auto evil_ept = reinterpret_cast<HelicsEndpoint>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsEndpointSetOption(nullptr, 5, HELICS_FALSE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsEndpointSetOption(nullptr, int option, HelicsBool value, nullptr);
     helicsEndpointSetOption(evil_ept, 2, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_endpoint_test, helicsEndpointGetOption)
@@ -3859,16 +3859,16 @@ TEST(evil_filter_fed_test, helicsFederateRegisterFilter)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterFilter(nullptr, HELICS_FILTER_TYPE_DELAY, "name", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterFilter(nullptr, HELICS_FILTER_TYPE_DELAY, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterFilter(evil_federate, HELICS_FILTER_TYPE_DELAY, "name", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_fed_test, helicsFederateRegisterGlobalFilter)
@@ -3878,9 +3878,9 @@ TEST(evil_filter_fed_test, helicsFederateRegisterGlobalFilter)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterGlobalFilter(nullptr, HELICS_FILTER_TYPE_DELAY, "name", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 =
@@ -3889,7 +3889,7 @@ TEST(evil_filter_fed_test, helicsFederateRegisterGlobalFilter)
     auto res3 =
         helicsFederateRegisterGlobalFilter(evil_federate, HELICS_FILTER_TYPE_DELAY, "name", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_fed_test, helicsFederateRegisterCloningFilter)
@@ -3899,16 +3899,16 @@ TEST(evil_filter_fed_test, helicsFederateRegisterCloningFilter)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterCloningFilter(nullptr, "deliver", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterCloningFilter(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterCloningFilter(evil_federate, "deliver", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_fed_test, helicsFederateRegisterGlobalCloningFilter)
@@ -3918,16 +3918,16 @@ TEST(evil_filter_fed_test, helicsFederateRegisterGlobalCloningFilter)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateRegisterGlobalCloningFilter(nullptr, "deliver", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateRegisterGlobalCloningFilter(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateRegisterGlobalCloningFilter(evil_federate, "deliver", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_fed_test, helicsFederateGetFilterCount)
@@ -3948,16 +3948,16 @@ TEST(evil_filter_fed_test, helicsFederateGetFilter)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetFilter(nullptr, "name", &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetFilter(nullptr, nullptr, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetFilter(evil_federate, "name", &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_fed_test, helicsFederateGetFilterByIndex)
@@ -3967,16 +3967,16 @@ TEST(evil_filter_fed_test, helicsFederateGetFilterByIndex)
     char rdata[256];
     auto evil_federate = reinterpret_cast<HelicsFederate>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsFederateGetFilterByIndex(nullptr, 0, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_EQ(res1, nullptr);
     helicsErrorClear(&err);
     auto res2 = helicsFederateGetFilterByIndex(nullptr, 0, nullptr);
     EXPECT_EQ(res2, nullptr);
     auto res3 = helicsFederateGetFilterByIndex(evil_federate, 0, &err);
     EXPECT_EQ(res3, nullptr);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Filter interface Functions
@@ -4007,16 +4007,16 @@ TEST(evil_filter_test, helicsFilterSet)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterSet(nullptr, nullptr, 5.3, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterSet(HelicsFilter filt, const char* prop, double val, nullptr);
     helicsFilterSet(evil_filt, "prop", 5.2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFilterSet(nullptr, "prop", 5.2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterSetString)
@@ -4026,14 +4026,14 @@ TEST(evil_filter_test, helicsFilterSetString)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterSetString(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterSetString(HelicsFilter filt, const char* prop, const char* val,
     // nullptr);
     helicsFilterSetString(evil_filt, "prop", "val", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterAddDestinationTarget)
@@ -4043,13 +4043,13 @@ TEST(evil_filter_test, helicsFilterAddDestinationTarget)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterAddDestinationTarget(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterAddDestinationTarget(HelicsFilter filt, const char* dest, nullptr);
     helicsFilterAddDestinationTarget(evil_filt, "dest", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterAddSourceTarget)
@@ -4058,13 +4058,13 @@ TEST(evil_filter_test, helicsFilterAddSourceTarget)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterAddSourceTarget(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterAddSourceTarget(HelicsFilter filt, const char* source, nullptr);
     helicsFilterAddSourceTarget(evil_filt, "source", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterAddDeliveryEndpoint)
@@ -4074,14 +4074,14 @@ TEST(evil_filter_test, helicsFilterAddDeliveryEndpoint)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterAddDeliveryEndpoint(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterAddDeliveryEndpoint(HelicsFilter filt, const char* deliveryEndpoint,
     // nullptr);
     helicsFilterAddDeliveryEndpoint(evil_filt, "deliver", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterRemoveTarget)
@@ -4090,13 +4090,13 @@ TEST(evil_filter_test, helicsFilterRemoveTarget)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterRemoveTarget(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterRemoveTarget(HelicsFilter filt, const char* target, nullptr);
     helicsFilterRemoveTarget(evil_filt, "target", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterRemoveDeliveryEndpoint)
@@ -4106,17 +4106,17 @@ TEST(evil_filter_test, helicsFilterRemoveDeliveryEndpoint)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterRemoveDeliveryEndpoint(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterRemoveDeliveryEndpoint(HelicsFilter filt, const char*
     // deliveryEndpoint, nullptr);
     helicsFilterRemoveDeliveryEndpoint(evil_filt, "deliver", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFilterRemoveDeliveryEndpoint(nullptr, "deliver", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterGetInfo)
@@ -4136,13 +4136,13 @@ TEST(evil_filter_test, helicsFilterSetInfo)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterSetInfo(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterSetInfo(HelicsFilter filt, const char* info, nullptr);
     helicsFilterSetInfo(evil_filt, "info", &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterSetOption)
@@ -4152,13 +4152,13 @@ TEST(evil_filter_test, helicsFilterSetOption)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterSetOption(nullptr, 0, HELICS_TRUE, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     // auto res2=helicsFilterSetOption(HelicsFilter filt, int option, HelicsBool value, nullptr);
     helicsFilterSetOption(evil_filt, 5, HELICS_TRUE, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_filter_test, helicsFilterGetOption)
@@ -4179,15 +4179,15 @@ TEST(evil_filter_test, helicsFilterSetCallback)
     char rdata[256];
     auto evil_filt = reinterpret_cast<HelicsFilter>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsFilterSetCustomCallback(nullptr, nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsFilterSetCustomCallback(nullptr, nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFilterSetCustomCallback(evil_filt, nullptr, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 // section Query Functions
@@ -4198,16 +4198,16 @@ TEST(evil_query_test, helicsQueryExecute)
     char rdata[256];
     auto evil_query = reinterpret_cast<HelicsQuery>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsQueryExecute(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_STREQ(res1, "#invalid");
     helicsErrorClear(&err);
     auto res2 = helicsQueryExecute(nullptr, nullptr, nullptr);
     EXPECT_STREQ(res2, "#invalid");
     auto res3 = helicsQueryExecute(evil_query, evil_query, &err);
     EXPECT_STREQ(res3, "#invalid");
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_query_test, helicsQueryCoreExecute)
@@ -4216,16 +4216,16 @@ TEST(evil_query_test, helicsQueryCoreExecute)
     auto evil_query = reinterpret_cast<HelicsQuery>(rdata);
     // const char*  helicsQueryCoreExecute(HelicsQuery query, HelicsCore core, HelicsError* err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsQueryCoreExecute(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_STREQ(res1, "#invalid");
     helicsErrorClear(&err);
     auto res2 = helicsQueryCoreExecute(nullptr, nullptr, nullptr);
     EXPECT_STREQ(res2, "#invalid");
     auto res3 = helicsQueryCoreExecute(evil_query, evil_query, &err);
     EXPECT_STREQ(res3, "#invalid");
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_query_test, helicsQueryBrokerExecute)
@@ -4235,16 +4235,16 @@ TEST(evil_query_test, helicsQueryBrokerExecute)
     // const char*  helicsQueryBrokerExecute(HelicsQuery query, HelicsBroker broker, HelicsError*
     // err);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsQueryBrokerExecute(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_STREQ(res1, "#invalid");
     helicsErrorClear(&err);
     auto res2 = helicsQueryBrokerExecute(nullptr, nullptr, nullptr);
     EXPECT_STREQ(res2, "#invalid");
     auto res3 = helicsQueryBrokerExecute(evil_query, evil_query, &err);
     EXPECT_STREQ(res3, "#invalid");
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_query_test, helicsQueryExecuteAsync)
@@ -4253,12 +4253,12 @@ TEST(evil_query_test, helicsQueryExecuteAsync)
     char rdata[256];
     auto evil_query = reinterpret_cast<HelicsQuery>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     helicsQueryExecuteAsync(nullptr, nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     helicsErrorClear(&err);
     helicsQueryExecuteAsync(evil_query, evil_query, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_query_test, helicsQueryExecuteComplete)
@@ -4267,16 +4267,16 @@ TEST(evil_query_test, helicsQueryExecuteComplete)
     char rdata[256];
     auto evil_query = reinterpret_cast<HelicsQuery>(rdata);
     auto err = helicsErrorInitialize();
-    err.errorCode = 45;
+    err.error_code = 45;
     auto res1 = helicsQueryExecuteComplete(nullptr, &err);
-    EXPECT_EQ(err.errorCode, 45);
+    EXPECT_EQ(err.error_code, 45);
     EXPECT_STREQ(res1, "#invalid");
     helicsErrorClear(&err);
     auto res2 = helicsQueryExecuteComplete(nullptr, nullptr);
     EXPECT_STREQ(res2, "#invalid");
     auto res3 = helicsQueryExecuteComplete(evil_query, &err);
     EXPECT_STREQ(res3, "#invalid");
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
 }
 
 TEST(evil_query_test, helicsQueryIsCompleted)

--- a/tests/helics/shared_library/loggingTests.cpp
+++ b/tests/helics/shared_library/loggingTests.cpp
@@ -29,7 +29,7 @@ TEST(logging_tests, check_log_message)
 
     logblocktype mlog;
 
-    auto logg = [](int level, const char*, const char* message, void* udata) {
+    auto logg = [](int level, const char* /*unused*/, const char* message, void* udata) {
         auto* mp = reinterpret_cast<logblocktype*>(udata);
         mp->lock()->emplace_back(level, message);
     };
@@ -67,7 +67,7 @@ TEST(logging_tests, check_log_message_levels)
 
     logblocktype mlog;
 
-    auto logg = [](int level, const char*, const char* message, void* udata) {
+    auto logg = [](int level, const char* /*unused*/, const char* message, void* udata) {
         auto* mp = reinterpret_cast<logblocktype*>(udata);
         mp->lock()->emplace_back(level, message);
     };
@@ -114,7 +114,7 @@ TEST(logging_tests, check_log_message_levels_high)
 
     logblocktype mlog;
 
-    auto logg = [](int level, const char*, const char* message, void* udata) {
+    auto logg = [](int level, const char* /*unused*/, const char* message, void* udata) {
         auto* mp = reinterpret_cast<logblocktype*>(udata);
         mp->lock()->emplace_back(level, message);
     };
@@ -154,7 +154,7 @@ TEST(logging_tests, core_logging)
 
     logblocktype mlog;
 
-    auto logg = [](int level, const char*, const char* message, void* udata) {
+    auto logg = [](int level, const char* /*unused*/, const char* message, void* udata) {
         auto* mp = reinterpret_cast<logblocktype*>(udata);
         mp->lock()->emplace_back(level, message);
     };
@@ -174,7 +174,7 @@ TEST(logging_tests, broker_logging)
 
     logblocktype mlog;
 
-    auto logg = [](int level, const char*, const char* message, void* udata) {
+    auto logg = [](int level, const char* /*unused*/, const char* message, void* udata) {
         auto* mp = reinterpret_cast<logblocktype*>(udata);
         mp->lock()->emplace_back(level, message);
     };

--- a/tests/helics/shared_library/loggingTests.cpp
+++ b/tests/helics/shared_library/loggingTests.cpp
@@ -36,13 +36,13 @@ TEST(logging_tests, check_log_message)
 
     helicsFederateSetLoggingCallback(fed, logg, &mlog, &err);
 
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateEnterExecutingMode(fed, &err);
     helicsFederateLogInfoMessage(fed, "test MEXAGE", &err);
     helicsFederateRequestNextStep(fed, &err);
     helicsFederateFinalize(fed, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     auto llock = mlog.lock();
     bool found = false;
     for (auto& m : llock) {
@@ -75,14 +75,14 @@ TEST(logging_tests, check_log_message_levels)
 
     helicsFederateSetLoggingCallback(fed, logg, &mlog, &err);
 
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateEnterExecutingMode(fed, &err);
     helicsFederateLogLevelMessage(fed, 3, "test MEXAGE1", &err);
     helicsFederateLogLevelMessage(fed, 8, "test MEXAGE2", &err);
     helicsFederateRequestNextStep(fed, &err);
     helicsFederateFinalize(fed, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     auto llock = mlog.lock();
     bool found_low = false;
@@ -121,14 +121,14 @@ TEST(logging_tests, check_log_message_levels_high)
 
     helicsFederateSetLoggingCallback(fed, logg, &mlog, &err);
 
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsFederateEnterExecutingMode(fed, &err);
     helicsFederateLogLevelMessage(fed, 3, "test MEXAGE1", &err);
     helicsFederateLogLevelMessage(fed, 8, "test MEXAGE2", &err);
     helicsFederateRequestNextStep(fed, &err);
     helicsFederateFinalize(fed, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     auto llock = mlog.lock();
     bool found_low = false;
@@ -160,7 +160,7 @@ TEST(logging_tests, core_logging)
     };
     auto err = helicsErrorInitialize();
     helicsCoreSetLoggingCallback(core, logg, &mlog, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsCoreDisconnect(core, nullptr);
     helicsCloseLibrary();
     EXPECT_FALSE(mlog.lock()->empty());
@@ -180,7 +180,7 @@ TEST(logging_tests, broker_logging)
     };
     auto err = helicsErrorInitialize();
     helicsBrokerSetLoggingCallback(broker, logg, &mlog, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     helicsBrokerDisconnect(broker, nullptr);
     helicsCloseLibrary();
     EXPECT_FALSE(mlog.lock()->empty());
@@ -197,7 +197,7 @@ TEST(logging_tests, broker_logging_file)
     helicsCloseLibrary();
     EXPECT_TRUE(ghc::filesystem::exists(lfile));
     ghc::filesystem::remove(lfile);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 }
 
 TEST(logging_tests, core_logging_file)

--- a/tests/helics/shared_library/test-message-federate.cpp
+++ b/tests/helics/shared_library/test-message-federate.cpp
@@ -47,7 +47,7 @@ TEST_P(mfed_simple_type_tests, endpoint_registration)
 
     auto epid = helicsFederateRegisterEndpoint(mFed1, "ep1", nullptr, &err);
     auto epid2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ep2", "random", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFederateEnterExecutingMode(mFed1, &err));
 
     CE(HelicsFederateState mFed1State = helicsFederateGetState(mFed1, &err));
@@ -84,7 +84,7 @@ TEST_P(mfed_simple_type_tests, send_receive)
 
     auto epid = helicsFederateRegisterEndpoint(mFed1, "ep1", nullptr, &err);
     auto epid2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ep2", "random", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFederateSetTimeProperty(mFed1, HELICS_PROPERTY_TIME_DELTA, 1.0, &err));
 
     CE(helicsFederateEnterExecutingMode(mFed1, &err));
@@ -127,7 +127,7 @@ TEST_P(mfed_simple_type_tests, send_receive_mobj)
 
     auto epid = helicsFederateRegisterEndpoint(mFed1, "ep1", nullptr, &err);
     auto epid2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ep2", "random", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFederateSetTimeProperty(mFed1, HELICS_PROPERTY_TIME_DELTA, 1.0, &err));
 
     CE(helicsFederateEnterExecutingMode(mFed1, &err));
@@ -171,7 +171,7 @@ TEST_F(mfed_tests, message_object_tests)
 
     auto epid = helicsFederateRegisterEndpoint(mFed1, "ep1", nullptr, &err);
     auto epid2 = helicsFederateRegisterGlobalEndpoint(mFed1, "ep2", "random", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     CE(helicsFederateSetTimeProperty(mFed1, HELICS_PROPERTY_TIME_DELTA, 1.0, &err));
 
     CE(helicsFederateEnterExecutingMode(mFed1, &err));
@@ -231,7 +231,7 @@ TEST_P(mfed_type_tests, send_receive_2fed)
     CE(auto epid2 = helicsFederateRegisterGlobalEndpoint(mFed2, "ep2", "random", &err));
 
     helicsEndpointSetOption(epid, HELICS_HANDLE_OPTION_IGNORE_INTERRUPTS, HELICS_TRUE, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     CE(helicsFederateSetTimeProperty(mFed1, HELICS_PROPERTY_TIME_DELTA, 1.0, &err));
     CE(helicsFederateSetTimeProperty(mFed2, HELICS_PROPERTY_TIME_DELTA, 1.0, &err));
@@ -400,14 +400,14 @@ TEST(message_object, test1)
     char data[20];
     int actSize = 10;
     helicsMessageGetBytes(m2, nullptr, 0, &actSize, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(actSize, 0);
     helicsErrorClear(&err);
 
     EXPECT_EQ(helicsMessageGetBytesPointer(nullptr), nullptr);
 
     helicsMessageGetBytes(m2, data, 20, &actSize, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 8);
     EXPECT_EQ(std::string(data, data + actSize), "raw data");
 
@@ -424,7 +424,7 @@ TEST(message_object, test1)
 
     helicsMessageSetFlagOption(m1, 22, HELICS_TRUE, &err);
     EXPECT_EQ(helicsMessageGetFlagOption(m1, 22), HELICS_FALSE);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     helicsMessageResize(m2, 500, nullptr);
@@ -440,11 +440,11 @@ TEST(message_object, test1)
 
     // this should generate an out of memory exception
     helicsMessageResize(m2, -8, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     // this should generate an out of memory exception
     helicsMessageReserve(m2, -2, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
     helicsFederateInfoFree(fi);
     helicsFederateFinalize(fed, nullptr);
@@ -479,10 +479,10 @@ TEST(message_object, copy)
     auto err = helicsErrorInitialize();
 
     helicsMessageCopy(m1, m2, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
 
     helicsMessageCopy(m1, nullptr, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     helicsErrorClear(&err);
 
     EXPECT_STREQ(helicsMessageGetString(m2), "raw data");
@@ -498,7 +498,7 @@ TEST(message_object, copy)
     int actSize = 10;
 
     helicsMessageGetBytes(m2, data, 20, &actSize, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 8);
     EXPECT_EQ(std::string(data, data + actSize), "raw data");
 

--- a/tests/helics/shared_library/test-value-federate1.cpp
+++ b/tests/helics/shared_library/test-value-federate1.cpp
@@ -228,7 +228,7 @@ TEST_F(vfed_single_tests, subscription_and_publication_registration)
 
     // this one should be invalid
     auto pubid_d = helicsFederateGetPublicationByIndex(vFed1, 5, &err);
-    EXPECT_NE(err.errorCode, 0);
+    EXPECT_NE(err.error_code, 0);
     EXPECT_EQ(pubid_d, nullptr);
     helicsErrorClear(&err);
 
@@ -276,7 +276,7 @@ TEST_F(vfed_single_tests, default_value_tests)
     EXPECT_EQ(helicsPublicationIsValid(pub), HELICS_TRUE);
 
     helicsInputSetDefaultBytes(inp_raw1, nullptr, -2, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     char data[256] = "this is a string";
     helicsInputSetDefaultBytes(inp_raw2, data, 30, &err);
 
@@ -289,7 +289,7 @@ TEST_F(vfed_single_tests, default_value_tests)
     helicsInputSetDefaultNamedPoint(inp_np, data, 15.7, &err);
 
     helicsFederateEnterExecutingMode(vFed1, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_STREQ(helicsInputGetInjectionUnits(inp_double), "MW");
     EXPECT_STREQ(helicsInputGetInjectionUnits(inp_double2), "MW");
     EXPECT_STREQ(helicsInputGetType(inp_double), "double");
@@ -300,7 +300,7 @@ TEST_F(vfed_single_tests, default_value_tests)
     int actSize = 56;
     // this should not be an error
     helicsInputGetVector(inp_vect, nullptr, 5, &actSize, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actSize, 0);
 
     auto optset = helicsInputGetOption(inp_double2, HELICS_HANDLE_OPTION_CONNECTION_REQUIRED);
@@ -340,12 +340,12 @@ TEST_F(vfed_single_tests, default_value_tests)
     int actLen = 66;
     double rval = 19.0;
     helicsInputGetNamedPoint(inp_np, nullptr, 5, &actLen, &rval, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_EQ(actLen, 0);
     EXPECT_DOUBLE_EQ(rval, 15.7);
     rval = 19.0;
     helicsInputGetNamedPoint(inp_np, out, 8, &actLen, &rval, &err);
-    EXPECT_EQ(err.errorCode, 0);
+    EXPECT_EQ(err.error_code, 0);
     EXPECT_STREQ(out, "this is");
     EXPECT_EQ(actLen, 8);
     EXPECT_DOUBLE_EQ(rval, 15.7);
@@ -959,12 +959,12 @@ TEST_P(vfed_type_tests, subscriber_and_publisher_registration)
         helicsFederateRegisterGlobalTypePublication(vFed, "pub2", "int", "", &err);
     HelicsPublication pubid3 =
         helicsFederateRegisterPublication(vFed, "pub3", HELICS_DATA_TYPE_DOUBLE, "V", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     // these aren't meant to match the publications
     auto subid = helicsFederateRegisterSubscription(vFed, "sub1", "", &err);
     auto subid2 = helicsFederateRegisterSubscription(vFed, "sub2", "", &err);
     auto subid3 = helicsFederateRegisterSubscription(vFed, "sub3", "V", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     // enter execution
     CE(helicsFederateEnterExecutingMode(vFed, &err));
 

--- a/tests/helics/shared_library/test-value-federate2.cpp
+++ b/tests/helics/shared_library/test-value-federate2.cpp
@@ -139,7 +139,7 @@ TEST_F(vfed2_tests, file_load)
     // fi = helicsCreateFederateInfo();
     // path of the JSON file is hardcoded for now
     vFed = helicsCreateValueFederateFromConfig(TEST_DIR "/example_value_fed.json", &err);
-    EXPECT_EQ(err.errorCode, HELICS_OK);
+    EXPECT_EQ(err.error_code, HELICS_OK);
     ASSERT_FALSE(vFed == nullptr);
     const char* s = helicsFederateGetName(vFed);
     EXPECT_STREQ(s, "valueFed");

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -859,7 +859,14 @@ TEST_F(query, queries_query)
     // federate queries
     auto res = vFed1->query("queries");
     auto vec = helics::vectorizeQueryResult(res);
+    bool skipversion = std::string(helics::versionString).find("error") != std::string::npos;
+
     for (auto& qstr : vec) {
+        if (skipversion) {
+            if (qstr == "version" || qstr == "version_all") {
+                continue;
+            }
+        }
         auto qres = vFed1->query(qstr);
         EXPECT_EQ(qres.find("error"), std::string::npos) << qstr << " produced an error";
         try {
@@ -873,6 +880,11 @@ TEST_F(query, queries_query)
     res = vFed1->query("core", "queries");
     vec = helics::vectorizeQueryResult(res);
     for (auto& qstr : vec) {
+        if (skipversion) {
+            if (qstr == "version" || qstr == "version_all") {
+                continue;
+            }
+        }
         auto qres = vFed1->query("core", qstr);
         EXPECT_EQ(qres.find("error"), std::string::npos) << qstr << " produced an error in core";
         try {
@@ -886,6 +898,11 @@ TEST_F(query, queries_query)
     res = vFed1->query("root", "queries");
     vec = helics::vectorizeQueryResult(res);
     for (auto& qstr : vec) {
+        if (skipversion) {
+            if (qstr == "version" || qstr == "version_all") {
+                continue;
+            }
+        }
         auto qres = vFed1->query("root", qstr);
         EXPECT_EQ(qres.find("error"), std::string::npos) << qstr << " produced an error in root";
         try {


### PR DESCRIPTION
…sues for HELICS2 to 3 conversions

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will revert the change to the error object used in the C shared API to prevent issues with the interfaces trying to provide a seamless transition from 2 to 3

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
