### PR TITLE
Give an error for attempted Python interface builds

### DIFF
--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -7,6 +7,21 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+if(BUILD_PYTHON_INTERFACE OR BUILD_PYTHON2_INTERFACE OR HELICS_BUILD_PYTHON_INTERFACE OR HELICS_BUILD_PYTHON2_INTERFACE)
+    set(tmp_py_interface_option "")
+    if(BUILD_PYTHON_INTERFACE)
+        set(tmp_py_interface_option "BUILD_PYTHON_INTERFACE")
+    elseif(HELICS_BUILD_PYTHON_INTERFACE)
+        set(tmp_py_interface_option "HELICS_BUILD_PYTHON_INTERFACE")
+    elseif(BUILD_PYTHON2_INTERFACE)
+        set(tmp_py_interface_option "BUILD_PYTHON2_INTERFACE")
+    elseif(HELICS_BUILD_PYTHON2_INTERFACE)
+        set(tmp_py_interface_option "HELICS_BUILD_PYTHON2_INTERFACE")
+    endif()
+    message(FATAL_ERROR "The Python interface is no longer compiled as part of building HELICS. On most platforms, it is enough to install with `pip install helics`. For more complex needs such as using a custom build of the HELICS library with pyhelics, see the installation docs at https://python.helics.org/installation/ and the new repository at https://github.com/gmlc-tdc/pyhelics for details.
+Re-run cmake with the `-U${tmp_py_interface_option}` option to get rid of this error message.")
+endif()
+
 cmake_dependent_option(
     HELICS_BUILD_MATLAB_INTERFACE "Build Matlab Extension" OFF "NOT HELICS_DISABLE_C_SHARED_LIB"
     OFF

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -7,7 +7,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-if(BUILD_PYTHON_INTERFACE OR BUILD_PYTHON2_INTERFACE OR HELICS_BUILD_PYTHON_INTERFACE OR HELICS_BUILD_PYTHON2_INTERFACE)
+if(BUILD_PYTHON_INTERFACE
+   OR BUILD_PYTHON2_INTERFACE
+   OR HELICS_BUILD_PYTHON_INTERFACE
+   OR HELICS_BUILD_PYTHON2_INTERFACE
+)
     set(tmp_py_interface_option "")
     if(BUILD_PYTHON_INTERFACE)
         set(tmp_py_interface_option "BUILD_PYTHON_INTERFACE")
@@ -18,8 +22,11 @@ if(BUILD_PYTHON_INTERFACE OR BUILD_PYTHON2_INTERFACE OR HELICS_BUILD_PYTHON_INTE
     elseif(HELICS_BUILD_PYTHON2_INTERFACE)
         set(tmp_py_interface_option "HELICS_BUILD_PYTHON2_INTERFACE")
     endif()
-    message(FATAL_ERROR "The Python interface is no longer compiled as part of building HELICS. On most platforms, it is enough to install with `pip install helics`. For more complex needs such as using a custom build of the HELICS library with pyhelics, see the installation docs at https://python.helics.org/installation/ and the new repository at https://github.com/gmlc-tdc/pyhelics for details.
-Re-run cmake with the `-U${tmp_py_interface_option}` option to get rid of this error message.")
+    message(
+        FATAL_ERROR
+            "The Python interface is no longer compiled as part of building HELICS. On most platforms, it is enough to install with `pip install helics`. For more complex needs such as using a custom build of the HELICS library with pyhelics, see the installation docs at https://python.helics.org/installation/ and the new repository at https://github.com/gmlc-tdc/pyhelics for details.
+Re-run cmake with the `-U${tmp_py_interface_option}` option to get rid of this error message."
+    )
 endif()
 
 cmake_dependent_option(


### PR DESCRIPTION
### Summary

If merged this pull request will add an error message that can't be ignored for if a user tries to build the Python interface, pointing them to `pip install helics` and the pyhelics docs/repository, with instructions on how to unset the CMake variable to dismiss the error message.

The two old option were `BUILD_PYTHON_INTERFACE` and `BUILD_PYTHON2_INTERFACE`. To catch users that thought the option names may have been changed to match the other interfaces, checks for `HELICS_BUILD_PYTHON_INTERFACE` and `HELICS_BUILD_PYTHON2_INTERFACE`.

### Proposed changes

- Add error message notifying user about the new Python interface if cmake is configured with an argument for building the python interface