### PR TITLE
Disable Java interface for code coverage builds

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,6 +25,7 @@ jobs:
       CMAKE_GENERATOR: Unix Makefiles
       MAKEFLAGS: '-j 4'
       CI_TEST_FLAGS: ""
+      DISABLE_INTERFACES: "Java"
       
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Summary

If merged this pull request will disable building the Java interface for the code coverage CI workflow.

### Proposed changes

- Disable Java interface for code coverage builds