### PR TITLE
Update HELICS version to 2.7.1 in vcpkg file

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "helics",
-  "version-string": "2.7.0",
+  "version-string": "2.7.1",
   "description": "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)",
   "homepage": "https://helics.org/",
   "default-features": ["zeromq", "ipc", "webserver"],


### PR DESCRIPTION
### Summary

If merged this pull request will update the HELICS version in vcpkg.json to 2.7.1; probably should've been done for the tagged release, but I think the only effect of this is that the version number will be misreported by vcpkg.

### Proposed changes

- Update vcpkg.json to 2.7.1