### PR TITLE
Add in a check for requesting large times 

### DIFF
--- a/src/helics/common/AsioContextManager.h
+++ b/src/helics/common/AsioContextManager.h
@@ -19,6 +19,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
+#include <asio/io_context.hpp>
 #include <atomic>
 #include <future>
 #include <map>
@@ -26,17 +27,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <mutex>
 #include <string>
 #include <utility>
-
-// The choice for noexcept isn't set correctly in asio::io_context (including asio.hpp instead
-// didn't help) With Boost 1.58 this resulted in a compile error, apparently from the BOOST_NOEXCEPT
-// define being empty
-#ifdef ASIO_ERROR_CATEGORY_NOEXCEPT
-#    undef ASIO_ERROR_CATEGORY_NOEXCEPT
-#endif
-
-#define ASIO_ERROR_CATEGORY_NOEXCEPT noexcept(true)
-#include <asio/io_context.hpp>
-#undef ASIO_ERROR_CATEGORY_NOEXCEPT
 
 /** class defining a (potential) singleton Asio io_context manager for all asio usage*/
 class AsioContextManager: public std::enable_shared_from_this<AsioContextManager> {

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1786,7 +1786,7 @@ void FederateState::sendCommand(ActionMessage& command)
 std::pair<std::string, std::string> FederateState::getCommand()
 {
     auto val = commandQueue.try_pop();
-    if (val->first == "notify") {
+    while (val && val->first == "notify") {
         if (parent_ != nullptr) {
             parent_->sendCommand(val->second,
                                  "notify_response",

--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -19,6 +19,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <vector>
 
 namespace helics {
+
+    static const Time bigTime(HELICS_BIG_NUMBER);
+
 static auto nullMessageFunction = [](const ActionMessage& /*unused*/) {};
 TimeCoordinator::TimeCoordinator(): sendMessageFunction(nullMessageFunction) {}
 
@@ -446,6 +449,7 @@ bool TimeCoordinator::updateTimeFactors()
     upstream =
         generateMinTimeUpstream(dependencies, info.restrictive_time_policy, GlobalFederateId{});
 
+    maxTime = Time::maxVal() - info.outputDelay - (std::max)(info.period, info.timeDelta);
     bool update = false;
     time_minminDe = total.minDe;
     Time prev_next = time_next;
@@ -457,14 +461,14 @@ bool TimeCoordinator::updateTimeFactors()
     if (prev_next != time_next) {
         update = true;
     }
-    if (total.minDe < Time::maxVal()) {
+    if (total.minDe < maxTime) {
         total.minDe = generateAllowedTime(total.minDe) + info.outputDelay;
     }
-    if (upstream.minDe < Time::maxVal() && upstream.minDe > total.minDe) {
+    if (upstream.minDe < maxTime && upstream.minDe > total.minDe) {
         upstream.minDe = generateAllowedTime(upstream.minDe) + info.outputDelay;
     }
-    if (info.event_triggered) {
-        if (upstream.Te < Time::maxVal()) {
+    if (info.event_triggered||time_requested>=bigTime) {
+        if (upstream.Te < maxTime) {
             upstream.Te = generateAllowedTime(upstream.minDe);
         }
     }
@@ -472,7 +476,7 @@ bool TimeCoordinator::updateTimeFactors()
         update = true;
         time_minDe = total.minDe;
     }
-    time_allow = (total.next < Time::maxVal()) ? info.inputDelay + total.next : Time::maxVal();
+    time_allow = (total.next < maxTime) ? info.inputDelay + total.next : Time::maxVal();
 
     updateNextExecutionTime();
     return update;
@@ -585,12 +589,12 @@ void TimeCoordinator::sendTimeRequest() const
         setActionFlag(upd, delayed_timing_flag);
     }
     upd.Te = checkAdd(time_exec, info.outputDelay);
-    if (info.event_triggered) {
+    if (info.event_triggered||time_requested>=bigTime) {
         upd.Te = std::min(upd.Te, checkAdd(upstream.Te, info.outputDelay));
         upd.actionTime = std::min(upd.actionTime, upd.Te);
     }
     upd.Tdemin = std::min(checkAdd(upstream.Te, info.outputDelay), upd.Te);
-    if (info.event_triggered) {
+    if (info.event_triggered || time_requested>=bigTime) {
         upd.Tdemin = std::min(upd.Tdemin, checkAdd(upstream.minDe, info.outputDelay));
 
         if (upd.Tdemin < upd.actionTime) {
@@ -611,7 +615,7 @@ void TimeCoordinator::sendTimeRequest() const
         if (upstream.minFed.isValid()) {
             upd.dest_id = upstream.minFed;
             upd.setExtraData(GlobalFederateId{}.baseValue());
-            if (info.event_triggered) {
+            if (info.event_triggered || time_requested>=bigTime) {
                 upd.Te = checkAdd(time_exec, info.outputDelay);
                 upd.Te = std::min(upd.Te, checkAdd(upstream.TeAlt, info.outputDelay));
             }

--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -20,7 +20,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 namespace helics {
 
-    static const Time bigTime(HELICS_BIG_NUMBER);
+static const Time bigTime(HELICS_BIG_NUMBER);
 
 static auto nullMessageFunction = [](const ActionMessage& /*unused*/) {};
 TimeCoordinator::TimeCoordinator(): sendMessageFunction(nullMessageFunction) {}
@@ -467,7 +467,7 @@ bool TimeCoordinator::updateTimeFactors()
     if (upstream.minDe < maxTime && upstream.minDe > total.minDe) {
         upstream.minDe = generateAllowedTime(upstream.minDe) + info.outputDelay;
     }
-    if (info.event_triggered||time_requested>=bigTime) {
+    if (info.event_triggered || time_requested >= bigTime) {
         if (upstream.Te < maxTime) {
             upstream.Te = generateAllowedTime(upstream.minDe);
         }
@@ -589,12 +589,12 @@ void TimeCoordinator::sendTimeRequest() const
         setActionFlag(upd, delayed_timing_flag);
     }
     upd.Te = checkAdd(time_exec, info.outputDelay);
-    if (info.event_triggered||time_requested>=bigTime) {
+    if (info.event_triggered || time_requested >= bigTime) {
         upd.Te = std::min(upd.Te, checkAdd(upstream.Te, info.outputDelay));
         upd.actionTime = std::min(upd.actionTime, upd.Te);
     }
     upd.Tdemin = std::min(checkAdd(upstream.Te, info.outputDelay), upd.Te);
-    if (info.event_triggered || time_requested>=bigTime) {
+    if (info.event_triggered || time_requested >= bigTime) {
         upd.Tdemin = std::min(upd.Tdemin, checkAdd(upstream.minDe, info.outputDelay));
 
         if (upd.Tdemin < upd.actionTime) {
@@ -615,7 +615,7 @@ void TimeCoordinator::sendTimeRequest() const
         if (upstream.minFed.isValid()) {
             upd.dest_id = upstream.minFed;
             upd.setExtraData(GlobalFederateId{}.baseValue());
-            if (info.event_triggered || time_requested>=bigTime) {
+            if (info.event_triggered || time_requested >= bigTime) {
                 upd.Te = checkAdd(time_exec, info.outputDelay);
                 upd.Te = std::min(upd.Te, checkAdd(upstream.TeAlt, info.outputDelay));
             }

--- a/src/helics/core/TimeCoordinator.hpp
+++ b/src/helics/core/TimeCoordinator.hpp
@@ -72,6 +72,7 @@ class TimeCoordinator {
     time(usually time granted unless values are changing) */
     Time time_grantBase = Time::minVal();
     Time time_block = Time::maxVal();  //!< a blocking time to not grant time >= the specified time
+    Time maxTime = Time::maxVal();
     /// these are to maintain an accessible record of dependent federates
     shared_guarded_m<std::vector<GlobalFederateId>> dependent_federates;
     /// these are to maintain an accessible record of dependency federates

--- a/src/helics/helics_enums.h
+++ b/src/helics/helics_enums.h
@@ -363,6 +363,8 @@ typedef enum {
     HELICS_SEQUENCING_MODE_DEFAULT = 2
 } HelicsSequencingModes;
 
+const double HELICS_BIG_NUMBER = 9223372036.854774;
+
 #ifdef __cplusplus
 } /* end of extern "C" { */
 #endif

--- a/src/helics/shared_api_library/api-data.h
+++ b/src/helics/shared_api_library/api-data.h
@@ -93,7 +93,7 @@ const HelicsTime HELICS_TIME_ZERO = 0.0; /*!< definition of time zero-the beginn
 const HelicsTime HELICS_TIME_EPSILON = 1.0e-9; /*!< definition of the minimum time resolution */
 const HelicsTime HELICS_TIME_INVALID = -1.785e39; /*!< definition of an invalid time that has no meaning */
 const HelicsTime HELICS_TIME_MAXTIME = HELICS_BIG_NUMBER; /*!< definition of time signifying the federate has
-                                                             terminated or to run until the end of the simulation*/
+                                                             terminated or run until the end of the simulation*/
 
 /**
  * defining a boolean type for use in the helics interface

--- a/src/helics/shared_api_library/api-data.h
+++ b/src/helics/shared_api_library/api-data.h
@@ -92,7 +92,7 @@ typedef double HelicsTime;
 const HelicsTime HELICS_TIME_ZERO = 0.0; /*!< definition of time zero-the beginning of simulation */
 const HelicsTime HELICS_TIME_EPSILON = 1.0e-9; /*!< definition of the minimum time resolution */
 const HelicsTime HELICS_TIME_INVALID = -1.785e39; /*!< definition of an invalid time that has no meaning */
-const HelicsTime HELICS_TIME_MAXTIME = 9223372036.854774; /*!< definition of time signifying the federate has
+const HelicsTime HELICS_TIME_MAXTIME = HELICS_BIG_NUMBER; /*!< definition of time signifying the federate has
                                                              terminated or to run until the end of the simulation*/
 
 /**

--- a/tests/helics/system_tests/commandInterfaceTests.cpp
+++ b/tests/helics/system_tests/commandInterfaceTests.cpp
@@ -106,7 +106,7 @@ TEST_F(command_tests, core_federate_command)
     vFed2->enterExecutingMode();
     vFed1->enterExecutingModeComplete();
 
-    auto cmd2 = vFed2->getCommand();
+    auto cmd2 = vFed2->waitCommand();
     EXPECT_EQ(cmd2.first, "test");
     cmd2 = vFed2->getCommand();
     EXPECT_TRUE(cmd2.first.empty());


### PR DESCRIPTION
which triggers like the event_driven flag, and a fix for a command call if none exists.

tweaking the timing a little on cases with requests for infinite time, see if that fixes any of the sporadic failures