### PR TITLE
Switch docker clang-format hook to use pypi clang-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,4 @@
 exclude: ^(ThirdParty/|interfaces/java/interface/|interfaces/matlab/interface/|.github/workflows/)
-ci:
-  skip: [docker-clang-format]
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.1
@@ -61,6 +59,12 @@ repos:
             '--skip="*.csv"',
             "--ignore-words=./config/spelling_whitelist.txt",
           ]
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.0
+    hooks:
+      - id: clang-format
+        types:
+          - c++
   - repo: local
     hooks:
       - id: shfmt
@@ -69,12 +73,3 @@ repos:
         additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.3.0]
         entry: shfmt -w
         types: [shell]
-      - id: docker-clang-format
-        name: Docker Clang Format
-        language: docker_image
-        types:
-          - c++
-        entry: unibeautify/clang-format:latest
-        args:
-          - -style=file
-          - -i


### PR DESCRIPTION
### Summary

If merged this pull request will replace the docker based clang-format hook with one that uses PyPI. This should make installing pre-commit hooks locally a bit easier (no docker dependency), and makes so that this step can also be run by the `pre-commit.ci` service if we decide to switch.

### Proposed changes

- Replace the local docker clang-format hook with the `pre-commit/mirrors-clang-format` hook that uses the clang-format PyPI package
- Probably using a newer version of clang-format than was in the docker container
