### PR TITLE
Updated vmImage and xcode_path in azure-pipelines.yml

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -57,8 +57,8 @@ jobs:
           vmImage: 'macOS-latest'
         XCode-oldest:
           test_config: 'ci'
-          vmImage: 'macOS-10.14'
-          xcode_path: '/Applications/Xcode_10.1.app'
+          vmImage: 'macOS-10.15'
+          xcode_path: '/Applications/Xcode_10.3.app'
     pool:
       vmImage: $[ variables['vmImage'] ]
     timeoutInMinutes: 90


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will update Azure Pipelines XCode-oldest job to use macOS 10.15

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->

In HELICS/.ci/azure-pipelines.yml

1. Changed vmImage to 'macOS-10.15'
2. Changed xcode_path to '/Applications/Xcode_10.3.app'
