### PR TITLE
Use latest gcc and clang releases for CI builds

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -15,10 +15,10 @@ jobs:
         ubuntuDefault:
           containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
           test_config: 'ci'
-        gcc10:
+        gcc11:
           containerImage: 'helics/buildenv:gcc11-builder'
           test_config: 'ci'
-        clang10:
+        clang12:
           containerImage: 'helics/buildenv:clang12-builder'
           test_config: 'ci'
         clang5:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -16,10 +16,10 @@ jobs:
           containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
           test_config: 'ci'
         gcc10:
-          containerImage: 'helics/buildenv:gcc10-builder'
+          containerImage: 'helics/buildenv:gcc11-builder'
           test_config: 'ci'
         clang10:
-          containerImage: 'helics/buildenv:clang10-builder'
+          containerImage: 'helics/buildenv:clang12-builder'
           test_config: 'ci'
         clang5:
           containerImage: 'helics/buildenv:clang5-builder'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -33,7 +33,6 @@ jobs:
     steps:
       - bash: |
           source scripts/setup-helics-ci-options.sh
-          module load mpi || true
           mkdir -p build && cd build
           ../scripts/ci-build.sh
         env:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - bash: |
           source scripts/setup-helics-ci-options.sh
+          module load mpi || true
           mkdir -p build && cd build
           ../scripts/ci-build.sh
         env:

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -4,6 +4,10 @@ if [[ "$SET_MSYS_PATH" == "true" ]]; then
     echo "$PATH"
 fi
 
+# Setup MPI on Fedora build images
+source /etc/os-release
+if [[ "$ID" == "fedora" ]]; then module load mpi || true; fi
+
 # Flag variables are left unquoted for globbing and word splitting by bash (enable them to contain multiple arguments)
 echo "cmake -G \"${CMAKE_GENERATOR}\" ${JOB_OPTION_FLAGS} ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS} ${CMAKE_COMPILER_LAUNCHER} .."
 # shellcheck disable=SC2086

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -6,7 +6,11 @@ fi
 
 # Setup MPI on Fedora build images
 source /etc/os-release
-if [[ "$ID" == "fedora" ]]; then module load mpi || true; fi
+if command -v module &>/dev/null; then
+    if [[ "$ID" == "fedora" ]]; then
+        module load mpi || true
+    fi
+fi
 
 # Flag variables are left unquoted for globbing and word splitting by bash (enable them to contain multiple arguments)
 echo "cmake -G \"${CMAKE_GENERATOR}\" ${JOB_OPTION_FLAGS} ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS} ${CMAKE_COMPILER_LAUNCHER} .."


### PR DESCRIPTION
### Summary

<!-- please finish the following statement -->

If merged this pull request will bump the CI builds for the newest gcc and clang builds from gcc 10 to gcc 11, and clang 10 to clang 12. Addresses #1962 and #1963 

### Proposed changes

- Update the gcc-10 builder to gcc-11
- Update the clang-10 builder to clang-12