### PR TITLE
Update CI build to clang13-builder

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -14,15 +14,19 @@ jobs:
         ubuntuDefault:
           containerImage: 'helics/buildenv:ubuntu18.04-default-builder'
           test_config: 'ci'
+          use_mpi: 'true'
         gcc11:
           containerImage: 'helics/buildenv:gcc11-builder'
           test_config: 'ci'
+          use_mpi: 'true'
         clang13:
           containerImage: 'helics/buildenv:clang13-builder'
           test_config: 'ci'
+          use_mpi: ''
         clang5:
           containerImage: 'helics/buildenv:clang5-builder'
           test_config: 'ci'
+          use_mpi: ''
 
     pool:
       vmImage: 'ubuntu-latest'
@@ -38,7 +42,7 @@ jobs:
           MAKEFLAGS: '-j 4'
           CMAKE_GENERATOR: 'Unix Makefiles'
           USE_SWIG: 'true'
-          USE_MPI: 'true'
+          USE_MPI: $[variables['use_mpi']]
           ZMQ_SUBPROJECT: $[variables['zmq_subproject']]
           ZMQ_FORCE_SUBPROJECT: $[variables['zmq_subproject']]
         displayName: 'Build HELICS'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -17,8 +17,8 @@ jobs:
         gcc11:
           containerImage: 'helics/buildenv:gcc11-builder'
           test_config: 'ci'
-        clang12:
-          containerImage: 'helics/buildenv:clang12-builder'
+        clang13:
+          containerImage: 'helics/buildenv:clang13-builder'
           test_config: 'ci'
         clang5:
           containerImage: 'helics/buildenv:clang5-builder'


### PR DESCRIPTION
### Summary

If merged this pull request will update the clang-12 build to clang-13.

Changes options to only enable MPI for the gcc builds -- the mpicc wrappers were ignoring CC/CXX set to clang and turning the clang builds into just another gcc build; the docs mention setting MPICH_CC, MPICH_CXX variables (and OMPI equivalents for OpenMPI), but notes that using a compiler different than the one used to build MPICH can cause problems.

### Proposed changes

- Update Azure Pipelines clang12 CI build to clang13
- Disable MPI for the clang builds