### PR TITLE
Add missing #include <thread> to tests

### DIFF
--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -16,9 +16,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "testFixtures.hpp"
 
 #include "gmock/gmock.h"
-#include <thread>
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 /** these test cases test out the value converters
  */
 

--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "testFixtures.hpp"
 
 #include "gmock/gmock.h"
+#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 /** these test cases test out the value converters

--- a/tests/helics/application_api/FilterAdditionalTests.cpp
+++ b/tests/helics/application_api/FilterAdditionalTests.cpp
@@ -11,10 +11,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/MessageOperators.hpp"
 #include "testFixtures.hpp"
 
-#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 #include <helics/core/Broker.hpp>
+#include <thread>
 /** these test cases test out the message federates
  */
 

--- a/tests/helics/application_api/FilterAdditionalTests.cpp
+++ b/tests/helics/application_api/FilterAdditionalTests.cpp
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/MessageOperators.hpp"
 #include "testFixtures.hpp"
 
+#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 #include <helics/core/Broker.hpp>

--- a/tests/helics/application_api/FilterTests.cpp
+++ b/tests/helics/application_api/FilterTests.cpp
@@ -19,9 +19,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #else
 #    include "testFixtures_shared.hpp"
 #endif
-#include <thread>
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 /** these test cases test out the message federates
  */
 

--- a/tests/helics/application_api/FilterTests.cpp
+++ b/tests/helics/application_api/FilterTests.cpp
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #else
 #    include "testFixtures_shared.hpp"
 #endif
+#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 /** these test cases test out the message federates

--- a/tests/helics/application_api/LoggingTests.cpp
+++ b/tests/helics/application_api/LoggingTests.cpp
@@ -13,6 +13,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/helics_definitions.hpp"
 #include "helics/external/filesystem.hpp"
 
+#include <thread>
 #include <future>
 #include <gmlc/libguarded/guarded.hpp>
 #include <gtest/gtest.h>

--- a/tests/helics/application_api/LoggingTests.cpp
+++ b/tests/helics/application_api/LoggingTests.cpp
@@ -13,10 +13,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/helics_definitions.hpp"
 #include "helics/external/filesystem.hpp"
 
-#include <thread>
 #include <future>
 #include <gmlc/libguarded/guarded.hpp>
 #include <gtest/gtest.h>
+#include <thread>
 
 /** these test cases test out user-directed logging functionality
  */

--- a/tests/helics/application_api/ValueFederateKeyTests.cpp
+++ b/tests/helics/application_api/ValueFederateKeyTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/helics_definitions.hpp"
 #include "helics/helics_enums.h"
 
+#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 #ifndef HELICS_SHARED_LIBRARY

--- a/tests/helics/application_api/ValueFederateKeyTests.cpp
+++ b/tests/helics/application_api/ValueFederateKeyTests.cpp
@@ -14,9 +14,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/helics_definitions.hpp"
 #include "helics/helics_enums.h"
 
-#include <thread>
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 #ifndef HELICS_SHARED_LIBRARY
 #    include "testFixtures.hpp"
 #else

--- a/tests/helics/application_api/zmqSSTests.cpp
+++ b/tests/helics/application_api/zmqSSTests.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/Core.hpp"
 
 #include "gtest/gtest.h"
+#include <thread>
 #include <future>
 #include <iostream>
 

--- a/tests/helics/application_api/zmqSSTests.cpp
+++ b/tests/helics/application_api/zmqSSTests.cpp
@@ -12,9 +12,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/Core.hpp"
 
 #include "gtest/gtest.h"
