### PR TITLE
Targeted endpoint target specification

### DIFF
--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -1842,7 +1842,6 @@ void CommonCore::sendToAt(InterfaceHandle sourceHandle,
                           std::string_view destination,
                           Time sendTime)
 {
-    
     if (destination.empty()) {
         // sendToAt should be the equivalent of sendAt if there is an empty destination
         sendAt(sourceHandle, data, length, sendTime);
@@ -1862,11 +1861,11 @@ void CommonCore::sendToAt(InterfaceHandle sourceHandle,
         auto res = std::find_if(targets.begin(), targets.end(), [destination](const auto& val) {
             return (val.second == destination);
         });
-        if (res==targets.end()) {
+        if (res == targets.end()) {
             throw(InvalidParameter("targeted endpoint destination not in target list"));
         }
     }
-    
+
     ActionMessage m(CMD_SEND_MESSAGE);
 
     m.messageID = ++messageCounter;
@@ -2011,27 +2010,23 @@ void CommonCore::sendMessage(InterfaceHandle sourceHandle, std::unique_ptr<Messa
                 return;
             }
             generateMessages(m, targets);
-        }
-        else
-        {
+        } else {
             throw(InvalidParameter("no destination specified in message"));
         }
-    }
-    else {
+    } else {
         if (checkActionFlag(*hndl, targeted_flag)) {
             auto targets = fed->getMessageDestinations(sourceHandle);
             auto res = std::find_if(targets.begin(),
                                     targets.end(),
                                     [destination = m.getString(targetStringLoc)](const auto& val) {
-                return (val.second == destination);
-            });
+                                        return (val.second == destination);
+                                    });
             if (res == targets.end()) {
                 throw(InvalidParameter("targeted endpoint destination not in target list"));
             }
         }
         addActionMessage(std::move(m));
     }
-    
 }
 
 void CommonCore::deliverMessage(ActionMessage& message)

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -4194,7 +4194,7 @@ void CommonCore::processDisconnectCommand(ActionMessage& cmd)
                     ActionMessage m(CMD_DISCONNECT);
                     m.source_id = global_broker_id_local;
                     transmit(parent_route_id, m);
