### PR TITLE
Use latest gcc and clang releases for HELICS 2 CI builds

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -15,11 +15,11 @@ jobs:
         ubuntuDefault:
           containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
           test_config: 'ci'
-        gcc10:
-          containerImage: 'helics/buildenv:gcc10-builder'
+        gcc11:
+          containerImage: 'helics/buildenv:gcc11-builder'
           test_config: 'ci'
-        clang10:
-          containerImage: 'helics/buildenv:clang10-builder'
+        clang12:
+          containerImage: 'helics/buildenv:clang12-builder'
           test_config: 'ci'
         clang5:
           containerImage: 'helics/buildenv:clang5-builder'

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -4,6 +4,14 @@ if [[ "$SET_MSYS_PATH" == "true" ]]; then
     echo "$PATH"
 fi
 
+# Setup MPI on Fedora build images
+source /etc/os-release
+if command -v module &>/dev/null; then
+    if [[ "$ID" == "fedora" ]]; then
+        module load mpi || true
+    fi
+fi
+
 # Flag variables are left unquoted for globbing and word splitting by bash (enable them to contain multiple arguments)
 echo "cmake -G \"${CMAKE_GENERATOR}\" ${JOB_OPTION_FLAGS} ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS} ${CMAKE_COMPILER_LAUNCHER} .."
 # shellcheck disable=SC2086


### PR DESCRIPTION
### Summary

<!-- please finish the following statement -->

If merged this pull request will backport the CI build updates from HELICS3 and update CI builds to use gcc 11 and clang 12.

### Proposed changes

* Use latest gcc and clang releases for CI builds
- Update the gcc-10 builder to gcc-11
- Update the clang-10 builder to clang-12

* Update CI job names to match new compiler versions
* Load mpi module on Fedora builders
* Check if the module command exists before trying to run it
