### PR TITLE
Remove setting of FindThreads output result variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,12 +481,8 @@ endif(HELICS_ENABLE_MPI_CORE)
 # -------------------------------------------------------------
 # add threading support
 # -------------------------------------------------------------
-if(NOT WIN32)
+if(MSYS OR CYGWIN OR NOT WIN32)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
-elseif(MSYS OR CYGWIN)
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-else()
-    set(CMAKE_USE_WIN32_THREADS_INIT ON)
 endif()
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
### Summary

If merged this pull request will remove setting a FindThreads output result variable that signals WIN32 threads are being used, and combine all the non-Windows thread cases into a single check.

### Proposed changes

- Remove (redundant) setting the FindThreads.cmake output variable `CMAKE_USE_WIN32_THREADS_INIT`
- Combine the conditions for setting `THREADS_PREFER_PTHREAD_FLAG`