### PR TITLE
Add ability to (re)build tags using updated workflow and actions/shell scripts

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,6 +1,7 @@
 name: Build release artifacts
 
 on:
+  # Picking a workflow branch that is a tag, in combination with using the commit field is likely to fail for magic git clone/checkout reasons
   workflow_dispatch:
     inputs:
       packages:
@@ -8,7 +9,7 @@ on:
         required: true
         default: 'everything'
       commit:
-        description: 'Commit-ish (tag, branchname, sha) to do the release build with (uses scripts from the same branch as the workflow)'
+        description: 'Commit-ish (tag, branchname, sha) for code to build (uses scripts from the same branch as the workflow)'
         default: ''
   schedule:
     - cron: '15 09 * * *' # Run in the early hours of the morning (UTC)
@@ -24,15 +25,28 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.packages, 'archive') || contains(github.event.inputs.packages, 'everything')))
     steps:
+    - name: Determine fetch depth
+      id: determine_fd
+      shell: bash
+      run: |
+        unset DEPTH
+        if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
+        echo "::set-output name=DEPTH::${DEPTH}"
+
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.commit }}
+        fetch-depth: ${{ steps.determine_fd.outputs.DEPTH }}
       if: github.event.action == 'published' || github.event_name == 'workflow_dispatch'
 
     - name: Checkout shell scripts for workflow
+      shell: bash
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
-      run: git checkout ${{ github.ref_name }} -- scripts/_git-all-archive.sh
+      run: |
+        git checkout ${{ github.event.inputs.commit }}
+        git checkout ${{ github.ref_name }} -- scripts/_git-all-archive.sh || exit $?
+        for i in $(git status --short | cut -f2 -d " "); do sha256sum $i; done
+        exit 0
 
     - name: Create archive
       if: github.event_name != 'workflow_dispatch'
@@ -74,10 +88,18 @@ jobs:
             cmake_gen: 'Visual Studio 17 2022'
             msvc_ver: 'msvc2022'
     steps:
+    - name: Determine fetch depth
+      id: determine_fd
+      shell: bash
+      run: |
+        unset DEPTH
+        if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
+        echo "::set-output name=DEPTH::${DEPTH}"
+
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.commit }}
+        fetch-depth: ${{ steps.determine_fd.outputs.DEPTH }}
       if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
@@ -87,8 +109,13 @@ jobs:
       if: github.event_name == 'schedule'
 
     - name: Checkout shell scripts for workflow
+      shell: bash
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
-      run: git checkout ${{ github.ref_name }} -- .github/actions/
+      run: |
+        git checkout ${{ github.event.inputs.commit }}
+        git checkout ${{ github.ref_name }} -- .github/actions/ || exit $?
+        for i in $(git status --short | cut -f2 -d " "); do sha256sum $i; done
+        exit 0
 
     # Compile HELICS and create the installer
     - name: Build installer
@@ -148,12 +175,20 @@ jobs:
             cpack_gen: TGZ
 
     steps:
+    - name: Determine fetch depth
+      id: determine_fd
+      shell: bash
+      run: |
+        unset DEPTH
+        if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
+        echo "::set-output name=DEPTH::${DEPTH}"
+
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.commit }}
+        fetch-depth: ${{ steps.determine_fd.outputs.DEPTH }}
       if: github.event_name != 'schedule'
-    
+
     - name: Checkout develop branch
       uses: actions/checkout@v3
       with:
@@ -161,8 +196,13 @@ jobs:
       if: github.event_name == 'schedule'
  
     - name: Checkout shell scripts for workflow
+      shell: bash
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
-      run: git checkout ${{ github.ref_name }} -- .github/actions/
+      run: |
+        git checkout ${{ github.event.inputs.commit }}
+        git checkout ${{ github.ref_name }} -- .github/actions/ || exit $?
+        for i in $(git status --short | cut -f2 -d " "); do sha256sum $i; done
+        exit 0
 
     # Setup a copy of the macOS SDK
     - name: Setup macOS SDK
