### PR TITLE
Fix doxygen read the docs build

### DIFF
--- a/docs/references/api-reference/index.md
+++ b/docs/references/api-reference/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-## [C++ API (doxygen)](https://docs.helics.org/en/latest/doxygen/index.html)
+## [C++ API (doxygen)](../../doxygen/index.html)
 
 ## [C API](./C_API.md)
 

--- a/scripts/render-doxyfile.py
+++ b/scripts/render-doxyfile.py
@@ -28,7 +28,7 @@ def main():
 
     for l in doxyfile_template.splitlines():
         l = l.replace("@HELICS_VERSION@", helics_version)
-        l = l.replace("@CMAKE_CURRENT_SOURCE_DIR@", current_source_dir)
+        l = l.replace("@PROJECT_SOURCE_DIR@", current_source_dir)
         l = l.replace("@DOXYGEN_OUTPUT_DIR@", output_dir)
         doxyfile.append(l)
 


### PR DESCRIPTION
Replace PROJECT_SOURCE_DIR instead of CMAKE_CURRENT_SOURCE_DIR when creating the Doxyfile for RTD builds

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
