### PR TITLE
Fix missing submodule source code in the HELICS release source archive

### DIFF
--- a/scripts/_git-all-archive.sh
+++ b/scripts/_git-all-archive.sh
@@ -57,7 +57,7 @@ if [[ -n "$tag" ]]; then
 fi
 
 # Get git submodule source code
-git submodule update --init
+git submodule update --init --recursive
 
 # Set the output name based on if a release name was provided
 OUTPUT_BASENAME="Helics-source"
@@ -73,7 +73,9 @@ echo "> appending submodule archives"
 # for each of git submodules append to the root archive
 # uses single quotes because it is the command run recursively by git submodule foreach and should not expand variables
 # shellcheck disable=SC2016
-git submodule foreach --recursive 'git archive --verbose --prefix=$path/ --format tar "$(git rev-parse --abbrev-ref HEAD)" --output $ROOT_ARCHIVE_DIR/repo-output-sub-$sha1.tar'
+git submodule foreach --recursive 'git archive --verbose --prefix=$displaypath/ --format tar "$(git rev-parse --abbrev-ref HEAD)" --output $ROOT_ARCHIVE_DIR/repo-output-sub-$(echo $displaypath | sed s,/,_,g)-$sha1.tar'
+
+#pushd ThirdParty/networking/ThirdParty/NetIF && git archive --verbose --prefix=ThirdParty/networking/ThirdParty/NetIF --format "tar" --output "${ROOT_ARCHIVE_DIR}/repo-output-sub-$sha1.tar" "$(git rev-parse --abbrev-ref HEAD)" && popd
 
 if (($(find repo-output-sub*.tar | wc -l) != 0)); then
     # combine all archives into one tar
@@ -99,7 +101,7 @@ rmdir_list=(
     'units/.circleci'
     'utilities/tests'
     'utilities/.ci'
-    'toml11/tests'
+    'toml/tests'
     'json_cpp/test'
     'json_cpp/.travis_scripts'
     'json_cpp/devtools'
@@ -116,6 +118,8 @@ rmdir_list=(
     'concurrency/docs'
     'concurrency/.ci'
     'concurrency/.circleci'
+    'networking/ThirdParty/concurrency'
+    'networking/ThirdParty/asio'
 )
 for i in "${rmdir_list[@]}"; do
     tar --delete -f "${OUTPUT_BASENAME}.tar" "ThirdParty/$i" || true

--- a/scripts/_git-all-archive.sh
+++ b/scripts/_git-all-archive.sh
@@ -118,6 +118,8 @@ rmdir_list=(
     'concurrency/docs'
     'concurrency/.ci'
     'concurrency/.circleci'
+    'networking/docs'
+    'networking/tests'
     'networking/ThirdParty/concurrency'
     'networking/ThirdParty/asio'
 )


### PR DESCRIPTION
### Summary

If merged this pull request will fix the script that generates the HELICS source archive that includes submodule code for the HELICS releases.

### Proposed changes

- recursive git submodule update to ensure submodules used by dependencies also get checkedout (e.g. NetIF in the `networking` submodule)
- use `$displaypath` instead of `$path` (or `$sm_path`, https://git-scm.com/docs/git-submodule/2.24.0 has more info on these variables) for the prefix, so the full relative path (from the HELICS repo root folder) to submodule folder is preserved (so that e.g. `ThirdParty/networking/ThirdParty/concurrency` is unpacked to `ThirdParty/networking/ThirdParty/concurrency` instead of `ThirdParty/concurrency`; or so `ThirdParty/networking/ThirdParty/NetIF` doesn't get unpacked to `ThirdParty/NetIF`)
- include `$displaypath` derived string in archived folder name for submodules, to avoid duplicates if both a direct HELICS submodule and a nested submodule are identical
- update name of `toml` submodule directory (toml11->toml) for slimming/cleanup step
- remove duplicate `asio` and `concurrency` submodules from the `networking` submodule; they aren't needed since the `networking` submodule is told to use the `asio` and `concurrency` modules that HELICS includes as immediate submodules