@@ -234,10 +274,18 @@ jobs:
             arch: x64
 
     steps:
+    - name: Determine fetch depth
+      id: determine_fd
+      shell: bash
+      run: |
+        unset DEPTH
+        if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
+        echo "::set-output name=DEPTH::${DEPTH}"
+
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.commit }}
+        fetch-depth: ${{ steps.determine_fd.outputs.DEPTH }}
       if: github.event_name != 'schedule'
 
     - name: Checkout develop branch
@@ -247,8 +295,13 @@ jobs:
       if: github.event_name == 'schedule'
 
     - name: Checkout shell scripts for workflow
+      shell: bash
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
-      run: git checkout ${{ github.ref_name }} -- .github/actions/
+      run: |
+        git checkout ${{ github.event.inputs.commit }}
+        git checkout ${{ github.ref_name }} -- .github/actions/ || exit $?
+        for i in $(git status --short | cut -f2 -d " "); do sha256sum $i; done
+        exit 0
 
     # Setup a copy of the macOS SDK
     - name: Setup macOS SDK

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,12 +1,15 @@
 name: Build release artifacts
 
 on:
-  # Handles a 'helics-release-build' dispatch event type
-  # The event payload should contain these fields:
-  # packages - a list of which packages to build (everything, archive, msvc, installer, sharedlib)
-  # commit (optional) - the commit-ish to do a release build with
-  repository_dispatch:
   workflow_dispatch:
+    inputs:
+      packages:
+        description: 'List of packages to build (everything, archive, msvc, installer, sharedlib)'
+        required: true
+        default: 'everything'
+      commit:
+        description: 'Commit-ish (tag, branchname, sha) to do the release build with (uses scripts from the same branch as the workflow)'
+        default: ''
   schedule:
     - cron: '15 09 * * *' # Run in the early hours of the morning (UTC)
   release:
@@ -19,25 +22,29 @@ jobs:
   create-all-submodule-archive:
     name: Create all submodule archive
     runs-on: ubuntu-latest
-    if: (github.event.action == 'published') || (github.event.action == 'helics-release-build' && (contains(github.event.client_payload.packages, 'archive') || contains(github.event.client_payload.packages, 'everything'))) || github.event_name == 'workflow_dispatch'
+    if: (github.event.action == 'published') || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.packages, 'archive') || contains(github.event.inputs.packages, 'everything')))
     steps:
-    - name: Checkout event ref
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.client_payload.commit }}
-      if: github.event.action == 'published' || github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
-      
+        ref: ${{ github.event.inputs.commit }}
+      if: github.event.action == 'published' || github.event_name == 'workflow_dispatch'
+
+    - name: Checkout shell scripts for workflow
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
+      run: git checkout ${{ github.ref_name }} -- scripts/_git-all-archive.sh
+
     - name: Create archive
-      if: github.event.action != 'helics-release-build' && github.event_name != 'workflow_dispatch'
+      if: github.event_name != 'workflow_dispatch'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh -l "$(git rev-parse --abbrev-ref "${GITHUB_REF}")" && mkdir artifact && mv "Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}")-source.tar.gz" artifact/
     - name: Create archive (no version)
-      if: github.event.action == 'helics-release-build' || github.event_name == 'workflow_dispatch'
+      if: github.event_name == 'workflow_dispatch'
       # Creates the archive then moves it to an artifact subfolder
       run: ./scripts/_git-all-archive.sh && mkdir artifact && mv "Helics-source.tar.gz" artifact/
      
     - name: Upload archive to release
-      if: github.event.action != 'helics-release-build' && github.event_name != 'workflow_dispatch'
+      if: github.event_name != 'workflow_dispatch'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UPLOAD_URL: ${{ github.event.release.upload_url }}
@@ -54,7 +61,7 @@ jobs:
 #####################################
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'msvc') || contains(github.event.client_payload.packages, 'everything')) || github.event == 'workflow_dispatch'
+    if: (github.event_name != 'workflow_dispatch') || (contains(github.event.inputs.packages, 'msvc') || contains(github.event.inputs.packages, 'everything'))
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
@@ -67,18 +74,22 @@ jobs:
             cmake_gen: 'Visual Studio 17 2022'
             msvc_ver: 'msvc2022'
     steps:
