### PR TITLE
Remove fix for ASIO_ERROR_CATEGORY_NOEXCEPT definition bug affecting Boost 1.58

### DIFF
--- a/src/helics/common/AsioContextManager.h
+++ b/src/helics/common/AsioContextManager.h
@@ -27,16 +27,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <string>
 #include <utility>
 
-// The choice for noexcept isn't set correctly in asio::io_context (including asio.hpp instead
-// didn't help) With Boost 1.58 this resulted in a compile error, apparently from the BOOST_NOEXCEPT
-// define being empty
-#ifdef ASIO_ERROR_CATEGORY_NOEXCEPT
-#    undef ASIO_ERROR_CATEGORY_NOEXCEPT
-#endif
-
-#define ASIO_ERROR_CATEGORY_NOEXCEPT noexcept(true)
 #include <asio/io_context.hpp>
-#undef ASIO_ERROR_CATEGORY_NOEXCEPT
 
 /** class defining a (potential) singleton Asio io_context manager for all asio usage*/
 class AsioContextManager: public std::enable_shared_from_this<AsioContextManager> {

--- a/src/helics/common/AsioContextManager.h
+++ b/src/helics/common/AsioContextManager.h
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
+#include <asio/io_context.hpp>
 #include <atomic>
 #include <future>
 #include <map>
@@ -26,8 +27,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <mutex>
 #include <string>
 #include <utility>
-
-#include <asio/io_context.hpp>
 
 /** class defining a (potential) singleton Asio io_context manager for all asio usage*/
 class AsioContextManager: public std::enable_shared_from_this<AsioContextManager> {


### PR DESCRIPTION
### Summary

If merged this pull request will remove a fix for `ASIO_ERROR_CATEGORY_NOEXCEPT` not getting set correctly due to Boost 1.58 not setting `BOOST_NOEXCEPT`. This change will be needed to use anything included from the asio ssl headers.

### Proposed changes

- Removed redefinition of `ASIO_ERROR_CATEGORY_NOEXCEPT` that was needed for Boost 1.58 compatibility
