### PR TITLE
Replace docker:git container for git submodule clone step on arm Drone CI builds

### DIFF
--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -12,9 +12,10 @@ steps:
       - uname -a
 
   - name: submodules
-    image: alpine/git:1.0.32
+    image: alpine:3.12
     commands:
       # for updating submodules to latest upstream, add --remote
+      - apk add --no-cache git
       - git submodule update --init --recursive
 
   - name: build

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
   - name: uname
-    image: alpine:3.12
+    image: alpine
     commands:
       - uname -a
 
@@ -18,7 +18,7 @@ steps:
       - git submodule update --init --recursive
 
   - name: build
-    image: alpine:3.12
+    image: alpine
     commands:
       - apk update
       - apk add --no-cache build-base git bash cmake ninja boost-dev zeromq-dev

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -12,7 +12,7 @@ steps:
       - uname -a
 
   - name: submodules
-    image: docker:git
+    image: alpine/git
     commands:
       # for updating submodules to latest upstream, add --remote
       - git submodule update --init --recursive
@@ -55,7 +55,7 @@ steps:
       - uname -a
 
   - name: submodules
-    image: docker:git
+    image: alpine/git
     commands:
       # for updating submodules to latest upstream, add --remote
       - git submodule update --init --recursive

--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -7,18 +7,18 @@ platform:
 
 steps:
   - name: uname
-    image: alpine
+    image: alpine:3.12
     commands:
       - uname -a
 
   - name: submodules
-    image: alpine/git
+    image: alpine/git:1.0.32
     commands:
       # for updating submodules to latest upstream, add --remote
       - git submodule update --init --recursive
 
   - name: build
-    image: alpine
+    image: alpine:3.12
     commands:
       - apk update
       - apk add --no-cache build-base git bash cmake ninja boost-dev zeromq-dev


### PR DESCRIPTION
### Summary

If merged this pull request will replace the docker:git container (often unavailable) used for the git submodule clone step on Drone CI with alpine/git for the aarch64 job, and alpine:3.12 with apk install for git on arm32 builds.

### Proposed changes

- Replace docker:git container with alpine/git container for aarch64 Drone CI build
- Replace docker:git container with alpine:3.12 and an apk install command for git on arm32 Drone CI build