-    - name: Checkout event ref
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.client_payload.commit }}
+        ref: ${{ github.event.inputs.commit }}
       if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: develop
       if: github.event_name == 'schedule'
-        
+
+    - name: Checkout shell scripts for workflow
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
+      run: git checkout ${{ github.ref_name }} -- .github/actions/
+
     # Compile HELICS and create the installer
     - name: Build installer
       env:
@@ -109,7 +120,7 @@ jobs:
   build-installers:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.cpack_gen }} Installer
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'installer') || contains(github.event.client_payload.packages, 'everything')) || github.event_name == 'workflow_dispatch'
+    if: (github.event_name != 'workflow_dispatch') || (contains(github.event.inputs.packages, 'installer') || contains(github.event.inputs.packages, 'everything'))
     strategy:
       matrix:
         id: [windows-x64, windows-x86, macos-x64, linux-x64]
@@ -137,25 +148,29 @@ jobs:
             cpack_gen: TGZ
 
     steps:
-    - name: Checkout event ref
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.client_payload.commit }}
+        ref: ${{ github.event.inputs.commit }}
       if: github.event_name != 'schedule'
     
     - name: Checkout develop branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: develop
       if: github.event_name == 'schedule'
  
+    - name: Checkout shell scripts for workflow
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
+      run: git checkout ${{ github.ref_name }} -- .github/actions/
+
     # Setup a copy of the macOS SDK
     - name: Setup macOS SDK
       if: runner.os == 'macOS'
       env:
         MACOS_SDK_VER: ${{ matrix.macos_target_ver }}
       run: ./.github/actions/setup-macos-sdk.sh
-        
+
     # Compile HELICS and create the installer
     - name: Build installer
       if: runner.os != 'Linux'
@@ -194,7 +209,7 @@ jobs:
 #####################################
   build-sharedlibs:
     runs-on: ${{ matrix.os }}
-    if: (github.event.action != 'helics-release-build') || (contains(github.event.client_payload.packages, 'sharedlib') || contains(github.event.client_payload.packages, 'everything')) || github.event_name == 'workflow_dispatch'
+    if: (github.event_name != 'workflow_dispatch') || (contains(github.event.inputs.packages, 'sharedlib') || contains(github.event.inputs.packages, 'everything'))
     name: Build ${{ matrix.os }} ${{ matrix.arch }} Shared Library
     strategy:
       matrix:
@@ -219,18 +234,22 @@ jobs:
             arch: x64
 
     steps:
-    - name: Checkout event ref
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.client_payload.commit }}
+        ref: ${{ github.event.inputs.commit }}
       if: github.event_name != 'schedule'
-    
+
     - name: Checkout develop branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: develop
       if: github.event_name == 'schedule'
-     
+
+    - name: Checkout shell scripts for workflow
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.commit
+      run: git checkout ${{ github.ref_name }} -- .github/actions/
+
     # Setup a copy of the macOS SDK
     - name: Setup macOS SDK
       if: runner.os == 'macOS'


### PR DESCRIPTION
### Summary

If merged this pull request will replace the functionality of the repository_dispatch trigger with the more easily used workflow_dispatch, and enable rebuilding release packages/tags with an updated release build workflow and shell scripts from another branch. This enables more easily fixing issues where something has been left out of the source archive or enabled CMake options for a binary package weren't right.

The new steps added make the initial checkout do a full clone (fetch-depth = 0) if a workflow dispatch event input specifies a commit to rebuild. The initial code checkout had to be the workflow file branch/tag -- this convoluted order was because checking out the "commit to rebuild" first resulted in git being weird and not recognizing the branch name it should be checking out the build related shell scripts from.



### Proposed changes

- Move repository_dispatch functionality to workflow_dispatch
- Add capability to build a package using the code from a tag, but the updated release build workflow and actions/shell scripts