### PR TITLE
Update Linux install and comboFed examples - hotfix main

### DIFF
--- a/docs/user-guide/installation/linux.md
+++ b/docs/user-guide/installation/linux.md
@@ -9,7 +9,7 @@
 - CMake 3.10 or newer (if using clang with libc++, use 3.18+)
 - git
 - Boost 1.67 or newer
-- ZeroMQ 4.2 or newer (if ZeroMQ support is needed)
+- ZeroMQ 4.2 or newer (generally recommended but technically not essential)
 - MPI-2 implementation (if MPI support is needed)
 
 ### Setup
@@ -21,8 +21,10 @@ To set up your environment:
 1. Install dependencies using apt-get.
 
    ```bash
-   sudo apt-get install libboost-dev
-   sudo apt-get install libzmq5-dev
+   $ sudo apt install libboost-dev
+   $ sudo apt install libzmq5-dev
+   $ sudo apt install git
+   $ sudo apt install cmake-curses-gui #includes ccmake gui
    ```
 
    As an alternative, you can use [vcpkg](https://github.com/microsoft/vcpkg#getting-started) -- it is slower
@@ -31,15 +33,20 @@ To set up your environment:
    `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake`, or by setting the environment
    variable `VCPKG_ROOT=[path to vcpkg]` prior to running `cmake`.
 
-2. Make sure _CMake_ and _git_ are available in the Command Prompt. If they aren't, add them to the system PATH variable.
+2. Make sure _CMake_ and _git_ are available in the Command Prompt. If they aren't, add them to the system PATH variable. This should be covered by installing them as above.
 
-Getting and building from source:
+	```bash
+	$ which git 
+	/usr/local/git
+	
+	$ which cmake
+	/usr/local/cmake
+	
+	$ which ccmake
+	/usr/local/ccmake
+	```
 
-1. Use `git clone` to to check out a copy of HELICS.
-
-2. Create a build folder. Run CMake and give it the path that HELICS was checked out into.
-
-3. Run "make".
+3. Checkout the source code and build from source:
 
 #### Notes for Ubuntu
 
@@ -51,8 +58,8 @@ mkdir build
 cd build
 cmake ../
 # the options can be modified by altering the CMakeCache.txt file or by using the ccmake command to edit them
-# the cmake-gui will also work to graphically edit the configuration options.
-cmake . # optional, to update install path or other configuration settings if modified.
+# the cmake GUI will also work to graphically edit the configuration options.
+ccmake . #optional, invokes the cmake GUI to edit options
 make
 make install
 ```

--- a/docs/user-guide/installation/linux.md
+++ b/docs/user-guide/installation/linux.md
@@ -82,7 +82,7 @@ To run a full co-simulation go to the "examples/comboFederate1" folder and run t
 
 ```text
 [2022-01-19 11:53:05.308] [console] [info] fed1 (0)::registering PUB fed1/pub
-[2022-01-19 11:53:05.308] [console] [info] fed1 (0)::registering Input 
+[2022-01-19 11:53:05.308] [console] [info] fed1 (0)::registering Input
 entering init State
 [2022-01-19 11:53:05.310] [console] [info] fed1 (131072)[t=-9223372036.854776]::Registration Complete
 [2022-01-19 11:53:05.311] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granting Initialization

--- a/docs/user-guide/installation/linux.md
+++ b/docs/user-guide/installation/linux.md
@@ -35,16 +35,16 @@ To set up your environment:
 
 2. Make sure _CMake_ and _git_ are available in the Command Prompt. If they aren't, add them to the system PATH variable. This should be covered by installing them as above.
 
-	```bash
-	$ which git 
-	/usr/local/git
-	
-	$ which cmake
-	/usr/local/cmake
-	
-	$ which ccmake
-	/usr/local/ccmake
-	```
+   ```bash
+   $ which git
+   /usr/local/git
+
+   $ which cmake
+   /usr/local/cmake
+
+   $ which ccmake
+   /usr/local/ccmake
+   ```
 
 3. Checkout the source code and build from source:
 

--- a/docs/user-guide/installation/linux.md
+++ b/docs/user-guide/installation/linux.md
@@ -78,6 +78,28 @@ $ helics_recorder --version
 3.x.x (20XX-XX-XX)
 ```
 
+To run a full co-simulation go to the "examples/comboFederate1" folder and run the "run2.sh". This will produce three output files: "broker.out", "fed1.out", and "fed2.out". The federate log files should show the exchange of information between federate 1 and 2 such as:
+
+```text
+[2022-01-17 14:50:32.990] [console] [info] fed1 (0)[t=-98763.2]::registering PUB fed1/pub
+[2022-01-17 14:50:32.990] [console] [info] fed1 (0)[t=-98763.2]::registering Input
+entering init State
+[2022-01-17 14:50:32.990] [console] [info] fed1 (131072)[t=-9223372036.854776]::Registration Complete
+[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granting Initialization
+[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granted Time=-9223372036.854776
+entered init State
+[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=-1000000]::Granting Execution
+[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=0]::Granted Time=0
+entered exec State
+message sent from fed1 to fed1/endpoint at time 1
+[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=1e-09]::Granted Time=1e-09
+processed time 1e-09
+received message from fed1/endpoint at 0 ::message sent from fed1 to fed1/endpoint at time 1
+received updated value of 1 at 1e-09s from fed1/pub
+message sent from fed1 to fed1/endpoint at time 2
+...
+```
+
 ## A few Specialized Platforms
 
 The HELICS build supports a few specialized platforms, more will be added as needed. Generally the build requirements are automatically detected but that is not always possible. So a system configuration can be specified in the HELICS_BUILD_CONFIGURATION variable of CMake.

--- a/docs/user-guide/installation/linux.md
+++ b/docs/user-guide/installation/linux.md
@@ -78,25 +78,31 @@ $ helics_recorder --version
 3.x.x (20XX-XX-XX)
 ```
 
-To run a full co-simulation go to the "examples/comboFederate1" folder and run the "run2.sh". This will produce three output files: "broker.out", "fed1.out", and "fed2.out". The federate log files should show the exchange of information between federate 1 and 2 such as:
+To run a full co-simulation go to the "examples/comboFederate1" folder and run the "run3.sh". This will produce four output files: "broker.out", "fed1.out", "fed2.out", and "fed3.out". Opening "fed1.out" should show it sending messages to fed2 and receiving messages from fed3.
 
 ```text
-[2022-01-17 14:50:32.990] [console] [info] fed1 (0)[t=-98763.2]::registering PUB fed1/pub
-[2022-01-17 14:50:32.990] [console] [info] fed1 (0)[t=-98763.2]::registering Input
+[2022-01-19 11:53:05.308] [console] [info] fed1 (0)::registering PUB fed1/pub
+[2022-01-19 11:53:05.308] [console] [info] fed1 (0)::registering Input 
 entering init State
-[2022-01-17 14:50:32.990] [console] [info] fed1 (131072)[t=-9223372036.854776]::Registration Complete
-[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granting Initialization
-[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granted Time=-9223372036.854776
+[2022-01-19 11:53:05.310] [console] [info] fed1 (131072)[t=-9223372036.854776]::Registration Complete
+[2022-01-19 11:53:05.311] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granting Initialization
+[2022-01-19 11:53:05.311] [console] [debug] fed1 (131072)[t=-9223372036.854776]::Granted Time=-9223372036.854776
 entered init State
-[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=-1000000]::Granting Execution
-[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=0]::Granted Time=0
+[2022-01-19 11:53:05.312] [console] [debug] fed1 (131072)[t=-1000000]::Granting Execution
+[2022-01-19 11:53:05.312] [console] [debug] fed1 (131072)[t=0]::Granted Time=0
 entered exec State
-message sent from fed1 to fed1/endpoint at time 1
-[2022-01-17 14:50:32.991] [console] [debug] fed1 (131072)[t=1e-09]::Granted Time=1e-09
+message sent from fed1 to fed2/endpoint at time 1
+[2022-01-19 11:53:05.313] [console] [debug] fed1 (131072)[t=1e-09]::Granted Time=1e-09
 processed time 1e-09
-received message from fed1/endpoint at 0 ::message sent from fed1 to fed1/endpoint at time 1
-received updated value of 1 at 1e-09s from fed1/pub
-message sent from fed1 to fed1/endpoint at time 2
+received message from fed3/endpoint at 0 ::message sent from fed3 to fed1/endpoint at time 1
+received updated value of 1 at 1e-09s from fed2/pub
+message sent from fed1 to fed2/endpoint at time 2
+[2022-01-19 11:53:05.315] [console] [debug] fed1 (131072)[t=2e-09]::Granted Time=2e-09
+processed time 2e-09
+received message from fed3/endpoint at 1e-09 ::message sent from fed3 to fed1/endpoint at time 2
+received updated value of 2 at 2e-09s from fed2/pub
+message sent from fed1 to fed2/endpoint at time 3
+
 ...
 ```
 

--- a/examples/comboFederates1/comboFed.cpp
+++ b/examples/comboFederates1/comboFed.cpp
@@ -38,6 +38,7 @@ int main(int argc, char* argv[])
         ->capture_default_str();
     app.add_option("--source,-s", myendpoint, "name of the source endpoint")->capture_default_str();
     app.add_option("--startbroker", brokerArgs, "start a broker with the specified arguments");
+    app.allow_extras();
 
     auto ret = app.helics_parse(argc, argv);
 

--- a/examples/comboFederates1/run.sh
+++ b/examples/comboFederates1/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Run this example from the examples/comboFederates1/ folder
 
-../../build/bin/comboFed --startbroker "-f1" --name=fed1 --target=fed1 > fed.out
+../../build/bin/comboFed --startbroker "-f1" --name=fed1 --target=fed1 >fed.out

--- a/examples/comboFederates1/run.sh
+++ b/examples/comboFederates1/run.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
+# Run this example from the examples/comboFederates1/ folder
 
-../../src/helics/core/helics_broker 2 --loglevel=4 >broker.out &
-./comboFed --name fed1 --target fed2 >fed1.out &
-./comboFed --name fed2 --target fed1 >fed2.out
+../../build/bin/comboFed --startbroker "-f1" --name=fed1 --target=fed1 > fed.out

--- a/examples/comboFederates1/run3.sh
+++ b/examples/comboFederates1/run3.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
+# Run this example from the examples/comboFederates1/ folder
 
-../../src/helics/core/helics_broker 3 --loglevel=4 >broker.out &
-./comboFed --name fed1 --target fed2 >fed1.out &
-./comboFed --name fed2 --target fed3 >fed2.out &
-./comboFed --name fed3 --target fed1 >fed3.out &
+helics_broker -f3 --loglevel=warning > broker.out &
+../../build/bin/comboFed --name=fed1 --target=fed2 >fed1.out &
+../../build/bin/comboFed --name=fed2 --target=fed3 >fed2.out &
+../../build/bin/comboFed --name=fed3 --target=fed1 >fed3.out &

--- a/examples/comboFederates1/run3.sh
+++ b/examples/comboFederates1/run3.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Run this example from the examples/comboFederates1/ folder
 
-helics_broker -f3 --loglevel=warning > broker.out &
+helics_broker -f3 --loglevel=warning >broker.out &
 ../../build/bin/comboFed --name=fed1 --target=fed2 >fed1.out &
 ../../build/bin/comboFed --name=fed2 --target=fed3 >fed2.out &
 ../../build/bin/comboFed --name=fed3 --target=fed1 >fed3.out &


### PR DESCRIPTION
### Summary

Small documentation changes to fix the instructions for installing under Ubuntu. Small changes to get the comboFederate example working to validate the installation. I've tested to confirm comboFed builds and runs properly with the new run shell scripts.

Fixes issue #2263.

A similar PR will be made provide these fixes to develop. This PR is being applied directly to main so that the public documentation will be fixed more quickly.
