### PR TITLE
look at the failures in the log buffer tests

### DIFF
--- a/tests/helics/application_api/LoggingTests.cpp
+++ b/tests/helics/application_api/LoggingTests.cpp
@@ -904,6 +904,7 @@ TEST(logging, remote_log_broker)
             ++remote_cnt;
         }
     }
+    llock.unlock();
     EXPECT_GT(remote_cnt, 0);
 }
 
@@ -938,6 +939,7 @@ TEST(logging, remote_log_fed)
             ++remote_cnt;
         }
     }
+    llock.unlock();
     EXPECT_GT(remote_cnt, 0);
 }
 
@@ -971,14 +973,15 @@ TEST(logging, remote_log_core)
     Fed->finalize();
 
     broker.reset();
-    auto llock = mlog.lock();
     int remote_cnt{0};
+    auto llock = mlog.lock();
     for (const auto& lg : llock) {
         if (std::get<1>(lg).find("broker10") != std::string::npos ||
             std::get<1>(lg).find("root") != std::string::npos) {
             ++remote_cnt;
         }
     }
+    llock.unlock();
     EXPECT_GT(remote_cnt, 0);
 }
 
@@ -1014,9 +1017,9 @@ TEST(logging, remote_log_multifed)
     Fed2->finalize();
     broker->query("root", "global_flush");
     broker.reset();
-    auto llock = mlog.lock();
     int remote_cnt1{0};
     int remote_cnt2{0};
+    auto llock = mlog.lock();
     for (const auto& lg : llock) {
         if (std::get<1>(lg).find("monitor1") != std::string::npos) {
             ++remote_cnt1;
@@ -1025,6 +1028,7 @@ TEST(logging, remote_log_multifed)
             ++remote_cnt2;
         }
     }
+    llock.unlock();
     EXPECT_GT(remote_cnt1, 0);
     EXPECT_GT(remote_cnt2, 0);
 }
@@ -1081,6 +1085,7 @@ TEST(logging, remote_log_multiObjects)
             ++remote_cnt2;
         }
     }
+    llock.unlock();
     EXPECT_GT(remote_cnt1, 0);
     EXPECT_GT(remote_cnt2, 0);
 
@@ -1096,6 +1101,7 @@ TEST(logging, remote_log_multiObjects)
             ++remote_cntFed2;
         }
     }
+    llock2.unlock();
     EXPECT_GT(remote_cntBroker, 0);
     EXPECT_GT(remote_cntFed2, 0);
 }

--- a/tests/helics/application_api/LoggingTests.cpp
+++ b/tests/helics/application_api/LoggingTests.cpp
@@ -1015,7 +1015,7 @@ TEST(logging, remote_log_multifed)
     rtime = Fed2->requestTime(2.0);
     EXPECT_EQ(rtime, 2.0);
     Fed2->finalize();
-    broker->query("root", "global_flush");
+    broker->waitForDisconnect();
     broker.reset();
     int remote_cnt1{0};
     int remote_cnt2{0};
@@ -1072,11 +1072,11 @@ TEST(logging, remote_log_multiObjects)
     rtime = Fed2->requestTime(2.0);
     EXPECT_EQ(rtime, 2.0);
     Fed2->finalize();
-    broker->query("root", "global_flush");
+    broker->waitForDisconnect();
     broker.reset();
-    auto llock = mlog.lock();
     int remote_cnt1{0};
     int remote_cnt2{0};
+    auto llock = mlog.lock();
     for (const auto& lg : llock) {
         if (std::get<1>(lg).find("monitor1") != std::string::npos) {
             ++remote_cnt1;
@@ -1089,9 +1089,10 @@ TEST(logging, remote_log_multiObjects)
     EXPECT_GT(remote_cnt1, 0);
     EXPECT_GT(remote_cnt2, 0);
 
-    auto llock2 = mlogFed.lock();
     int remote_cntFed2{0};
     int remote_cntBroker{0};
+    auto llock2 = mlogFed.lock();
+    
     for (const auto& lg : llock2) {
         if (std::get<1>(lg).find("broker12") != std::string::npos ||
             std::get<1>(lg).find("root") != std::string::npos) {

--- a/tests/helics/application_api/LoggingTests.cpp
+++ b/tests/helics/application_api/LoggingTests.cpp
@@ -1092,7 +1092,7 @@ TEST(logging, remote_log_multiObjects)
     int remote_cntFed2{0};
     int remote_cntBroker{0};
     auto llock2 = mlogFed.lock();
-    
+
     for (const auto& lg : llock2) {
         if (std::get<1>(lg).find("broker12") != std::string::npos ||
             std::get<1>(lg).find("root") != std::string::npos) {

--- a/tests/helics/system_tests/QueryTests.cpp
+++ b/tests/helics/system_tests/QueryTests.cpp
@@ -301,7 +301,7 @@ TEST_F(query, current_time)
     EXPECT_EQ(val["requested_time"].asDouble(), 3.0);
     mFed2->requestTime(3.0);
     mFed1->requestTimeComplete();
-
+    mFed1->query("broker", "flush");
     res = mFed1->query("broker", "current_time");
     val = loadJsonStr(res);
     EXPECT_EQ(val["time_next"].asDouble(), 3.0);


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will try to resolve some deadlock issues with the log buffer tests

I suspect the issue was destructor ordering on some compilers combined with sporadic delayed logging on some of the tests which could have caused a deadlock in the destructors.  
