### PR TITLE
Default HELICS_USE_ZMQ_STATIC_LIBRARY=ON if only the static zmq library is found

### DIFF
--- a/config/cmake/addZeroMQ.cmake
+++ b/config/cmake/addZeroMQ.cmake
@@ -113,8 +113,10 @@ else()
                 show_variable(ZeroMQ_LIBRARY FILEPATH "path to the ZeroMQ library" "")
                 show_variable(ZeroMQ_ROOT_DIR PATH "path to the ZeroMQ root directory"
                               "")
-                show_variable(ZeroMQ_STATIC_LIBRARY FILEPATH
-                              "path to the ZeroMQ static library" "")
+                if(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY)
+                    show_variable(ZeroMQ_STATIC_LIBRARY FILEPATH
+                                  "path to the ZeroMQ static library" "")
+                endif()
                 show_variable(ZeroMQ_INCLUDE_DIR PATH
                               "path to the ZeroMQ include directory" "")
             endif()

--- a/config/cmake/addZeroMQ.cmake
+++ b/config/cmake/addZeroMQ.cmake
@@ -42,9 +42,16 @@ mark_as_advanced(${PROJECT_NAME}_USE_SYSTEM_ZEROMQ_ONLY)
 mark_as_advanced(${PROJECT_NAME}_ZMQ_SUBPROJECT)
 mark_as_advanced(${PROJECT_NAME}_ZMQ_FORCE_SUBPROJECT)
 
-option(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY "use the ZMQ static library" OFF)
-
-mark_as_advanced(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY)
+# Add option after seeing if only the static ZMQ library is available
+# Using a macro so the option() command appears near other option() commands
+macro(add_zmq_static_lib_option)
+    if(ZeroMQ_STATIC_LIBRARY AND NOT ZeroMQ_LIBRARY)
+        option(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY "use the ZMQ static library" ON)
+    else()
+        option(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY "use the ZMQ static library" OFF)
+    endif()
+    mark_as_advanced(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY)
+endmacro()
 
 # flag that zeromq headers are required
 set(ZeroMQ_REQUIRE_HEADERS ON)
@@ -106,10 +113,8 @@ else()
                 show_variable(ZeroMQ_LIBRARY FILEPATH "path to the ZeroMQ library" "")
                 show_variable(ZeroMQ_ROOT_DIR PATH "path to the ZeroMQ root directory"
                               "")
-                if(${PROJECT_NAME}_USE_ZMQ_STATIC_LIBRARY)
-                    show_variable(ZeroMQ_STATIC_LIBRARY FILEPATH
-                                  "path to the ZeroMQ static library" "")
-                endif()
+                show_variable(ZeroMQ_STATIC_LIBRARY FILEPATH
+                              "path to the ZeroMQ static library" "")
                 show_variable(ZeroMQ_INCLUDE_DIR PATH
                               "path to the ZeroMQ include directory" "")
             endif()
@@ -120,6 +125,8 @@ else()
 
 endif() # ${PROJECT_NAME}_USE_SYSTEM_ZEROMQ_ONLY
 hide_variable(ZeroMQ_DIR)
+
+add_zmq_static_lib_option()
 
 if(WIN32 AND NOT MSYS AND NOT CYGWIN)
     if(TARGET libzmq)

--- a/docs/installation/helics_cmake_options.md
+++ b/docs/installation/helics_cmake_options.md
@@ -65,7 +65,7 @@ Options effect the connection of libraries used in HELICS and how they are linke
 #### ZeroMQ related Options
 
 - `HELICS_USE_SYSTEM_ZEROMQ_ONLY`: \[Default=OFF\] Only find Zeromq through the system libraries, never attempt a local build.
-- `HELICS_USE_ZMQ_STATIC_LIBRARY`: \[Default=OFF\] Build and link Zeromq using a static library. (NOTE: This has licensing implications if the resulting binary is distributed)
+- `HELICS_USE_ZMQ_STATIC_LIBRARY`: \[Default=OFF (unless only libzmq-static found)\] Build and link Zeromq using a static library. (NOTE: This has licensing implications if the resulting binary is distributed)
 - `HELICS_ZMQ_SUBPROJECT`: \[Default=ON (MSVC) OFF(otherwise)\] Allow ZeroMQ to be built as a subproject if a system library is not found
 - `HELICS_ZMQ_FORCE_SUBPROJECT`: \[Default=OFF\] Force ZMQ to be built and linked as a subproject.
 - `ZeroMQ_INSTALL_PATH`: Can be used to specify a path to ZeroMQ for inclusion.


### PR DESCRIPTION
### Summary

If merged this pull request will default the `HELICS_USE_ZMQ_STATIC_LIBRARY` to `ON` if only the static zmq library is found. Otherwise, it will continue to default to `OFF`.

### Proposed changes

- Default HELICS_USE_ZMQ_STATIC_LIBRARY=ON if only the static zmq library is found
