### PR TITLE
Undefine _LIBCPP_HAS_ALIGNED_ALLOC when using MSVCRT or MinGW

### DIFF
--- a/src/helics/apps/helicsWebServer.cpp
+++ b/src/helics/apps/helicsWebServer.cpp
@@ -35,7 +35,7 @@ SPDX-License-Identifier: BSD-3-Clause
 // but it isn't in environments that use MSVCRT/UCRT; we're undefine it so that
 // asio won't rely on the function
 #if defined(_LIBCPP_HAS_ALIGNED_ALLOC) && (defined(_LIBCPP_MSVCRT) || defined(__MINGW32__))
-#undef _LIBCPP_HAS_ALIGNED_ALLOC
+#    undef _LIBCPP_HAS_ALIGNED_ALLOC
 #endif
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/strand.hpp>


### PR DESCRIPTION
### Summary

If merged this pull request will undefine `_LIBCPP_HAS_ALIGNED_ALLOC` for the helicsWebServer app when using libc++ with MSVCRT or MinGW (uses MSVCRT/UCRT).

libc++ assumes that the underlying c library has an `aligned_alloc` function available, and always sets `_LIBCPP_HAS_ALIGNED_ALLOC` to true while depending on the compiler attribute `using_if_exists` to resolve the symbol later. Asio depends on this macro to determine if `std::aligned_alloc` is available, which causes unresolved symbol problems when the underlying C library is MSVCRT/UCRT because those will "never" support the `aligned_alloc` function.

Some info on MSVCRT/UCRT support for `aligned_alloc`:
https://osdn.net/projects/mingw/ticket/40315#comment:3917:40315:1587331334
https://github.com/microsoft/STL/blob/6aac0c9d38ca8feba1173674c3fd6b4435851738/tests/libcxx/expected_results.txt#L428

### Proposed changes

- Undefine `_LIBCPP_HAS_ALIGNED_ALLOC` if it is defined when using MSVCRT or MinGW
