### PR TITLE
Query timeouts

### DIFF
--- a/src/helics/common/JsonBuilder.cpp
+++ b/src/helics/common/JsonBuilder.cpp
@@ -73,6 +73,12 @@ bool JsonMapBuilder::clearComponents(int32_t code)
     return false;
 }
 
+bool JsonMapBuilder::clearComponents()
+{
+    missing_components.clear();
+    return static_cast<bool>(jMap);
+}
+
 std::string JsonMapBuilder::generate()
 {
     if (jMap) {

--- a/src/helics/common/JsonBuilder.hpp
+++ b/src/helics/common/JsonBuilder.hpp
@@ -42,8 +42,13 @@ class JsonMapBuilder {
     /** generate a new location to fill in later
     @return the index value of the location for use in addComponent*/
     int generatePlaceHolder(const std::string& location, int32_t code);
-    /** generate the JSON value*/
+    /** clear components with a specific code
+    return true if the map is now complete*/
     bool clearComponents(int32_t code);
+    /** clear all remaining components
+    return true if the builder can be generated*/
+    bool clearComponents();
+    /** generate the JSON value*/
     std::string generate();
     /** reset the builder*/
     void reset();

--- a/src/helics/core/BrokerBase.cpp
+++ b/src/helics/core/BrokerBase.cpp
@@ -220,6 +220,11 @@ std::shared_ptr<helicsCLI11App> BrokerBase::generateBaseCLI()
         networkTimeout,
         "time to wait for a broker connection default unit is in ms(can also be entered as a time "
         "like '10s' or '45ms') ");
+    timeout_group->add_option(
+        "--querytimeout",
+        queryTimeout,
+        "time to wait for a query to be answered default unit is in  ms default 15s(can also be entered as a time "
+        "like '10s' or '45ms') ");
     timeout_group
         ->add_option("--errordelay,--errortimeout",
                      errorDelay,
@@ -687,7 +692,7 @@ void BrokerBase::queueProcessingLoop()
                     }
                     break;
                 }
-                if (messagesSinceLastTick == 0 || forwardTick) {
+                if (messagesSinceLastTick == 0 || forwardTick>0U) {
 #ifndef DISABLE_TICK
                     processCommand(std::move(command));
 #endif

--- a/src/helics/core/BrokerBase.hpp
+++ b/src/helics/core/BrokerBase.hpp
@@ -51,6 +51,7 @@ class BrokerBase {
     Time tickTimer{5.0};  //!< the length of each heartbeat tick
     Time timeout{30.0};  //!< timeout to wait to establish a broker connection before giving up
     Time networkTimeout{-1.0};  //!< timeout to establish a socket connection before giving up
+    Time queryTimeout{15.0}; //!< timeout for queries, if the query isn't answered within this time period respond with timeout error
     Time errorDelay{10.0};  //!< time to delay before terminating after error state
     std::string identifier;  //!< an identifier for the broker
     std::string brokerKey;  //!< a key that all joining federates must have to connect if empty no
@@ -112,8 +113,8 @@ class BrokerBase {
         false};  //!< flag indicating that the broker has entered execution mode
     bool waitingForBrokerPingReply{false};  //!< flag indicating we are waiting for a ping reply
     bool hasFilters{false};  //!< flag indicating filters come through the broker
-    bool forwardTick{
-        false};  //!< indicator that ticks should be forwarded to the command processor regardless
+    uint8_t forwardTick{
+        0U};  //!< indicator that ticks should be forwarded to the command processor regardless
     bool no_ping{false};  //!< indicator that the broker is not very responsive to ping requests
     bool uuid_like{false};  //!< will be set to true if the name looks like a uuid
     decltype(std::chrono::steady_clock::now())

--- a/src/helics/core/BrokerBase.hpp
+++ b/src/helics/core/BrokerBase.hpp
@@ -108,12 +108,11 @@ class BrokerBase {
         errored = 7,  //!< an error was encountered
     };
 
-    enum class TickForwardingReasons:uint32_t
-    {
-        none=0,
-        no_comms=0x01,
+    enum class TickForwardingReasons : uint32_t {
+        none = 0,
+        no_comms = 0x01,
         ping_response = 0x02,
-        query_timeout=0x04
+        query_timeout = 0x04
     };
     bool noAutomaticID{false};  //!< the broker should not automatically generate an ID
     bool hasTimeDependency{false};  //!< set to true if the broker has Time dependencies

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2070,9 +2070,16 @@ void CommonCore::initializeMapBuilder(const std::string& request,
                 builder.generatePlaceHolder("federates", fed->global_id.load().baseValue());
             std::string ret = federateQuery(fed.fed, request, force_ordering);
             if (ret == "#wait") {
-                queryReq.messageID = brkindex;
-                queryReq.dest_id = fed.fed->global_id;
-                fed.fed->addAction(queryReq);
+                if (fed->getState() <= federate_state::HELICS_EXECUTING)
+                {
+                    queryReq.messageID = brkindex;
+                    queryReq.dest_id = fed.fed->global_id;
+                    fed.fed->addAction(queryReq);
+                }
+                else
+                {
+                    builder.addComponent("", brkindex);
+                }
             } else {
                 builder.addComponent(ret, brkindex);
             }
@@ -2427,7 +2434,7 @@ void CommonCore::processPriorityCommand(ActionMessage&& command)
                 if (delayInitCounter < 0 && minFederateCount == 0) {
                     if (allInitReady()) {
                         if (transitionBrokerState(broker_state_t::connected,
-                                                  broker_state_t::initializing)) {
+                                                                broker_state_t::initializing)) {
                             // make sure we only do this once
                             ActionMessage init(CMD_INIT);
                             checkDependencies();
@@ -2489,9 +2496,6 @@ void CommonCore::processPriorityCommand(ActionMessage&& command)
                 processCommand(std::move(command));
             }
         }
-
-            // case CMD_DISCONNECT_ACK:
-            //    break;
     }
 }
 
@@ -2587,6 +2591,7 @@ void CommonCore::processCommand(ActionMessage&& command)
                 timeoutMon->tick(this);
                 LOG_SUMMARY(global_broker_id_local, getIdentifier(), " core tick");
             }
+            checkQueryTimeouts();
             break;
         case CMD_PING:
         case CMD_BROKER_PING:  // broker ping for core is the same as core
@@ -2641,7 +2646,7 @@ void CommonCore::processCommand(ActionMessage&& command)
             if (isConnected()) {
                 if (getBrokerState() <
                     broker_state_t::terminating) {  // only send a disconnect message
-                                                    // if we haven't done so already
+                                                                  // if we haven't done so already
                     setBrokerState(broker_state_t::terminating);
                     sendDisconnect();
                     ActionMessage m(CMD_DISCONNECT);
@@ -2669,7 +2674,7 @@ void CommonCore::processCommand(ActionMessage&& command)
             if (isConnected()) {
                 if (getBrokerState() <
                     broker_state_t::terminating) {  // only send a disconnect message
-                                                    // if we haven't done so already
+                                                                  // if we haven't done so already
                     setBrokerState(broker_state_t::terminating);
                     sendDisconnect();
                     ActionMessage m(CMD_DISCONNECT);
@@ -2989,7 +2994,7 @@ void CommonCore::processCommand(ActionMessage&& command)
                     if (transitionBrokerState(
                             broker_state_t::connected,
                             broker_state_t::initializing)) {  // make sure we only do
-                        // this once
+                                                                   // this once
                         checkDependencies();
                         command.source_id = global_broker_id_local;
                         transmit(parent_route_id, command);
@@ -3416,6 +3421,23 @@ void CommonCore::removeTargetFromInterface(ActionMessage& command)
     }
 }
 
+void CommonCore::checkQueryTimeouts()
+{
+    if (!queryTimeouts.empty()) {
+        auto ctime = std::chrono::steady_clock::now();
+        for (auto &qt : queryTimeouts)
+        {
+            if (activeQueries.isRecognized(qt.first) && !activeQueries.isCompleted(qt.first))
+            {
+                if (Time(ctime - qt.second) > queryTimeout) {
+                    activeQueries.setDelayedValue(qt.first, "#timeout");
+                }
+            }
+            
+        }
+        }
+    }
+
 void CommonCore::processQueryResponse(const ActionMessage& m)
 {
     if (m.counter == general_query) {
@@ -3653,6 +3675,15 @@ void CommonCore::processQueryCommand(ActionMessage& cmd)
                         transmit(getRoute(queryResp.dest_id), queryResp);
                     }
                 } else {
+                    if (cmd.source_id == direct_core_id)
+                    {
+                        if (queryTimeouts.empty())
+                        {
+                            ++forwardTick;
+                        }
+                        queryTimeouts.emplace_back(cmd.messageID,std::chrono::steady_clock::now());
+                        
+                    }
                     ActionMessage queryResp(force_ordered ? CMD_QUERY_REPLY_ORDERED :
                                                             CMD_QUERY_REPLY);
                     queryResp.dest_id = cmd.source_id;
@@ -3863,6 +3894,7 @@ bool CommonCore::checkAndProcessDisconnect()
         return true;
     }
     if (allDisconnected()) {
+        checkInFlightQueriesForDisconnect();
         setBrokerState(broker_state_t::terminating);
         timeCoord->disconnect();
         ActionMessage dis(CMD_DISCONNECT);
@@ -3893,9 +3925,44 @@ int CommonCore::generateMapObjectCounter() const
     return result;
 }
 
+void CommonCore::checkInFlightQueriesForDisconnect()
+{
+    for (auto& mb : mapBuilders) {
+        auto& builder = std::get<0>(mb);
+        auto& requestors = std::get<1>(mb);
+        if (builder.isCompleted()) {
+            return;
+        }
+        if (builder.clearComponents()) {
+            auto str = builder.generate();
+            for (int ii = 0; ii < static_cast<int>(requestors.size()) - 1; ++ii) {
+                if (requestors[ii].dest_id == global_broker_id_local) {
+                    activeQueries.setDelayedValue(requestors[ii].messageID, str);
+                } else {
+                    requestors[ii].payload = str;
+                    routeMessage(std::move(requestors[ii]));
+                }
+            }
+            if (requestors.back().dest_id == global_broker_id_local) {
+                // TODO(PT) add rvalue reference method
+                activeQueries.setDelayedValue(requestors.back().messageID, str);
+            } else {
+                requestors.back().payload = std::move(str);
+                routeMessage(std::move(requestors.back()));
+            }
+
+            requestors.clear();
+            if (std::get<2>(mb)) {
+                builder.reset();
+            }
+        }
+    }
+}
+
 void CommonCore::sendDisconnect()
 {
     LOG_CONNECTIONS(global_broker_id_local, "core", "sending disconnect");
+    checkInFlightQueriesForDisconnect();
     ActionMessage bye(CMD_STOP);
     bye.source_id = global_broker_id_local;
     for (auto fed : loopFederates) {

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -2070,14 +2070,11 @@ void CommonCore::initializeMapBuilder(const std::string& request,
                 builder.generatePlaceHolder("federates", fed->global_id.load().baseValue());
             std::string ret = federateQuery(fed.fed, request, force_ordering);
             if (ret == "#wait") {
-                if (fed->getState() <= federate_state::HELICS_EXECUTING)
-                {
+                if (fed->getState() <= federate_state::HELICS_EXECUTING) {
                     queryReq.messageID = brkindex;
                     queryReq.dest_id = fed.fed->global_id;
                     fed.fed->addAction(queryReq);
-                }
-                else
-                {
+                } else {
                     builder.addComponent("", brkindex);
                 }
             } else {
@@ -2434,7 +2431,7 @@ void CommonCore::processPriorityCommand(ActionMessage&& command)
                 if (delayInitCounter < 0 && minFederateCount == 0) {
                     if (allInitReady()) {
                         if (transitionBrokerState(broker_state_t::connected,
-                                                                broker_state_t::initializing)) {
+                                                  broker_state_t::initializing)) {
                             // make sure we only do this once
                             ActionMessage init(CMD_INIT);
                             checkDependencies();
@@ -2587,18 +2584,17 @@ void CommonCore::processCommand(ActionMessage&& command)
         case CMD_IGNORE:
             break;
         case CMD_TICK:
-            if (isReasonForTick(command.messageID, TickForwardingReasons::ping_response)||isReasonForTick(command.messageID,TickForwardingReasons::no_comms))
-            {
+            if (isReasonForTick(command.messageID, TickForwardingReasons::ping_response) ||
+                isReasonForTick(command.messageID, TickForwardingReasons::no_comms)) {
                 if (getBrokerState() == broker_state_t::operating) {
                     timeoutMon->tick(this);
                     LOG_SUMMARY(global_broker_id_local, getIdentifier(), " core tick");
                 }
             }
-            if (isReasonForTick(command.messageID, TickForwardingReasons::query_timeout))
-            {
+            if (isReasonForTick(command.messageID, TickForwardingReasons::query_timeout)) {
                 checkQueryTimeouts();
             }
-            
+
             break;
         case CMD_PING:
         case CMD_BROKER_PING:  // broker ping for core is the same as core
@@ -2653,7 +2649,7 @@ void CommonCore::processCommand(ActionMessage&& command)
             if (isConnected()) {
                 if (getBrokerState() <
                     broker_state_t::terminating) {  // only send a disconnect message
-                                                                  // if we haven't done so already
+                                                    // if we haven't done so already
                     setBrokerState(broker_state_t::terminating);
                     sendDisconnect();
                     ActionMessage m(CMD_DISCONNECT);
@@ -2681,7 +2677,7 @@ void CommonCore::processCommand(ActionMessage&& command)
             if (isConnected()) {
                 if (getBrokerState() <
                     broker_state_t::terminating) {  // only send a disconnect message
-                                                                  // if we haven't done so already
+                                                    // if we haven't done so already
                     setBrokerState(broker_state_t::terminating);
                     sendDisconnect();
                     ActionMessage m(CMD_DISCONNECT);
@@ -2998,10 +2994,9 @@ void CommonCore::processCommand(ActionMessage&& command)
             if (fed != nullptr) {
                 fed->init_transmitted = true;
                 if (allInitReady()) {
-                    if (transitionBrokerState(
-                            broker_state_t::connected,
-                            broker_state_t::initializing)) {  // make sure we only do
-                                                                   // this once
+                    if (transitionBrokerState(broker_state_t::connected,
+                                              broker_state_t::initializing)) {  // make sure we only
+                                                                                // do this once
                         checkDependencies();
                         command.source_id = global_broker_id_local;
                         transmit(parent_route_id, command);
@@ -3432,22 +3427,18 @@ void CommonCore::checkQueryTimeouts()
 {
     if (!queryTimeouts.empty()) {
         auto ctime = std::chrono::steady_clock::now();
-        for (auto &qt : queryTimeouts)
-        {
-            if (activeQueries.isRecognized(qt.first) && !activeQueries.isCompleted(qt.first))
-            {
+        for (auto& qt : queryTimeouts) {
+            if (activeQueries.isRecognized(qt.first) && !activeQueries.isCompleted(qt.first)) {
                 if (Time(ctime - qt.second) > queryTimeout) {
                     activeQueries.setDelayedValue(qt.first, "#timeout");
                     qt.first = 0;
                 }
             }
         }
-        while (!queryTimeouts.empty()  && queryTimeouts.front().first == 0)
-        {
+        while (!queryTimeouts.empty() && queryTimeouts.front().first == 0) {
             queryTimeouts.pop_front();
         }
-        if (queryTimeouts.empty())
-        {
+        if (queryTimeouts.empty()) {
             setTickForwarding(TickForwardingReasons::query_timeout, false);
         }
     }
@@ -3690,14 +3681,11 @@ void CommonCore::processQueryCommand(ActionMessage& cmd)
                         transmit(getRoute(queryResp.dest_id), queryResp);
                     }
                 } else {
-                    if (cmd.source_id == direct_core_id)
-                    {
-                        if (queryTimeouts.empty())
-                        {
+                    if (cmd.source_id == direct_core_id) {
+                        if (queryTimeouts.empty()) {
                             setTickForwarding(TickForwardingReasons::query_timeout, true);
                         }
-                        queryTimeouts.emplace_back(cmd.messageID,std::chrono::steady_clock::now());
-                        
+                        queryTimeouts.emplace_back(cmd.messageID, std::chrono::steady_clock::now());
                     }
                     ActionMessage queryResp(force_ordered ? CMD_QUERY_REPLY_ORDERED :
                                                             CMD_QUERY_REPLY);

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -27,6 +27,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <deque>
 #include <map>
 #include <memory>
 #include <set>

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -26,6 +26,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "json/forwards.h"
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <set>
@@ -239,6 +240,10 @@ class CommonCore: public Core, public BrokerBase {
      * may need a helper class of some sort*/
     virtual void processDisconnect(bool skipUnregister = false) override final;
 
+    /** check to make sure there are no inflight queries that need to be resolved before
+     * disconnect*/
+    void checkInFlightQueriesForDisconnect();
+
     virtual void setInterfaceInfo(interface_handle handle, std::string info) override final;
     virtual const std::string& getInterfaceInfo(interface_handle handle) const override final;
 
@@ -341,7 +346,8 @@ class CommonCore: public Core, public BrokerBase {
     void checkDependencies();
     /** deal with a query response addressed to this core*/
     void processQueryResponse(const ActionMessage& m);
-
+    /** manage query timeouts*/
+    void checkQueryTimeouts();
     /** handle command with the core itself as a destination at the core*/
     void processCommandsForCore(const ActionMessage& cmd);
     /** process configure commands for the core*/
@@ -403,6 +409,8 @@ class CommonCore: public Core, public BrokerBase {
     std::atomic<int> queryCounter{1};
     /// holder for active queries
     gmlc::concurrency::DelayedObjects<std::string> activeQueries;
+    /// timeout manager for queries
+    std::deque<std::pair<int32_t, decltype(std::chrono::steady_clock::now())>> queryTimeouts;
     /// holder for the query map builder information
     mutable std::vector<std::tuple<JsonMapBuilder, std::vector<ActionMessage>, bool>> mapBuilders;
 

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -1246,8 +1246,7 @@ void CoreBroker::processBrokerConfigureCommands(ActionMessage& cmd)
             }
             break;
         case REQUEST_TICK_FORWARDING:
-            if (checkActionFlag(cmd, indicator_flag))
-            {
+            if (checkActionFlag(cmd, indicator_flag)) {
                 setTickForwarding(TickForwardingReasons::ping_response, true);
             }
             break;
@@ -2281,8 +2280,7 @@ void CoreBroker::processDisconnect(ActionMessage& command)
                     }
                 }
             } else if (command.dest_id == parent_broker_id) {
-                if (!isRootc)
-                {
+                if (!isRootc) {
                     if (command.source_id == higher_broker_id) {
                         LOG_CONNECTIONS(parent_broker_id,
                                         getIdentifier(),

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -1245,7 +1245,10 @@ void CoreBroker::processBrokerConfigureCommands(ActionMessage& cmd)
             }
             break;
         case REQUEST_TICK_FORWARDING:
-            forwardTick = checkActionFlag(cmd, indicator_flag);
+            if (checkActionFlag(cmd, indicator_flag))
+            {
+                ++forwardTick;
+            }
         default:
             break;
     }
@@ -2276,12 +2279,12 @@ void CoreBroker::processDisconnect(ActionMessage& command)
                     }
                 }
             } else if (command.dest_id == parent_broker_id) {
-                if (!isRootc)  // we got a disconnect from up above
+                if (!isRootc)
                 {
-                    LOG_CONNECTIONS(parent_broker_id,
-                                    getIdentifier(),
-                                    "got disconnect from parent");
                     if (command.source_id == higher_broker_id) {
+                        LOG_CONNECTIONS(parent_broker_id,
+                                        getIdentifier(),
+                                        "got disconnect from parent");
                         sendDisconnect();
                         addActionMessage(CMD_STOP);
                         return;

--- a/src/helics/core/CoreBroker.hpp
+++ b/src/helics/core/CoreBroker.hpp
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <array>
 #include <atomic>
+#include <deque>
 #include <functional>
 #include <map>
 #include <memory>
@@ -122,6 +123,8 @@ class CoreBroker: public Broker, public BrokerBase {
     gmlc::concurrency::DelayedObjects<std::string> activeQueries;  //!< holder for active queries
     /// holder for the query map builder information
     std::vector<std::tuple<JsonMapBuilder, std::vector<ActionMessage>, bool>> mapBuilders;
+    /// timeout manager for queries
+    std::deque<std::pair<int32_t, decltype(std::chrono::steady_clock::now())>> queryTimeouts;
 
     std::vector<ActionMessage> earlyMessages;  //!< list of messages that came before connection
     gmlc::concurrency::TriggerVariable disconnection;  //!< controller for the disconnection process
@@ -331,6 +334,8 @@ class CoreBroker: public Broker, public BrokerBase {
     /** answer a query or route the message the appropriate location*/
     void processQuery(ActionMessage& m);
 
+    /** manage query timeouts*/
+    void checkQueryTimeouts();
     /** answer a query or route the message the appropriate location*/
     void processQueryResponse(const ActionMessage& m);
     /** generate an answer to a local query*/

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -437,7 +437,7 @@ iteration_result FederateState::enterInitializingMode()
         return static_cast<iteration_result>(ret);
     }
 
-    std::lock_guard<FederateState> fedlock(*this);
+    sleeplock();
     iteration_result ret;
     switch (getState()) {
         case HELICS_ERROR:
@@ -446,13 +446,14 @@ iteration_result FederateState::enterInitializingMode()
         case HELICS_FINISHED:
             ret = iteration_result::halted;
             break;
-        case HELICS_CREATED: {
+        case HELICS_CREATED:
+            unlock();
             return enterInitializingMode();
-        }
         default:  // everything >= HELICS_INITIALIZING
             ret = iteration_result::next_step;
             break;
     }
+    unlock();
     return ret;
 }
 

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -241,9 +241,7 @@ class FederateState {
     /** tries to lock the processing return true if successful and false if not*/
     bool try_lock() const { return !processing.test_and_set(); }
     /** unlocks the processing*/
-    void unlock() const {
-        processing.clear();
-    }
+    void unlock() const { processing.clear(); }
     /** get the current logging level*/
     int loggingLevel() const { return logLevel; }
 

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -241,7 +241,9 @@ class FederateState {
     /** tries to lock the processing return true if successful and false if not*/
     bool try_lock() const { return !processing.test_and_set(); }
     /** unlocks the processing*/
-    void unlock() const { processing.clear(std::memory_order_release); }
+    void unlock() const {
+        processing.clear();
+    }
     /** get the current logging level*/
     int loggingLevel() const { return logLevel; }
 

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -976,3 +976,27 @@ TEST_F(query, queries_disconnected)
     EXPECT_EQ(res, "#disconnected");
     vFed1->finalize();
 }
+
+
+TEST_F(query, queries_disconnected_global)
+{
+    SetupTest<helics::ValueFederate>("test_2", 3);
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
+    auto vFed3 = GetFederateAs<helics::ValueFederate>(2);
+    vFed1->enterExecutingModeAsync();
+    vFed3->enterExecutingModeAsync();
+    vFed2->enterExecutingMode();
+    vFed1->enterExecutingModeComplete();
+    vFed3->enterExecutingModeComplete();
+
+    auto res = brokers[0]->query("root", "global_time");
+    vFed2->finalize();
+    vFed1->requestTime(3.0);
+    res = brokers[0]->query("root", "global_time");
+    vFed2->finalize();
+    res = brokers[0]->query("root", "global_time");
+    vFed3->finalize();
+    res = brokers[0]->query("root", "global_time");
+    
+}

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 
 #include "../application_api/testFixtures.hpp"
-#include "gmock/gmock.h"
 #include "helics/application_api/CombinationFederate.hpp"
 #include "helics/application_api/Filters.hpp"
 #include "helics/application_api/Publications.hpp"
@@ -15,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/common/JsonProcessingFunctions.hpp"
 #include "helics/core/helicsVersion.hpp"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <thread>
 
@@ -1021,7 +1021,6 @@ TEST_F(query, queries_timeout_ci_skip)
     vFed1->finalize();
     vFed2->finalize();
 }
-
 
 TEST_F(query, broker_queries_timeout_ci_skip)
 {


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will add timeouts for queries, In the rare case that a disconnect and query cross paths.  The query will timeout and result in a timeout result.  
The query timeout can be controlled via command line 

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
- add the command line option for query timeouts
- add timeout management code for local queries
- add tickforwarding controls in the broker base with reasons (and flexibility for adding more reasons in the future).  
- update the concurrency library with some new methods to the the delayedObject class.
- clean up the queries on disconnect from a core

### Notes
This is in response to some reported bugs about queries hanging