### PR TITLE
Update HELICS options for network tests and helics_broker build location

### DIFF
--- a/src/helics/apps/CMakeLists.txt
+++ b/src/helics/apps/CMakeLists.txt
@@ -112,7 +112,7 @@ if(HELICS_BUILD_APP_LIBRARY)
         target_link_libraries(helics_broker PUBLIC HELICS::apps)
         target_link_libraries(helics_broker PRIVATE compile_flags_target)
         set_target_properties(helics_broker PROPERTIES FOLDER apps)
-        set(HELICS_BROKER_LOC ${CMAKE_CURRENT_BINARY_DIR}
+	set(HELICS_BROKER_LOC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             CACHE INTERNAL "build folder location of the broker"
         )
 
@@ -124,7 +124,7 @@ if(HELICS_BUILD_APP_LIBRARY)
         target_link_libraries(helics_broker_server PUBLIC HELICS::apps)
         target_link_libraries(helics_broker_server PRIVATE compile_flags_target)
         set_target_properties(helics_broker_server PROPERTIES FOLDER apps)
-        set(HELICS_BROKER_SERVER_LOC ${CMAKE_CURRENT_BINARY_DIR}
+	set(HELICS_BROKER_SERVER_LOC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             CACHE INTERNAL "build folder location of the broker server"
         )
         install(TARGETS helics_broker helics_broker_server ${HELICS_EXPORT_COMMAND}

--- a/src/helics/apps/CMakeLists.txt
+++ b/src/helics/apps/CMakeLists.txt
@@ -112,7 +112,7 @@ if(HELICS_BUILD_APP_LIBRARY)
         target_link_libraries(helics_broker PUBLIC HELICS::apps)
         target_link_libraries(helics_broker PRIVATE compile_flags_target)
         set_target_properties(helics_broker PROPERTIES FOLDER apps)
-	set(HELICS_BROKER_LOC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        set(HELICS_BROKER_LOC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             CACHE INTERNAL "build folder location of the broker"
         )
 
@@ -124,7 +124,7 @@ if(HELICS_BUILD_APP_LIBRARY)
         target_link_libraries(helics_broker_server PUBLIC HELICS::apps)
         target_link_libraries(helics_broker_server PRIVATE compile_flags_target)
         set_target_properties(helics_broker_server PROPERTIES FOLDER apps)
-	set(HELICS_BROKER_SERVER_LOC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        set(HELICS_BROKER_SERVER_LOC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             CACHE INTERNAL "build folder location of the broker server"
         )
         install(TARGETS helics_broker helics_broker_server ${HELICS_EXPORT_COMMAND}

--- a/tests/helics/application_api/CMakeLists.txt
+++ b/tests/helics/application_api/CMakeLists.txt
@@ -35,7 +35,7 @@ set(application_api_test_sources
     MultiInputTests.cpp
 )
 
-if(ENABLE_ZMQ_CORE)
+if(HEILCS_ENABLE_ZMQ_CORE)
     list(APPEND application-api-tests zmqSSTests.cpp)
 endif()
 

--- a/tests/helics/application_api/FederateTests.cpp
+++ b/tests/helics/application_api/FederateTests.cpp
@@ -235,12 +235,12 @@ TEST(federate_tests, timeout_abort_zmq)
 
 #endif
 
-#ifdef ENABLE_TCP_CORE
+#ifdef HELICS_ENABLE_TCP_CORE
 TEST(federate_tests, timeout_abort_tcp)
 {
     std::future<std::shared_ptr<helics::Federate>> fut;
     auto call = []() {
-        helics::FederateInfo fi(helics::core_type::TCP);
+        helics::FederateInfo fi(helics::CoreType::TCP);
         fi.coreInitString = "";
         auto fed = std::make_shared<helics::Federate>("test1", fi);
         return fed;
@@ -252,7 +252,7 @@ TEST(federate_tests, timeout_abort_tcp)
     while (helics::CoreFactory::getCoreCount() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    helics::CoreFactory::abortAllCores(helics_error_user_abort, "aborting55");
+    helics::CoreFactory::abortAllCores(HELICS_ERROR_USER_ABORT, "aborting55");
     try {
         cret.get();
         EXPECT_TRUE(false);
@@ -266,7 +266,7 @@ TEST(federate_tests, timeout_abort_tcpss)
 {
     std::future<std::shared_ptr<helics::Federate>> fut;
     auto call = []() {
-        helics::FederateInfo fi(helics::core_type::TCP_SS);
+        helics::FederateInfo fi(helics::CoreType::TCP_SS);
         fi.coreInitString = "";
         auto fed = std::make_shared<helics::Federate>("test1", fi);
         return fed;
@@ -278,7 +278,7 @@ TEST(federate_tests, timeout_abort_tcpss)
     while (helics::CoreFactory::getCoreCount() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    helics::CoreFactory::abortAllCores(helics_error_user_abort, "aborting55");
+    helics::CoreFactory::abortAllCores(HELICS_ERROR_USER_ABORT, "aborting55");
     try {
         cret.get();
         EXPECT_TRUE(false);
@@ -289,12 +289,12 @@ TEST(federate_tests, timeout_abort_tcpss)
 }
 #endif
 
-#ifdef ENABLE_UDP_CORE
+#ifdef HELICS_ENABLE_UDP_CORE
 TEST(federate_tests, timeout_abort_udp)
 {
     std::future<std::shared_ptr<helics::Federate>> fut;
     auto call = []() {
-        helics::FederateInfo fi(helics::core_type::UDP);
+        helics::FederateInfo fi(helics::CoreType::UDP);
         fi.coreInitString = "";
         auto fed = std::make_shared<helics::Federate>("test1", fi);
         return fed;
@@ -305,7 +305,7 @@ TEST(federate_tests, timeout_abort_udp)
     while (helics::CoreFactory::getCoreCount() == 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    helics::CoreFactory::abortAllCores(helics_error_user_abort, "aborting55");
+    helics::CoreFactory::abortAllCores(HELICS_ERROR_USER_ABORT, "aborting55");
     try {
         cret.get();
         EXPECT_TRUE(false);

--- a/tests/helics/application_api/zmqSSTests.cpp
+++ b/tests/helics/application_api/zmqSSTests.cpp
@@ -87,7 +87,7 @@ class FedTest {
 TEST(ZMQSSCore_tests, zmqSSMultiCoreInitialization_test)
 {
     int feds = 20;
-    auto broker = helics::BrokerFactory::create(helics::core_type::ZMQ_SS,
+    auto broker = helics::BrokerFactory::create(helics::CoreType::ZMQ_SS,
                                                 "ZMQ_SS_broker",
                                                 std::string("-f ") + std::to_string(feds));
     std::vector<std::shared_ptr<helics::Core>> cores(feds);
@@ -95,7 +95,7 @@ TEST(ZMQSSCore_tests, zmqSSMultiCoreInitialization_test)
     SCOPED_TRACE("created broker");
     for (int ii = 0; ii < feds; ++ii) {
         std::string configureString = "-f 1 --name=core" + std::to_string(ii);
-        cores[ii] = helics::CoreFactory::create(helics::core_type::ZMQ_SS, configureString);
+        cores[ii] = helics::CoreFactory::create(helics::CoreType::ZMQ_SS, configureString);
         cores[ii]->connect();
         int s_index = ii + 1;
         if (ii == feds - 1) {

--- a/tests/helics/apps/MultiBrokerTests.cpp
+++ b/tests/helics/apps/MultiBrokerTests.cpp
@@ -57,7 +57,7 @@ TEST(MultiBroker, connect1)
     helics::CoreFactory::terminateAllCores();
 }
 
-#if defined(ENABLE_ZMQ_CORE)
+#if defined(HELICS_ENABLE_ZMQ_CORE)
 TEST(MultiBroker, file2)
 {
     using helics::CoreType;
@@ -80,7 +80,7 @@ TEST(MultiBroker, file2)
     helics::cleanupHelicsLibrary();
 }
 
-#    if defined(ENABLE_TCP_CORE) && defined(ENABLE_IPC_CORE)
+#    if defined(HELICS_ENABLE_TCP_CORE) && defined(HELICS_ENABLE_IPC_CORE)
 TEST(MultiBroker, file3)
 {
     using helics::CoreType;
@@ -107,7 +107,7 @@ TEST(MultiBroker, file3)
 
 #    endif
 
-#    if defined(ENABLE_ZMQ_CORE) && defined(ENABLE_TCP_CORE)
+#    if defined(HELICS_ENABLE_ZMQ_CORE) && defined(HELICS_ENABLE_TCP_CORE)
 TEST(MultiBroker, file1)
 {
     using helics::CoreType;

--- a/tests/helics/network/InprocCore-Tests.cpp
+++ b/tests/helics/network/InprocCore-Tests.cpp
@@ -19,11 +19,11 @@ using namespace helics::CoreFactory;
 
 TEST(InprocCore_tests, initialization_test)
 {
-    auto broker = helics::BrokerFactory::create(helics::core_type::INPROC, std::string{});
+    auto broker = helics::BrokerFactory::create(helics::CoreType::INPROC, std::string{});
     ASSERT_TRUE(broker);
     EXPECT_TRUE(broker->isConnected());
     std::string configureString = std::string("-f 4") + " --broker=" + broker->getIdentifier();
-    auto core = create(helics::core_type::INPROC, configureString);
+    auto core = create(helics::CoreType::INPROC, configureString);
 
     auto Tcore = std::dynamic_pointer_cast<helics::inproc::InprocCore>(core);
 
@@ -44,11 +44,11 @@ TEST(InprocCore_tests, initialization_test)
 
 TEST(InprocCore_tests, initialization_test_with_test_broker)
 {
-    auto broker = helics::BrokerFactory::create(helics::core_type::TEST, std::string{});
+    auto broker = helics::BrokerFactory::create(helics::CoreType::TEST, std::string{});
     ASSERT_TRUE(broker);
     EXPECT_TRUE(broker->isConnected());
     std::string configureString = std::string("-f 4") + " --broker=" + broker->getIdentifier();
-    auto core = create(helics::core_type::INPROC, configureString);
+    auto core = create(helics::CoreType::INPROC, configureString);
 
     auto Tcore = std::dynamic_pointer_cast<helics::inproc::InprocCore>(core);
 
@@ -70,7 +70,7 @@ TEST(InprocCore_tests, initialization_test_with_test_broker)
 TEST(InprocCore_tests, pubsub_value_test)
 {
     const char* configureString = "-f 1 --autobroker";
-    auto core = create(helics::core_type::INPROC, configureString);
+    auto core = create(helics::CoreType::INPROC, configureString);
 
     ASSERT_TRUE(core != nullptr);
     EXPECT_TRUE(core->isConfigured());
@@ -141,7 +141,7 @@ TEST(InprocCore_tests, send_receive_test)
 {
     const char* initializationString =
         "--autobroker --broker=\"brk1\" --broker_init_string=\"--name=brk1\"";
-    auto core = create(helics::core_type::INPROC, initializationString);
+    auto core = create(helics::CoreType::INPROC, initializationString);
 
     ASSERT_TRUE(core != nullptr);
     EXPECT_TRUE(core->isConfigured());
@@ -206,7 +206,7 @@ TEST(InprocCore_tests, messagefilter_callback_test)
     };
 
     std::string configureString = "--autobroker";
-    auto core = create(helics::core_type::INPROC, configureString);
+    auto core = create(helics::CoreType::INPROC, configureString);
 
     ASSERT_TRUE(core != nullptr);
     EXPECT_TRUE(core->isConfigured());

--- a/tests/helics/system_tests/ErrorTests.cpp
+++ b/tests/helics/system_tests/ErrorTests.cpp
@@ -515,7 +515,7 @@ TEST_P(error_tests_type, test_duplicate_broker_name)
 
 INSTANTIATE_TEST_SUITE_P(error_tests, error_tests_type, ::testing::ValuesIn(CoreTypes_simple));
 
-#if defined(ENABLE_ZMQ_CORE) || defined(ENABLE_UDP_CORE)
+#if defined(HELICS_ENABLE_ZMQ_CORE) || defined(HELICS_ENABLE_UDP_CORE)
 
 constexpr const char* networkCores[] = {ZMQTEST UDPTEST};
 

--- a/tests/helics/system_tests/ErrorTests.cpp
+++ b/tests/helics/system_tests/ErrorTests.cpp
@@ -411,7 +411,7 @@ TEST_F(error_tests, missing_required_pub)
 
     fed1->registerGlobalPublication("t1", "");
     auto& i2 = fed2->registerSubscription("abcd", "");
-    i2.setOption(helics::defs::Options::CONNECTION_REQUIRED, true);
+    i2.setOption(helics::defs::Options::CONNECTION_REQUIRED);
 
     fed1->enterInitializingModeAsync();
     EXPECT_THROW(fed2->enterInitializingMode(), helics::ConnectionFailure);

--- a/tests/helics/system_tests/networkTests.cpp
+++ b/tests/helics/system_tests/networkTests.cpp
@@ -229,12 +229,12 @@ TEST_F(network_tests, test_otherport_broker_local_env)
 
 #endif
 
-#ifdef ENABLE_TCP_CORE
+#ifdef HELICS_ENABLE_TCP_CORE
 TEST_F(network_tests, test_core_type_env)
 {
     setEnvironmentVariable("HELICS_CORE_TYPE", "TCP");
     const std::string brokerArgs = "-f 2";
-    auto broker = helics::BrokerFactory::create(helics::core_type::TCP, brokerArgs);
+    auto broker = helics::BrokerFactory::create(helics::CoreType::TCP, brokerArgs);
     EXPECT_TRUE(broker->isConnected());
 
     helics::FederateInfo fi("--corename=c1bt");


### PR DESCRIPTION
### Summary

If merged this pull request will update a few more spots where the HELICS option names changed for enabling cores, that had resulted in tests being disabled. It will also update HELICS_BROKER_LOC to actually point to the build folder where the helics_broker binary is located.

### Proposed changes

- Update `HELICS_BROKER_LOC` and `HELICS_BROKER_SERVER_LOC` to point to `${CMAKE_RUNTIME_OUTPUT_DIRECTORY}` (runtime output build folder was changed to place all binaries in a top level build/bin folder instead of scattered around)
- Update several places where the old option to check if a core was enabled had still been used, re-enabling several tests
- Update `helics::core_type` to `helics::CoreType` in tests that are now re-enabled
- Update `helics_error_user_abort` to `HELICS_ERROR_USER_ABORT` in re-enabled tests
