### PR TITLE
Use calibreapp/image-actions@main for compressing images

### DIFF
--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@master
+        uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           # For PR builds from this repository, automatically add the compressed images; otherwise just compress images


### PR DESCRIPTION
### Summary

If merged this pull request will switch to using `calibreapp/image-actions@main` instead of `calibreapp/image-actions@master`

### Proposed changes

- Use calibreapp/image-actions@main for compressing images workflow