### PR TITLE
Backport Boost 1.77 fix to HELICS 2

### DIFF
--- a/config/cmake/addBoost.cmake
+++ b/config/cmake/addBoost.cmake
@@ -15,6 +15,8 @@ if(WIN32 AND NOT UNIX_LIKE)
 
     set(
         boost_versions
+        boost_1_77_0
+        boost_1_76_0
         boost_1_75_0
         boost_1_74_0
         boost_1_73_0

--- a/src/helics/network/ipc/IpcQueueHelper.cpp
+++ b/src/helics/network/ipc/IpcQueueHelper.cpp
@@ -7,11 +7,20 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 #include "IpcQueueHelper.h"
 
+#include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <string>
 #include <thread>
 
 namespace boostipc = boost::interprocess;
+
+using timetype = boost::posix_time::ptime;
+
+#if BOOST_VERSION >= 107700
+using clocktype = boost::interprocess::ipcdetail::microsec_clock<timetype>;
+#else
+using clocktype = boost::date_time::microsec_clock<timetype>;
+#endif
 
 namespace helics {
 namespace ipc {
@@ -114,8 +123,7 @@ namespace ipc {
         unsigned int priority{0};
         while (true) {
             if (timeout >= 0) {
-                boost::posix_time::ptime abs_time =
-                    boost::date_time::microsec_clock<boost::posix_time::ptime>::universal_time();
+                timetype abs_time = clocktype::universal_time();
                 abs_time += boost::posix_time::milliseconds(timeout);
                 bool res =
                     rqueue->timed_receive(buffer.data(), mxSize, rx_size, priority, abs_time);


### PR DESCRIPTION
### Summary

If merged this pull request will backport the Boost 1.77 fix to HELICS 2 for the IPC core.

### Proposed changes

* Fix building IPC core with Boost 1.77.0
* Use type aliases for posix_time and microsec_clock