-                    for (auto& fed : loopFederates) {
+                    for (const auto& fed : loopFederates) {
                         m.dest_id = fed->global_id;
                         fed.fed->addAction(m);
                     }

--- a/src/helics/core/EndpointInfo.hpp
+++ b/src/helics/core/EndpointInfo.hpp
@@ -54,7 +54,7 @@ class EndpointInfo {
   public:
     bool hasFilter{false};  //!< indicator that the message has a filter
     bool required{false};
-    bool targettedEndpoint{false};  //!< indicator that the endpoint is a targeted endpoint only
+    bool targetedEndpoint{false};  //!< indicator that the endpoint is a targeted endpoint only
     /** get the next message up to the specified time*/
     std::unique_ptr<Message> getMessage(Time maxTime);
     /** get the number of messages in the queue up to the specified time*/

--- a/src/helics/core/flagOperations.hpp
+++ b/src/helics/core/flagOperations.hpp
@@ -52,7 +52,7 @@ constexpr uint16_t child_flag = extra_flag4;
 constexpr uint16_t non_counting_flag = empty_flag;
 
 /// overload of extra_flag2 indicating an endpoint is targeted
-constexpr uint16_t targetted_flag = extra_flag2;
+constexpr uint16_t targeted_flag = extra_flag2;
 
 constexpr uint16_t filter_processing_required_flag =
     extra_flag1;  // overload of extra_flag1 indicating that the message requires processing for

--- a/tests/helics/application_api/MessageFederateAdditionalTests.cpp
+++ b/tests/helics/application_api/MessageFederateAdditionalTests.cpp
@@ -906,7 +906,7 @@ TEST_F(mfed_tests, missing_endpoint)
 
 TEST_F(mfed_tests, targeted_endpoint_send_error1)
 {
-    SetupTest<helics::MessageFederate>("test", 2,1.0);
+    SetupTest<helics::MessageFederate>("test", 2, 1.0);
     auto mFed1 = GetFederateAs<helics::MessageFederate>(0);
     auto mFed2 = GetFederateAs<helics::MessageFederate>(1);
 
@@ -926,7 +926,7 @@ TEST_F(mfed_tests, targeted_endpoint_send_error1)
     mFed1->enterExecutingModeComplete();
 
     EXPECT_NO_THROW(ep1.sendTo(message1.c_str(), 26, "ep2"));
-    EXPECT_THROW(ep1.sendTo(message1.c_str(), 26, "ep3"),helics::InvalidParameter);
+    EXPECT_THROW(ep1.sendTo(message1.c_str(), 26, "ep3"), helics::InvalidParameter);
     mFed1->requestTimeAsync(1.0);
     mFed2->requestTimeAdvance(1.0);
     mFed1->requestTimeComplete();
@@ -944,7 +944,6 @@ TEST_F(mfed_tests, targeted_endpoint_send_error1)
     mFed1->finalize();
 }
 
-
 TEST_F(mfed_tests, targeted_endpoint_send_error2)
 {
     SetupTest<helics::MessageFederate>("test", 2, 1.0);
@@ -954,7 +953,7 @@ TEST_F(mfed_tests, targeted_endpoint_send_error2)
     auto& ep1 = mFed1->registerGlobalTargetedEndpoint("ep1");
 
     auto& ep2 = mFed2->registerGlobalTargetedEndpoint("ep2");
-    auto& ep3= mFed2->registerGlobalTargetedEndpoint("ep3");
+    auto& ep3 = mFed2->registerGlobalTargetedEndpoint("ep3");
     auto& ep4 = mFed2->registerGlobalTargetedEndpoint("ep4");
 
     ep1.addDestinationTarget("ep2");
@@ -966,8 +965,8 @@ TEST_F(mfed_tests, targeted_endpoint_send_error2)
     mFed2->enterExecutingMode();
     mFed1->enterExecutingModeComplete();
 
-    EXPECT_NO_THROW(ep1.sendToAt(message1.c_str(), 26, "ep2",0.0));
-    EXPECT_THROW(ep1.sendToAt(message1.c_str(), 26, "ep3",0.0), helics::InvalidParameter);
+    EXPECT_NO_THROW(ep1.sendToAt(message1.c_str(), 26, "ep2", 0.0));
+    EXPECT_THROW(ep1.sendToAt(message1.c_str(), 26, "ep3", 0.0), helics::InvalidParameter);
     mFed1->requestTimeAsync(1.0);
     mFed2->requestTimeAdvance(1.0);
     mFed1->requestTimeComplete();
@@ -985,7 +984,6 @@ TEST_F(mfed_tests, targeted_endpoint_send_error2)
     mFed1->finalize();
 }
 
-
 TEST_F(mfed_tests, targeted_endpoint_send_error3)
 {
     SetupTest<helics::MessageFederate>("test", 2, 1.0);
@@ -995,7 +993,7 @@ TEST_F(mfed_tests, targeted_endpoint_send_error3)
     auto& ep1 = mFed1->registerGlobalTargetedEndpoint("ep1");
 
     auto& ep2 = mFed2->registerGlobalTargetedEndpoint("ep2");
-    auto & ep3= mFed2->registerGlobalTargetedEndpoint("ep3");
+    auto& ep3 = mFed2->registerGlobalTargetedEndpoint("ep3");
     auto& ep4 = mFed2->registerGlobalTargetedEndpoint("ep4");
 
     ep1.addDestinationTarget("ep2");
@@ -1031,7 +1029,6 @@ TEST_F(mfed_tests, targeted_endpoint_send_error3)
     mFed2->finalize();
     mFed1->finalize();
 }
-
 
 TEST_F(mfed_tests, targeted_endpoint_send_all)
 {
@@ -1074,7 +1071,7 @@ TEST_F(mfed_tests, targeted_endpoint_send_all)
         EXPECT_EQ(m->time, helics::timeZero);
     }
 
-     auto m2 = ep4.getMessage();
+    auto m2 = ep4.getMessage();
     if (m2) {
         EXPECT_EQ(m2->data.size(), 26U);
         EXPECT_EQ(m2->time, helics::timeZero);

--- a/tests/helics/application_api/MessageFederateAdditionalTests.cpp
+++ b/tests/helics/application_api/MessageFederateAdditionalTests.cpp
@@ -903,3 +903,211 @@ TEST_F(mfed_tests, missing_endpoint)
     mm.unlock();
     mFed1->finalize();
 }
+
+TEST_F(mfed_tests, targeted_endpoint_send_error1)
+{
+    SetupTest<helics::MessageFederate>("test", 2,1.0);
+    auto mFed1 = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed2 = GetFederateAs<helics::MessageFederate>(1);
+
+    auto& ep1 = mFed1->registerGlobalTargetedEndpoint("ep1");
+
+    auto& ep2 = mFed2->registerGlobalTargetedEndpoint("ep2");
+    auto& ep3 = mFed2->registerGlobalTargetedEndpoint("ep3");
+    auto& ep4 = mFed2->registerGlobalTargetedEndpoint("ep4");
+
+    ep1.addDestinationTarget("ep2");
+    ep1.addDestinationTarget("ep4");
+    ep2.addDestinationTarget("ep1");
+
+    const std::string message1{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+    mFed1->enterExecutingModeAsync();
+    mFed2->enterExecutingMode();
+    mFed1->enterExecutingModeComplete();
+
+    EXPECT_NO_THROW(ep1.sendTo(message1.c_str(), 26, "ep2"));
+    EXPECT_THROW(ep1.sendTo(message1.c_str(), 26, "ep3"),helics::InvalidParameter);
+    mFed1->requestTimeAsync(1.0);
+    mFed2->requestTimeAdvance(1.0);
+    mFed1->requestTimeComplete();
+
+    EXPECT_TRUE(ep2.hasMessage());
+    EXPECT_FALSE(ep4.hasMessage());
+    EXPECT_FALSE(ep3.hasMessage());
+    auto m = ep2.getMessage();
+    if (m) {
+        EXPECT_EQ(m->data.size(), 26U);
+        EXPECT_EQ(m->time, helics::timeZero);
+    }
+
+    mFed2->finalize();
+    mFed1->finalize();
+}
+
+
+TEST_F(mfed_tests, targeted_endpoint_send_error2)
+{
+    SetupTest<helics::MessageFederate>("test", 2, 1.0);
+    auto mFed1 = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed2 = GetFederateAs<helics::MessageFederate>(1);
+
+    auto& ep1 = mFed1->registerGlobalTargetedEndpoint("ep1");
+
+    auto& ep2 = mFed2->registerGlobalTargetedEndpoint("ep2");
+    auto& ep3= mFed2->registerGlobalTargetedEndpoint("ep3");
+    auto& ep4 = mFed2->registerGlobalTargetedEndpoint("ep4");
+
+    ep1.addDestinationTarget("ep2");
+    ep1.addDestinationTarget("ep4");
+    ep2.addDestinationTarget("ep1");
+
+    const std::string message1{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+    mFed1->enterExecutingModeAsync();
+    mFed2->enterExecutingMode();
+    mFed1->enterExecutingModeComplete();
+
+    EXPECT_NO_THROW(ep1.sendToAt(message1.c_str(), 26, "ep2",0.0));
+    EXPECT_THROW(ep1.sendToAt(message1.c_str(), 26, "ep3",0.0), helics::InvalidParameter);
+    mFed1->requestTimeAsync(1.0);
+    mFed2->requestTimeAdvance(1.0);
+    mFed1->requestTimeComplete();
+
+    EXPECT_TRUE(ep2.hasMessage());
+    EXPECT_FALSE(ep4.hasMessage());
+    EXPECT_FALSE(ep3.hasMessage());
+    auto m = ep2.getMessage();
+    if (m) {
+        EXPECT_EQ(m->data.size(), 26U);
+        EXPECT_EQ(m->time, helics::timeZero);
+    }
+
+    mFed2->finalize();
+    mFed1->finalize();
+}
+
+
+TEST_F(mfed_tests, targeted_endpoint_send_error3)
+{
+    SetupTest<helics::MessageFederate>("test", 2, 1.0);
+    auto mFed1 = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed2 = GetFederateAs<helics::MessageFederate>(1);
+
+    auto& ep1 = mFed1->registerGlobalTargetedEndpoint("ep1");
+
+    auto& ep2 = mFed2->registerGlobalTargetedEndpoint("ep2");
+    auto & ep3= mFed2->registerGlobalTargetedEndpoint("ep3");
+    auto& ep4 = mFed2->registerGlobalTargetedEndpoint("ep4");
+
+    ep1.addDestinationTarget("ep2");
+    ep1.addDestinationTarget("ep4");
+    ep2.addDestinationTarget("ep1");
+
+    const std::string message1{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+    mFed1->enterExecutingModeAsync();
+    mFed2->enterExecutingMode();
+    mFed1->enterExecutingModeComplete();
+
+    helics::Message val;
+    val.dest = "ep2";
+    val.data = std::string_view(message1.c_str(), 26);
+    val.source = "ep1";
+
+    EXPECT_NO_THROW(ep1.send(val));
+    val.dest = "ep3";
+    EXPECT_THROW(ep1.send(val), helics::InvalidParameter);
+    mFed1->requestTimeAsync(1.0);
+    mFed2->requestTimeAdvance(1.0);
+    mFed1->requestTimeComplete();
+
+    EXPECT_TRUE(ep2.hasMessage());
+    EXPECT_FALSE(ep4.hasMessage());
+    EXPECT_FALSE(ep3.hasMessage());
+    auto m = ep2.getMessage();
+    if (m) {
+        EXPECT_EQ(m->data.size(), 26U);
+        EXPECT_EQ(m->time, helics::timeZero);
+    }
+
+    mFed2->finalize();
+    mFed1->finalize();
+}
+
+
+TEST_F(mfed_tests, targeted_endpoint_send_all)
+{
+    SetupTest<helics::MessageFederate>("test", 2, 1.0);
+    auto mFed1 = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed2 = GetFederateAs<helics::MessageFederate>(1);
+
+    auto& ep1 = mFed1->registerGlobalTargetedEndpoint("ep1");
+
+    auto& ep2 = mFed2->registerGlobalTargetedEndpoint("ep2");
+    auto& ep3 = mFed2->registerGlobalTargetedEndpoint("ep3");
+    auto& ep4 = mFed2->registerGlobalTargetedEndpoint("ep4");
+
+    ep1.addDestinationTarget("ep2");
+    ep1.addDestinationTarget("ep4");
+
+    const std::string message1{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+    mFed1->enterExecutingModeAsync();
+    mFed2->enterExecutingMode();
+    mFed1->enterExecutingModeComplete();
+
+    helics::Message val;
+    val.data = std::string_view(message1.c_str(), 26);
+    val.source = "ep1";
+
+    EXPECT_NO_THROW(ep1.send(val));
+
+    EXPECT_NO_THROW(ep1.sendToAt(message1.c_str(), 26, "", 0.0));
+    EXPECT_NO_THROW(ep1.sendTo(message1.c_str(), 26, ""));
+    mFed1->requestTimeAsync(1.0);
+    mFed2->requestTimeAdvance(1.0);
+    mFed1->requestTimeComplete();
+
+    EXPECT_TRUE(ep2.hasMessage());
+    EXPECT_TRUE(ep4.hasMessage());
+    EXPECT_FALSE(ep3.hasMessage());
+    auto m = ep2.getMessage();
+    if (m) {
+        EXPECT_EQ(m->data.size(), 26U);
+        EXPECT_EQ(m->time, helics::timeZero);
+    }
+
+     auto m2 = ep4.getMessage();
+    if (m2) {
+        EXPECT_EQ(m2->data.size(), 26U);
+        EXPECT_EQ(m2->time, helics::timeZero);
+    }
+
+    EXPECT_TRUE(ep2.hasMessage());
+    EXPECT_TRUE(ep4.hasMessage());
+    m = ep2.getMessage();
+    if (m) {
+        EXPECT_EQ(m->data.size(), 26U);
+        EXPECT_EQ(m->time, helics::timeZero);
+    }
+
+    m2 = ep4.getMessage();
+    if (m2) {
+        EXPECT_EQ(m2->data.size(), 26U);
+        EXPECT_EQ(m2->time, helics::timeZero);
+    }
+
+    EXPECT_TRUE(ep2.hasMessage());
+    EXPECT_TRUE(ep4.hasMessage());
+    m = ep2.getMessage();
+    if (m) {
+        EXPECT_EQ(m->data.size(), 26U);
+        EXPECT_EQ(m->time, helics::timeZero);
+    }
+
+    m2 = ep4.getMessage();
+    if (m2) {
+        EXPECT_EQ(m2->data.size(), 26U);
+        EXPECT_EQ(m2->time, helics::timeZero);
+    }
+
+    mFed2->finalize();
+    mFed1->finalize();
+}


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will tweak the operation of `sendTo` and `sendToAt` for targeted endpoints.  Basically setting and empty destination will result in equivalent behavior to `send` and `sendAt`.  And if a destination is specified it must be in the target list,  if not an exception is generated.  

This is a change from previous behavior where those function would just generate a blanket exception for  targetedEndpoints.  This allows specific messages to be sent to specific destinations within known targets.  


