### PR TITLE
Add missing #include <thread> to tests (backported)

### DIFF
--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gmock/gmock.h"
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 /** these test cases test out the value converters
  */
 

--- a/tests/helics/application_api/FilterAdditionalTests.cpp
+++ b/tests/helics/application_api/FilterAdditionalTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <future>
 #include <gtest/gtest.h>
 #include <helics/core/Broker.hpp>
+#include <thread>
 /** these test cases test out the message federates
  */
 

--- a/tests/helics/application_api/FilterTests.cpp
+++ b/tests/helics/application_api/FilterTests.cpp
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #endif
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 /** these test cases test out the message federates
  */
 

--- a/tests/helics/application_api/LoggingTests.cpp
+++ b/tests/helics/application_api/LoggingTests.cpp
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <future>
 #include <gmlc/libguarded/guarded.hpp>
 #include <gtest/gtest.h>
+#include <thread>
 
 /** these test cases test out user-directed logging functionality
  */

--- a/tests/helics/application_api/ValueFederateKeyTests.cpp
+++ b/tests/helics/application_api/ValueFederateKeyTests.cpp
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 #ifndef HELICS_SHARED_LIBRARY
 #    include "testFixtures.hpp"
 #else

--- a/tests/helics/application_api/zmqSSTests.cpp
+++ b/tests/helics/application_api/zmqSSTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/apps/BrokerAppTests.cpp
+++ b/tests/helics/apps/BrokerAppTests.cpp
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(BrokerAppTests, constructor1)
 {

--- a/tests/helics/apps/BrokerServerTests.cpp
+++ b/tests/helics/apps/BrokerServerTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "gtest/gtest.h"
 #include <cstdio>
+#include <thread>
 
 using namespace helics;
 

--- a/tests/helics/apps/CloneTests.cpp
+++ b/tests/helics/apps/CloneTests.cpp
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(clone_tests, simple_clone_test_pub)
 {

--- a/tests/helics/apps/CoreAppTests.cpp
+++ b/tests/helics/apps/CoreAppTests.cpp
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(CoreAppTests, constructor1)
 {

--- a/tests/helics/apps/EchoTests.cpp
+++ b/tests/helics/apps/EchoTests.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <cstdio>
 #include <future>
+#include <thread>
 
 // this test will test basic echo functionality
 TEST(echo_tests, echo_test1)

--- a/tests/helics/apps/PlayerTests.cpp
+++ b/tests/helics/apps/PlayerTests.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/apps/Player.hpp"
 
 #include <future>
+#include <thread>
 
 TEST(player_tests, simple_player_test)
 {

--- a/tests/helics/apps/RecorderTests.cpp
+++ b/tests/helics/apps/RecorderTests.cpp
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <cstdio>
 #include <future>
+#include <thread>
 
 TEST(recorder_tests, simple_recorder_test)
 {

--- a/tests/helics/apps/TracerTests.cpp
+++ b/tests/helics/apps/TracerTests.cpp
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <algorithm>
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/core/CoreFactory-tests.cpp
+++ b/tests/helics/core/CoreFactory-tests.cpp
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/loadCores.hpp"
 
 #include "gtest/gtest.h"
+#include <thread>
 
 static const bool ld = helics::loadCores();
 

--- a/tests/helics/core/MessageTimerTests.cpp
+++ b/tests/helics/core/MessageTimerTests.cpp
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/core/MessageTimer.hpp"
 
 #include "gtest/gtest.h"
+#include <thread>
 using namespace helics;
 
 using namespace std::literals::chrono_literals;

--- a/tests/helics/network/IPCcore_tests.cpp
+++ b/tests/helics/network/IPCcore_tests.cpp
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/TcpCore-tests.cpp
+++ b/tests/helics/network/TcpCore-tests.cpp
@@ -20,6 +20,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <future>
 #include <numeric>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/TcpSSCore-tests.cpp
+++ b/tests/helics/network/TcpSSCore-tests.cpp
@@ -20,6 +20,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <future>
 #include <numeric>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/UdpCore-tests.cpp
+++ b/tests/helics/network/UdpCore-tests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <asio/ip/udp.hpp>
 #include <future>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/ZeromqCore-tests.cpp
+++ b/tests/helics/network/ZeromqCore-tests.cpp
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/network/ZeromqSSCore-tests.cpp
+++ b/tests/helics/network/ZeromqSSCore-tests.cpp
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <future>
 #include <iostream>
+#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/helics/shared_library/FilterTests.cpp
+++ b/tests/helics/shared_library/FilterTests.cpp
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include <future>
 #include <gtest/gtest.h>
+#include <thread>
 /** these test cases test out the message federates
  */
 

--- a/tests/helics/system_tests/ErrorTests.cpp
+++ b/tests/helics/system_tests/ErrorTests.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <complex>
 #include <future>
+#include <thread>
 
 #define CORE_TYPE_TO_TEST helics::core_type::TEST
 

--- a/tests/helics/system_tests/TimingTests2.cpp
+++ b/tests/helics/system_tests/TimingTests2.cpp
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/helics.hpp"
 
 #include <future>
+#include <thread>
 
 struct timing_tests2: public FederateTestFixture, public ::testing::Test {
 };

--- a/tests/helics/system_tests/brokerTimeoutTests.cpp
+++ b/tests/helics/system_tests/brokerTimeoutTests.cpp
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/network/test/TestCore.h"
 
 #include <future>
+#include <thread>
 
 #define CORE_TYPE_TO_TEST helics::core_type::TEST
 

--- a/tests/helics/system_tests/federateRealTimeTests.cpp
+++ b/tests/helics/system_tests/federateRealTimeTests.cpp
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "gtest/gtest.h"
 #include <chrono>
 #include <future>
+#include <thread>
 
 /** @file these test cases test out the real time mode for HELICS
  */

--- a/tests/helics/system_tests/iterationTests.cpp
+++ b/tests/helics/system_tests/iterationTests.cpp
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "helics/application_api/ValueConverter.hpp"
 
 #include <future>
+#include <thread>
 
 struct iteration_tests: public FederateTestFixture, public ::testing::Test {
 };


### PR DESCRIPTION
### Summary

If merged this pull request will add `#include <thread>` to test files that use `sleep_for`.

### Proposed changes

- Add `#include <thread>` to test files that use `sleep_for`