### PR TITLE
Backport libcpp aligned alloc fix to HELICS 2

### DIFF
--- a/src/helics/application_api/BrokerApp.hpp
+++ b/src/helics/application_api/BrokerApp.hpp
@@ -131,7 +131,7 @@ class HELICS_CXX_EXPORT BrokerApp {
 #ifdef HELICS_CXX_STATIC_DEFINE
     /** overload the -> operator so all broker functions can be called if needed
      */
-    auto* operator-> () const { return broker.operator->(); }
+    auto* operator->() const { return broker.operator->(); }
 #else
     BrokerApp* operator->() { return this; }
     const BrokerApp* operator->() const { return this; }

--- a/src/helics/application_api/CoreApp.hpp
+++ b/src/helics/application_api/CoreApp.hpp
@@ -135,7 +135,7 @@ class HELICS_CXX_EXPORT CoreApp {
 #ifdef HELICS_CXX_STATIC_DEFINE
     /** overload the -> operator so core functions can be called if needed
      */
-    auto* operator-> () const { return core.operator->(); }
+    auto* operator->() const { return core.operator->(); }
 #else
     CoreApp* operator->() { return this; }
     const CoreApp* operator->() const { return this; }

--- a/src/helics/apps/helicsWebServer.cpp
+++ b/src/helics/apps/helicsWebServer.cpp
@@ -30,6 +30,13 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "indexPage.hpp"
 
 #include <algorithm>
+
+// libc++ assumes aligned_alloc is available in the underlying c library,
+// but it isn't in environments that use MSVCRT/UCRT; we're undefine it so that
+// asio won't rely on the function
+#if defined(_LIBCPP_HAS_ALIGNED_ALLOC) && (defined(_LIBCPP_MSVCRT) || defined(__MINGW32__))
+#    undef _LIBCPP_HAS_ALIGNED_ALLOC
+#endif
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/core.hpp>


### PR DESCRIPTION
### Summary

If merged this pull request will backport the LIBCPP aligned alloc fix to HELICS 2.

### Proposed changes

- Backport the libcpp aligned alloc fix to HELICS 2