-#include <thread>
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/apps/BrokerAppTests.cpp
+++ b/tests/helics/apps/BrokerAppTests.cpp
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(BrokerAppTests, constructor1)
 {

--- a/tests/helics/apps/BrokerServerTests.cpp
+++ b/tests/helics/apps/BrokerServerTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 #include <cstdio>
+#include <thread>
 
 using namespace helics;
 

--- a/tests/helics/apps/CloneTests.cpp
+++ b/tests/helics/apps/CloneTests.cpp
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(clone_tests, simple_clone_test_pub)
 {

--- a/tests/helics/apps/CoreAppTests.cpp
+++ b/tests/helics/apps/CoreAppTests.cpp
@@ -26,6 +26,7 @@ using ::testing::HasSubstr;
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(CoreAppTests, constructor1)
 {

--- a/tests/helics/apps/EchoTests.cpp
+++ b/tests/helics/apps/EchoTests.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <cstdio>
 #include <future>
+#include <thread>
 
 // this test will test basic echo functionality
 TEST(echo_tests, echo_test1)

--- a/tests/helics/apps/PlayerTests.cpp
+++ b/tests/helics/apps/PlayerTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/apps/Player.hpp"
 
 #include <future>
+#include <thread>
 
 TEST(player_tests, simple_player_test)
 {

--- a/tests/helics/apps/RecorderTests.cpp
+++ b/tests/helics/apps/RecorderTests.cpp
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(recorder_tests, simple_recorder_test)
 {

--- a/tests/helics/apps/TracerTests.cpp
+++ b/tests/helics/apps/TracerTests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <algorithm>
 #include <future>
+#include <thread>
 #include <iostream>
 
 using namespace std::literals::chrono_literals;

--- a/tests/helics/apps/TracerTests.cpp
+++ b/tests/helics/apps/TracerTests.cpp
@@ -18,8 +18,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <algorithm>
 #include <future>
-#include <thread>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/core/CoreFactory-tests.cpp
+++ b/tests/helics/core/CoreFactory-tests.cpp
@@ -12,6 +12,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 
+#include <thread>
+
 static const bool ld = helics::loadCores();
 
 #ifdef HELICS_ENABLE_ZMQ_CORE

--- a/tests/helics/core/CoreFactory-tests.cpp
+++ b/tests/helics/core/CoreFactory-tests.cpp
@@ -11,7 +11,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/loadCores.hpp"
 
 #include "gtest/gtest.h"
-
 #include <thread>
 
 static const bool ld = helics::loadCores();

--- a/tests/helics/core/MessageTimerTests.cpp
+++ b/tests/helics/core/MessageTimerTests.cpp
@@ -8,7 +8,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/MessageTimer.hpp"
 
 #include "gtest/gtest.h"
-
 #include <thread>
 using namespace helics;
 

--- a/tests/helics/core/MessageTimerTests.cpp
+++ b/tests/helics/core/MessageTimerTests.cpp
@@ -8,6 +8,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/MessageTimer.hpp"
 
 #include "gtest/gtest.h"
+
+#include <thread>
 using namespace helics;
 
 using namespace std::literals::chrono_literals;

--- a/tests/helics/network/IPCcore_tests.cpp
+++ b/tests/helics/network/IPCcore_tests.cpp
@@ -17,9 +17,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/ipc/IpcQueueHelper.h"
 
 #include <boost/interprocess/ipc/message_queue.hpp>
-#include <thread>
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/IPCcore_tests.cpp
+++ b/tests/helics/network/IPCcore_tests.cpp
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/ipc/IpcQueueHelper.h"
 
 #include <boost/interprocess/ipc/message_queue.hpp>
+#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 

--- a/tests/helics/network/TcpCore-tests.cpp
+++ b/tests/helics/network/TcpCore-tests.cpp
@@ -18,9 +18,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/tcp/TcpHelperClasses.h"
 
 #include "gtest/gtest.h"
-#include <thread>
 #include <future>
 #include <numeric>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/TcpCore-tests.cpp
+++ b/tests/helics/network/TcpCore-tests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/tcp/TcpHelperClasses.h"
 
 #include "gtest/gtest.h"
+#include <thread>
 #include <future>
 #include <numeric>
 

--- a/tests/helics/network/TcpSSCore-tests.cpp
+++ b/tests/helics/network/TcpSSCore-tests.cpp
@@ -18,9 +18,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/tcp/TcpHelperClasses.h"
 
 #include "gtest/gtest.h"
-#include <thread>
 #include <future>
 #include <numeric>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/TcpSSCore-tests.cpp
+++ b/tests/helics/network/TcpSSCore-tests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/tcp/TcpHelperClasses.h"
 
 #include "gtest/gtest.h"
+#include <thread>
 #include <future>
 #include <numeric>
 

--- a/tests/helics/network/UdpCore-tests.cpp
+++ b/tests/helics/network/UdpCore-tests.cpp
@@ -17,8 +17,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 #include <asio/ip/udp.hpp>
-#include <thread>
 #include <future>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/UdpCore-tests.cpp
+++ b/tests/helics/network/UdpCore-tests.cpp
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 #include <asio/ip/udp.hpp>
+#include <thread>
 #include <future>
 
 using namespace std::literals::chrono_literals;

--- a/tests/helics/network/ZeromqCore-tests.cpp
+++ b/tests/helics/network/ZeromqCore-tests.cpp
@@ -19,9 +19,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/zmq/ZmqRequestSets.h"
 
 #include "gtest/gtest.h"
-#include <thread>
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/ZeromqCore-tests.cpp
+++ b/tests/helics/network/ZeromqCore-tests.cpp
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/zmq/ZmqRequestSets.h"
 
 #include "gtest/gtest.h"
+#include <thread>
 #include <future>
 #include <iostream>
 

--- a/tests/helics/network/ZeromqSSCore-tests.cpp
+++ b/tests/helics/network/ZeromqSSCore-tests.cpp
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/zmq/ZmqCore.h"
 
 #include "gtest/gtest.h"
+#include <thread>
 #include <future>
 #include <iostream>
 

--- a/tests/helics/network/ZeromqSSCore-tests.cpp
+++ b/tests/helics/network/ZeromqSSCore-tests.cpp
@@ -19,9 +19,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/zmq/ZmqCore.h"
 
 #include "gtest/gtest.h"
-#include <thread>
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -8,9 +8,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "ctestFixtures.hpp"
 #include "helics/helics.h"
 
-#include <thread>
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 /** these test cases test out the message federates
  */
 

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "ctestFixtures.hpp"
 #include "helics/helics.h"
 
+#include <thread>
 #include <future>
 #include <gtest/gtest.h>
 /** these test cases test out the message federates

--- a/tests/helics/system_tests/ErrorTests.cpp
+++ b/tests/helics/system_tests/ErrorTests.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <complex>
 #include <future>
+#include <thread>
 
 #define CORE_TYPE_TO_TEST helics::CoreType::TEST
 

--- a/tests/helics/system_tests/TimingTests2.cpp
+++ b/tests/helics/system_tests/TimingTests2.cpp
@@ -13,6 +13,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "../application_api/testFixtures.hpp"
 #include "helics/helics.hpp"
 
+#include <thread>
 #include <future>
 
 struct timing_tests2: public FederateTestFixture, public ::testing::Test {

--- a/tests/helics/system_tests/TimingTests2.cpp
+++ b/tests/helics/system_tests/TimingTests2.cpp
@@ -13,8 +13,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "../application_api/testFixtures.hpp"
 #include "helics/helics.hpp"
 
-#include <thread>
 #include <future>
+#include <thread>
 
 struct timing_tests2: public FederateTestFixture, public ::testing::Test {
 };

--- a/tests/helics/system_tests/brokerTimeoutTests.cpp
+++ b/tests/helics/system_tests/brokerTimeoutTests.cpp
@@ -17,8 +17,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/test/TestComms.h"
 #include "helics/network/test/TestCore.h"
 
-#include <thread>
 #include <future>
+#include <thread>
 
 #define CORE_TYPE_TO_TEST helics::CoreType::TEST
 

--- a/tests/helics/system_tests/brokerTimeoutTests.cpp
+++ b/tests/helics/system_tests/brokerTimeoutTests.cpp
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/test/TestComms.h"
 #include "helics/network/test/TestCore.h"
 
+#include <thread>
 #include <future>
 
 #define CORE_TYPE_TO_TEST helics::CoreType::TEST

--- a/tests/helics/system_tests/commandInterfaceTests.cpp
+++ b/tests/helics/system_tests/commandInterfaceTests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/ValueConverter.hpp"
 #include "helics/application_api/ValueFederate.hpp"
 
+#include <thread>
 #include <future>
 
 struct command_tests: public FederateTestFixture, public ::testing::Test {

--- a/tests/helics/system_tests/commandInterfaceTests.cpp
+++ b/tests/helics/system_tests/commandInterfaceTests.cpp
@@ -18,8 +18,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/ValueConverter.hpp"
 #include "helics/application_api/ValueFederate.hpp"
 
-#include <thread>
 #include <future>
+#include <thread>
 
 struct command_tests: public FederateTestFixture, public ::testing::Test {
 };

--- a/tests/helics/system_tests/federateRealTimeTests.cpp
+++ b/tests/helics/system_tests/federateRealTimeTests.cpp
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <chrono>
 #include <future>
+#include <thread>
 
 /** @file these test cases test out the real time mode for HELICS
  */

--- a/tests/helics/system_tests/iterationTests.cpp
+++ b/tests/helics/system_tests/iterationTests.cpp
@@ -18,8 +18,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/ValueConverter.hpp"
 #include "helics/application_api/ValueFederate.hpp"
 
-#include <thread>
 #include <future>
+#include <thread>
 
 struct iteration_tests: public FederateTestFixture, public ::testing::Test {
 };

--- a/tests/helics/system_tests/iterationTests.cpp
+++ b/tests/helics/system_tests/iterationTests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/ValueConverter.hpp"
 #include "helics/application_api/ValueFederate.hpp"
 
+#include <thread>
 #include <future>
 
 struct iteration_tests: public FederateTestFixture, public ::testing::Test {


### PR DESCRIPTION
### Summary

If merged this pull request will add missing `#include <thread>` to various tests to fix compile errors related to `sleep_for` with gcc 11

[Test run with successful compilation using the changes in this PR + the gcc 11 builder](https://dev.azure.com/HELICS-test/HELICS/_build/results?buildId=9443&view=logs&j=5d41f8ef-4f47-598d-e8d3-02d64667fe0e&t=9664420a-373e-55ce-5034-64407dcf183d)

### Proposed changes

- Add `#include <thread>` to tests using `sleep_for`
