### PR TITLE
Remove helics::zmq target dependency when ZMQ core is disabled

### DIFF
--- a/src/helics/network/CMakeLists.txt
+++ b/src/helics/network/CMakeLists.txt
@@ -131,8 +131,12 @@ endif()
 add_library(helics_network STATIC ${NETWORK_SRC_FILES} ${NETWORK_INCLUDE_FILES})
 
 target_link_libraries(
-    helics_network PUBLIC HELICS::core PRIVATE fmt::fmt compile_flags_target helics::zmq
+    helics_network PUBLIC HELICS::core PRIVATE fmt::fmt compile_flags_target
 )
+
+if(HELICS_ENABLE_ZMQ_CORE)
+    target_link_libraries(helics_network PRIVATE helics::zmq)
+endif()
 
 if(TARGET Boost::boost AND NOT HELICS_DISABLE_BOOST)
     target_compile_definitions(helics_network PRIVATE BOOST_DATE_TIME_NO_LIB)

--- a/src/helics/network/CMakeLists.txt
+++ b/src/helics/network/CMakeLists.txt
@@ -130,9 +130,7 @@ endif()
 
 add_library(helics_network STATIC ${NETWORK_SRC_FILES} ${NETWORK_INCLUDE_FILES})
 
-target_link_libraries(
-    helics_network PUBLIC HELICS::core PRIVATE fmt::fmt compile_flags_target
-)
+target_link_libraries(helics_network PUBLIC HELICS::core PRIVATE fmt::fmt compile_flags_target)
 
 if(HELICS_ENABLE_ZMQ_CORE)
     target_link_libraries(helics_network PRIVATE helics::zmq)


### PR DESCRIPTION
### Summary

If merged this pull request will only link with the helics::zmq library when the ZeroMQ core is disabled -- even with an empty helics::zmq imported target, it can still factor into the CMake calculating targets that must be in an export set.

### Proposed changes

- Only link `helics` C shared library with helics::zmq when the ZeroMQ core is enabled
