### PR TITLE
Upgrade pre-commit hooks and skip clang-format on pre-commit.ci

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: pre-commit/action@v2.0.3
     - name: Create/update a file update PR with changed files
       if: failure() && github.event.pull_request.draft != true && github.event.pull_request.head.repo.full_name == github.repository
       uses: gmlc-tdc/create-pr-action@v0.2

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -24,8 +24,6 @@ jobs:
     - uses: actions/setup-python@v2
     - name: set PY
       run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - name: install shfmt
-      run: sudo snap install shfmt
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,10 +37,11 @@ repos:
       - id: markdownlint
         args: [-s, ./config/.markdownlintrc]
         exclude: "mac.md"
-      - id: shellcheck
-      - id: shfmt
-        args: [-w]
       - id: script-must-have-extension
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.2.1
+    hooks:
+      - id: shellcheck
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.10
     hooks:
@@ -58,6 +59,12 @@ repos:
           ]
   - repo: local
     hooks:
+      - id: shfmt
+        name: shfmt
+        language: golang
+        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.3.0]
+        entry: shfmt -w
+        types: [shell]
       - id: docker-clang-format
         name: Docker Clang Format
         language: docker_image

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 exclude: ^(ThirdParty/|interfaces/java/interface/|interfaces/matlab/interface/|interfaces/python/interface/|.github/workflows/)
+ci:
+  skip: [docker-clang-format]
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.1
@@ -6,16 +8,16 @@ repos:
       - id: dockerfile_lint
         args: [--rulefile, ./config/Docker/docker_rules.yml, --dockerfile]
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 21.7b0
     hooks:
       - id: black
         args: ["--line-length=100"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.7
+    rev: v1.1.10
     hooks:
       - id: remove-tabs
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: mixed-line-ending
@@ -43,12 +45,12 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.10
+    rev: v0.6.13
     hooks:
       - id: cmake-format
         exclude: "cmake+"
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.16.0
+    rev: v2.1.0
     hooks:
       - id: codespell
         args:


### PR DESCRIPTION
### Summary

If merged this pull request will update the formatting workflow to use pre-commit/action v2.0.3

### Proposed changes

- update the formatting workflow to use pre-commit/action v2.0.3
- update hooks to latest versions
- set ci skip so pre-commit.ci doesn't try to run clang-format (fails due to no docker)
