### PR TITLE
Switch Code Coverage job to running nightly

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,10 +6,12 @@ on:
       testConfig:
         description: 'Test Config'
         default: 'Coverage'
+  schedule:
+    - cron: '15 09 * * *' # Run in the early hours of the morning (UTC)
   push:
-    branches: [ main, develop]
-  pull_request:
-    branches: [ main, develop]
+    branches: [ main ]
+#  pull_request:
+#    branches: [ main, develop ]
 
 jobs:
   build:
@@ -33,16 +35,23 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-      
+      if: github.event_name != 'schedule'
+
+    - name: Checkout develop branch
+      uses: actions/checkout@v2
+      with:
+        ref: develop
+      if: github.event_name == 'schedule'
+
     - name: Build HELICS
       run: |
         source scripts/setup-helics-ci-options.sh
         mkdir -p build && cd build
         ../scripts/ci-build.sh
-        
+
     - name: Setup coverage counters
       run: scripts/lcov-helper.sh setup-counters
-      
+
     - name: Run tests
       working-directory: build
       run: |
@@ -51,6 +60,6 @@ jobs:
         export CTEST_OPTIONS="--output-on-failure"
         echo "Running CI tests with flags ${CI_TEST_FLAGS}"
         ../scripts/run-ci-tests.sh ${CI_TEST_FLAGS}
-      
+
     - name: Gather and upload coverage results
       run: scripts/lcov-helper.sh gather-coverage-info --gcov ${GCOV_TOOL} --codecov

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,7 +8,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: '15 09 * * *' # Run at in the early hours of the morning (UTC)
+    - cron: '15 09 * * *' # Run in the early hours of the morning (UTC)
   release:
     types: published
 


### PR DESCRIPTION
### Summary

If merged this pull request will run the code coverage job nightly on the develop branch instead of on PRs to main/develop or pushes to develop. Some of the flaky tests that seem to happen more consistently with the code coverage builds need to get fixed before the job becomes useful again -- workflow dispatch trigger can be used to trigger it on individual branches to test if a change resolves some of the failing tests.

### Proposed changes

- Add nightly scheduled code coverage build for the develop branch
- Remove PR and push triggers for the develop branch code coverage builds
- Remove PR trigger for main branch code coverage builds
