### PR TITLE
Remove README in-line html details tag to fix linting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,6 @@ Contributors are welcome see the [Contributing](CONTRIBUTING.md) guidelines for 
 
 ### Optional components
 
-<details>
-  <summary>Click to expand!</summary>
-
 A list of optional component that are not included in HELICS but are optionally used by the library
 
 #### [zmq](http://www.zeromq.org)
@@ -151,8 +148,6 @@ HELICS tests are written to use the Google Test and mock frameworks. Google Test
 ### [Google Benchmark](https://github.com/google/benchmark)
 
 Some timing benchmarks with HELICS are written to use the Google Benchmark library. Benchmarks is an optional component and is not included in the main source tarball and must be downloaded separately. Google Benchmark is released with an [Apache 2.0](https://github.com/google/benchmark/blob/v1.5.0/LICENSE) license.
-
-</details>
 
 ## Build Status
 


### PR DESCRIPTION
### Summary

If merged this pull request will remove the html details tags surrounding the optional 3rd party components in the README -- the markdownlint ruby gem doesn't handle the markdown links correctly when they are in that section.

There is a nodejs markdownlint tool that could be considered as an alternative, but the config file format might not be compatible with the current tool used.

### Proposed changes

- Remove html `<details>` tags surrounding the optional 3rd party components in the README
