### PR TITLE
Update vcpkg.json dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "helics",
-  "version-string": "3.0.0",
+  "version-string": "3.0.1",
   "description": "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)",
   "homepage": "https://helics.org/",
   "default-features": ["zeromq", "ipc", "webserver"],
-  "dependencies": ["boost-core"],
+  "dependencies": ["boost-core", "boost-spirit"],
   "features": {
     "zeromq": {
       "description": "Build ZeroMQ core",
@@ -25,7 +25,7 @@
     },
     "webserver": {
       "description": "Build webserver in broker_server",
-      "dependencies": ["boost-beast"]
+      "dependencies": ["boost-beast", "boost-uuid"]
     }
   }
 }


### PR DESCRIPTION
### Summary

If merged this pull request will update the dependencies when building using vcpkg to install dependencies. Works with Boost 1.77

### Proposed changes

- Bump the version to `3.0.1` to match the latest release -- need to remember to update this for the next release
- Add `boost-spirit` as a dependency to build HELICS
- Add `boost-uuid` as a dependency for building the webserver feature
