### PR TITLE
Use ASIO AsyncWriteStream and AsyncReadStream compatible functions for I/O and lowest layer socket for low level socket operations

### DIFF
--- a/src/helics/network/tcp/TcpHelperClasses.cpp
+++ b/src/helics/network/tcp/TcpHelperClasses.cpp
@@ -35,7 +35,7 @@ void TcpConnection::startReceive()
             receivingHalt.activate();
         }
         if (!triggerhalt) {
-            socket_.async_receive(asio::buffer(data.data() + residBufferSize,
+            socket_.async_read_some(asio::buffer(data.data() + residBufferSize,
                                                data.size() - residBufferSize),
                                   [ptr = shared_from_this()](const std::error_code& err,
                                                              size_t bytes) {
@@ -43,7 +43,7 @@ void TcpConnection::startReceive()
                                   });
             if (triggerhalt) {
                 // cancel previous operation if triggerhalt is now active
-                socket_.cancel();
+                socket_.lowest_layer().cancel();
                 // receivingHalt.trigger();
             }
         } else {
@@ -149,7 +149,7 @@ void TcpConnection::handle_read(const std::error_code& error, size_t bytes_trans
 }
 
 // asio::socket_base::linger optionLinger(true, 2);
-// socket_.set_option(optionLinger, ec);
+// socket_.lowest_layer().set_option(optionLinger, ec);
 void TcpConnection::close()
 {
     closeNoWait();
@@ -174,8 +174,8 @@ void TcpConnection::closeNoWait()
     }
 
     std::error_code ec;
-    if (socket_.is_open()) {
-        socket_.shutdown(tcp::socket::shutdown_both, ec);
+    if (socket_.lowest_layer().is_open()) {
+        socket_.lowest_layer().shutdown(tcp::socket::shutdown_both, ec);
         if (ec) {
             if ((ec.value() != asio::error::not_connected) &&
                 (ec.value() != asio::error::connection_reset)) {
@@ -184,9 +184,9 @@ void TcpConnection::closeNoWait()
             }
             ec.clear();
         }
-        socket_.close(ec);
+        socket_.lowest_layer().close(ec);
     } else {
-        socket_.close(ec);
+        socket_.lowest_layer().close(ec);
     }
 }
 
@@ -200,7 +200,7 @@ void TcpConnection::waitOnClose()
 
         while (!receivingHalt.wait_for(std::chrono::milliseconds(200))) {
             std::cout << "wait timeout " << static_cast<int>(state.load()) << " "
-                      << socket_.is_open() << " " << receivingHalt.isTriggered() << std::endl;
+                      << socket_.lowest_layer().is_open() << " " << receivingHalt.isTriggered() << std::endl;
 
             std::cout << "wait info " << context_.stopped() << " " << connecting << std::endl;
         }
@@ -228,7 +228,7 @@ TcpConnection::TcpConnection(asio::io_context& io_context,
     tcp::resolver resolver(io_context);
     tcp::resolver::query query(tcp::v4(), connection, port);
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-    socket_.async_connect(*endpoint_iterator,
+    socket_.lowest_layer().async_connect(*endpoint_iterator,
                           [this](const std::error_code& error) { connect_handler(error); });
 }
 
@@ -236,7 +236,7 @@ void TcpConnection::connect_handler(const std::error_code& error)
 {
     if (!error) {
         connected.activate();
-        socket_.set_option(asio::ip::tcp::no_delay(true));
+        socket_.lowest_layer().set_option(asio::ip::tcp::no_delay(true));
     } else {
         std::cerr << "connection error " << error.message() << ": code =" << error.value() << '\n';
         connectionError = true;
@@ -260,7 +260,7 @@ size_t TcpConnection::send(const void* buffer, size_t dataLength)
     size_t p{0};
     int count{0};
     while (count++ < 5 &&
-           (sz = socket_.send(
+           (sz = socket_.write_some(
                 asio::buffer(reinterpret_cast<const char*>(buffer) + p, sent_size))) != sent_size) {
         sent_size -= sz;
         p += sz;
@@ -291,7 +291,7 @@ size_t TcpConnection::send(const std::string& dataString)
                     return 0;
                 }
             }
-            auto sz = socket_.send(asio::buffer(dataString));
+            auto sz = socket_.write_some(asio::buffer(dataString));
             assert(sz == dataString.size());
             return sz;
     */
@@ -299,7 +299,7 @@ size_t TcpConnection::send(const std::string& dataString)
 
 size_t TcpConnection::receive(void* buffer, size_t maxDataSize)
 {
-    return socket_.receive(asio::buffer(buffer, maxDataSize));
+    return socket_.read_some(asio::buffer(buffer, maxDataSize));
 }
 
 bool TcpConnection::waitUntilConnected(std::chrono::milliseconds timeOut)

--- a/src/helics/network/tcp/TcpHelperClasses.cpp
+++ b/src/helics/network/tcp/TcpHelperClasses.cpp
@@ -36,11 +36,11 @@ void TcpConnection::startReceive()
         }
         if (!triggerhalt) {
             socket_.async_read_some(asio::buffer(data.data() + residBufferSize,
-                                               data.size() - residBufferSize),
-                                  [ptr = shared_from_this()](const std::error_code& err,
-                                                             size_t bytes) {
-                                      ptr->handle_read(err, bytes);
-                                  });
+                                                 data.size() - residBufferSize),
+                                    [ptr = shared_from_this()](const std::error_code& err,
+                                                               size_t bytes) {
+                                        ptr->handle_read(err, bytes);
+                                    });
             if (triggerhalt) {
                 // cancel previous operation if triggerhalt is now active
                 socket_.lowest_layer().cancel();
@@ -200,7 +200,8 @@ void TcpConnection::waitOnClose()
 
         while (!receivingHalt.wait_for(std::chrono::milliseconds(200))) {
             std::cout << "wait timeout " << static_cast<int>(state.load()) << " "
-                      << socket_.lowest_layer().is_open() << " " << receivingHalt.isTriggered() << std::endl;
+                      << socket_.lowest_layer().is_open() << " " << receivingHalt.isTriggered()
+                      << std::endl;
 
             std::cout << "wait info " << context_.stopped() << " " << connecting << std::endl;
         }
@@ -228,8 +229,9 @@ TcpConnection::TcpConnection(asio::io_context& io_context,
     tcp::resolver resolver(io_context);
     tcp::resolver::query query(tcp::v4(), connection, port);
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-    socket_.lowest_layer().async_connect(*endpoint_iterator,
-                          [this](const std::error_code& error) { connect_handler(error); });
+    socket_.lowest_layer().async_connect(*endpoint_iterator, [this](const std::error_code& error) {
+        connect_handler(error);
+    });
 }
 
 void TcpConnection::connect_handler(const std::error_code& error)

--- a/src/helics/network/tcp/TcpHelperClasses.h
+++ b/src/helics/network/tcp/TcpHelperClasses.h
@@ -45,11 +45,11 @@ namespace tcp {
             return pointer(new TcpConnection(io_context, bufferSize));
         }
         /** get the underlying socket object*/
-        asio::ip::tcp::socket& socket() { return socket_; }
+        auto& socket() { return socket_.lowest_layer(); }
         /** start the receiving loop*/
         void startReceive();
         /** cancel ongoing socket operations*/
-        void cancel() { socket_.cancel(); }
+        void cancel() { socket_.lowest_layer().cancel(); }
         /** close the socket*/
         void close();
         /** perform the close actions but don't wait for them to be processed*/
@@ -90,7 +90,7 @@ namespace tcp {
         template<typename Process>
         void send_async(const void* buffer, size_t dataLength, Process callback)
         {
-            socket_.async_send(asio::buffer(buffer, dataLength), callback);
+		socket_.async_write_some(asio::buffer(buffer, dataLength), callback);
         }
         /**perform an asynchronous receive operation
     @param buffer the data to send
@@ -103,7 +103,7 @@ namespace tcp {
         template<typename Process>
         void async_receive(void* buffer, size_t dataLength, Process callback)
         {
-            socket_.async_receive(asio::buffer(buffer, dataLength), callback);
+            socket_.async_read_some(asio::buffer(buffer, dataLength), callback);
         }
 
         /**perform an asynchronous receive operation
@@ -115,7 +115,7 @@ namespace tcp {
                                               size_t dataLength,
                                               const std::error_code& error)> callback)
         {
-            socket_.async_receive(asio::buffer(data, data.size()),
+            socket_.async_read_some(asio::buffer(data, data.size()),
                                   [connection = shared_from_this(),
                                    callback = std::move(callback)](const std::error_code& error,
                                                                    size_t bytes_transferred) {

--- a/src/helics/network/tcp/TcpHelperClasses.h
+++ b/src/helics/network/tcp/TcpHelperClasses.h
@@ -90,7 +90,7 @@ namespace tcp {
         template<typename Process>
         void send_async(const void* buffer, size_t dataLength, Process callback)
         {
-		socket_.async_write_some(asio::buffer(buffer, dataLength), callback);
+            socket_.async_write_some(asio::buffer(buffer, dataLength), callback);
         }
         /**perform an asynchronous receive operation
     @param buffer the data to send
@@ -116,11 +116,11 @@ namespace tcp {
                                               const std::error_code& error)> callback)
         {
             socket_.async_read_some(asio::buffer(data, data.size()),
-                                  [connection = shared_from_this(),
-                                   callback = std::move(callback)](const std::error_code& error,
-                                                                   size_t bytes_transferred) {
-                                      connection->handle_read(bytes_transferred, error, callback);
-                                  });
+                                    [connection = shared_from_this(),
+                                     callback = std::move(callback)](const std::error_code& error,
+                                                                     size_t bytes_transferred) {
+                                        connection->handle_read(bytes_transferred, error, callback);
+                                    });
         }
         /** check if the socket has finished the connection process*/
         bool isConnected() const


### PR DESCRIPTION
### Summary

If merged this pull request will switch to use functions for reading and writing to sockets that are compatible with the AsyncReadStream and AsyncWriteStream interfaces, and ensure that low level socket operations are done on the underlying. This is a step towards making the tcp helper classes useable for encrypted communication.

### Proposed changes

- Use AsyncReadStream and AsyncWriteStream interface compatible I/O functions for sockets
- Ensure the asio basic_stream_socket is used for several lower level socket functions that might not be exported by various stream wrappers
