### PR TITLE
add protection functions in the C API 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,15 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     endif()
 endif()
 
+if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+option(HELICS_ENABLE_PYTHON_BUILD_SCRIPTS "HELICS build systems can use python to automatically generate some files.  This is not required but may be useful if you are a developer and frequently modifying some files" OFF)
+mark_as_advanced(HELICS_ENABLE_PYTHON_BUILD_SCRIPTS)
+
+if (HELICS_ENABLE_PYTHON_BUILD_SCRIPTS)
+find_package(Python COMPONENTS Interpreter)
+endif()
+endif()
+
 # allow BOOST library inclusion to be turned off completely; this option will disable the IPC core
 option(HELICS_DISABLE_BOOST OFF "disable all references to the Boost C++ libraries")
 mark_as_advanced(HELICS_DISABLE_BOOST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,12 +151,16 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.12)
-option(HELICS_ENABLE_PYTHON_BUILD_SCRIPTS "HELICS build systems can use python to automatically generate some files.  This is not required but may be useful if you are a developer and frequently modifying some files" OFF)
-mark_as_advanced(HELICS_ENABLE_PYTHON_BUILD_SCRIPTS)
+    option(
+        HELICS_ENABLE_PYTHON_BUILD_SCRIPTS
+        "HELICS build systems can use python to automatically generate some files.  This is not required but may be useful if you are a developer and frequently modifying some files"
+        OFF
+    )
+    mark_as_advanced(HELICS_ENABLE_PYTHON_BUILD_SCRIPTS)
 
-if (HELICS_ENABLE_PYTHON_BUILD_SCRIPTS)
-find_package(Python COMPONENTS Interpreter)
-endif()
+    if(HELICS_ENABLE_PYTHON_BUILD_SCRIPTS)
+        find_package(Python COMPONENTS Interpreter)
+    endif()
 endif()
 
 # allow BOOST library inclusion to be turned off completely; this option will disable the IPC core

--- a/src/helics/core/CoreFactory.cpp
+++ b/src/helics/core/CoreFactory.cpp
@@ -29,7 +29,7 @@ DECLARE_TRIPLINE()
 
 namespace helics::CoreFactory {
 
-static const std::string gEmptyString;
+static const std::string gHelicsEmptyString;
 
 /*** class to hold the set of builders
 @details this doesn't work as a global since it tends to get initialized after some of the things
@@ -128,12 +128,12 @@ std::shared_ptr<Core> create(std::string_view initializationString)
     tparser.addTypeOption();
     tparser.allow_extras();
     tparser.parse(std::string(initializationString));
-    return create(tparser.getCoreType(), gEmptyString, tparser.remaining_for_passthrough());
+    return create(tparser.getCoreType(), gHelicsEmptyString, tparser.remaining_for_passthrough());
 }
 
 std::shared_ptr<Core> create(CoreType type, std::string_view configureString)
 {
-    return create(type, gEmptyString, configureString);
+    return create(type, gHelicsEmptyString, configureString);
 }
 
 std::shared_ptr<Core>
@@ -160,12 +160,12 @@ std::shared_ptr<Core> create(std::vector<std::string> args)
 
     tparser.allow_extras();
     tparser.parse(std::move(args));
-    return create(tparser.getCoreType(), gEmptyString, tparser.remaining_for_passthrough());
+    return create(tparser.getCoreType(), gHelicsEmptyString, tparser.remaining_for_passthrough());
 }
 
 std::shared_ptr<Core> create(CoreType type, std::vector<std::string> args)
 {
-    return create(type, gEmptyString, std::move(args));
+    return create(type, gHelicsEmptyString, std::move(args));
 }
 
 std::shared_ptr<Core>
@@ -194,7 +194,7 @@ std::shared_ptr<Core> create(int argc, char* argv[])
 
 std::shared_ptr<Core> create(CoreType type, int argc, char* argv[])
 {
-    return create(type, gEmptyString, argc, argv);
+    return create(type, gHelicsEmptyString, argc, argv);
 }
 
 std::shared_ptr<Core> create(CoreType type, std::string_view coreName, int argc, char* argv[])
@@ -402,14 +402,14 @@ void displayHelp(CoreType type)
 {
     if (type == CoreType::DEFAULT || type == CoreType::UNRECOGNIZED) {
         std::cout << "All core types have similar options\n";
-        auto cr = makeCore(CoreType::DEFAULT, gEmptyString);
+        auto cr = makeCore(CoreType::DEFAULT, gHelicsEmptyString);
         cr->configure(helpStr);
 #ifdef HELICS_ENABLE_TCP_CORE
-        cr = makeCore(CoreType::TCP_SS, gEmptyString);
+        cr = makeCore(CoreType::TCP_SS, gHelicsEmptyString);
         cr->configure(helpStr);
 #endif
     } else {
-        auto cr = makeCore(type, gEmptyString);
+        auto cr = makeCore(type, gHelicsEmptyString);
         cr->configure(helpStr);
     }
 }

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -42,23 +42,23 @@ class MessageTimer {};
 #endif
 
 #include "../common/fmt_format.h"
-static const std::string gEmptyStr;
-#define LOG_ERROR(message) logMessage(HELICS_LOG_LEVEL_ERROR, gEmptyStr, message)
-#define LOG_WARNING(message) logMessage(HELICS_LOG_LEVEL_WARNING, gEmptyStr, message)
+static const std::string gHelicsEmptyStr;
+#define LOG_ERROR(message) logMessage(HELICS_LOG_LEVEL_ERROR, gHelicsEmptyStr, message)
+#define LOG_WARNING(message) logMessage(HELICS_LOG_LEVEL_WARNING, gHelicsEmptyStr, message)
 
 #ifdef HELICS_ENABLE_LOGGING
 
 #    define LOG_SUMMARY(message)                                                                   \
         do {                                                                                       \
             if (maxLogLevel >= HELICS_LOG_LEVEL_SUMMARY) {                                         \
-                logMessage(HELICS_LOG_LEVEL_SUMMARY, gEmptyStr, message);                          \
+                logMessage(HELICS_LOG_LEVEL_SUMMARY, gHelicsEmptyStr, message);                          \
             }                                                                                      \
         } while (false)
 
 #    define LOG_INTERFACES(message)                                                                \
         do {                                                                                       \
             if (maxLogLevel >= HELICS_LOG_LEVEL_INTERFACES) {                                      \
-                logMessage(HELICS_LOG_LEVEL_INTERFACES, gEmptyStr, message);                       \
+                logMessage(HELICS_LOG_LEVEL_INTERFACES, gHelicsEmptyStr, message);                       \
             }                                                                                      \
         } while (false)
 
@@ -66,14 +66,14 @@ static const std::string gEmptyStr;
 #        define LOG_TIMING(message)                                                                \
             do {                                                                                   \
                 if (maxLogLevel >= HELICS_LOG_LEVEL_TIMING) {                                      \
-                    logMessage(HELICS_LOG_LEVEL_TIMING, gEmptyStr, message);                       \
+                    logMessage(HELICS_LOG_LEVEL_TIMING, gHelicsEmptyStr, message);                       \
                 }                                                                                  \
             } while (false)
 
 #        define LOG_DATA(message)                                                                  \
             do {                                                                                   \
                 if (maxLogLevel >= HELICS_LOG_LEVEL_DATA) {                                        \
-                    logMessage(HELICS_LOG_LEVEL_DATA, gEmptyStr, message);                         \
+                    logMessage(HELICS_LOG_LEVEL_DATA, gHelicsEmptyStr, message);                         \
                 }                                                                                  \
             } while (false)
 #    else
@@ -85,7 +85,7 @@ static const std::string gEmptyStr;
 #        define LOG_TRACE(message)                                                                 \
             do {                                                                                   \
                 if (maxLogLevel >= HELICS_LOG_LEVEL_TRACE) {                                       \
-                    logMessage(HELICS_LOG_LEVEL_TRACE, gEmptyStr, message);                        \
+                    logMessage(HELICS_LOG_LEVEL_TRACE, gHelicsEmptyStr, message);                        \
                 }                                                                                  \
             } while (false)
 #    else

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -51,14 +51,14 @@ static const std::string gHelicsEmptyStr;
 #    define LOG_SUMMARY(message)                                                                   \
         do {                                                                                       \
             if (maxLogLevel >= HELICS_LOG_LEVEL_SUMMARY) {                                         \
-                logMessage(HELICS_LOG_LEVEL_SUMMARY, gHelicsEmptyStr, message);                          \
+                logMessage(HELICS_LOG_LEVEL_SUMMARY, gHelicsEmptyStr, message);                    \
             }                                                                                      \
         } while (false)
 
 #    define LOG_INTERFACES(message)                                                                \
         do {                                                                                       \
             if (maxLogLevel >= HELICS_LOG_LEVEL_INTERFACES) {                                      \
-                logMessage(HELICS_LOG_LEVEL_INTERFACES, gHelicsEmptyStr, message);                       \
+                logMessage(HELICS_LOG_LEVEL_INTERFACES, gHelicsEmptyStr, message);                 \
             }                                                                                      \
         } while (false)
 
@@ -66,14 +66,14 @@ static const std::string gHelicsEmptyStr;
 #        define LOG_TIMING(message)                                                                \
             do {                                                                                   \
                 if (maxLogLevel >= HELICS_LOG_LEVEL_TIMING) {                                      \
-                    logMessage(HELICS_LOG_LEVEL_TIMING, gHelicsEmptyStr, message);                       \
+                    logMessage(HELICS_LOG_LEVEL_TIMING, gHelicsEmptyStr, message);                 \
                 }                                                                                  \
             } while (false)
 
 #        define LOG_DATA(message)                                                                  \
             do {                                                                                   \
                 if (maxLogLevel >= HELICS_LOG_LEVEL_DATA) {                                        \
-                    logMessage(HELICS_LOG_LEVEL_DATA, gHelicsEmptyStr, message);                         \
+                    logMessage(HELICS_LOG_LEVEL_DATA, gHelicsEmptyStr, message);                   \
                 }                                                                                  \
             } while (false)
 #    else
@@ -85,7 +85,7 @@ static const std::string gHelicsEmptyStr;
 #        define LOG_TRACE(message)                                                                 \
             do {                                                                                   \
                 if (maxLogLevel >= HELICS_LOG_LEVEL_TRACE) {                                       \
-                    logMessage(HELICS_LOG_LEVEL_TRACE, gHelicsEmptyStr, message);                        \
+                    logMessage(HELICS_LOG_LEVEL_TRACE, gHelicsEmptyStr, message);                  \
                 }                                                                                  \
             } while (false)
 #    else

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -551,6 +551,14 @@ class Federate {
         return helicsFederateGetName(fed);
     }
 
+    /** protect the federate and make it retrievable even if not library objects exist*/
+    void protect() {
+        helicsFederateProtect(helicsFederateGetName(fed), HELICS_IGNORE_ERROR);
+    }
+
+    /** unprotect the federate and make it retrievable even if not library objects exist*/
+    void unProtect() { helicsFederateUnProtect(helicsFederateGetName(fed), HELICS_IGNORE_ERROR); }
+
     /** make a query of the federate
     @details this call is blocking until the value is returned which make take some time depending
     on the size of the federation and the specific string being queried
@@ -932,6 +940,20 @@ class Federate {
     }
 #endif
 };
+
+inline void protect(const std::string& name)
+{
+    helicsFederateProtect(name.c_str(), hThrowOnError());
+}
+inline void unProtect(const std::string& name)
+{
+    helicsFederateUnProtect(name.c_str(), hThrowOnError());
+}
+
+inline bool isProtected(const std::string& name)
+{
+    return (helicsFederateIsProtected(name.c_str(), hThrowOnError()) == HELICS_TRUE) ? true : false;
+}
 
 }  // namespace helicscpp
 

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -552,12 +552,16 @@ class Federate {
     }
 
     /** protect the federate and make it retrievable even if not library objects exist*/
-    void protect() {
+    void protect()
+    {
         helicsFederateProtect(helicsFederateGetName(fed), HELICS_IGNORE_ERROR);
     }
 
     /** unprotect the federate and make it retrievable even if not library objects exist*/
-    void unProtect() { helicsFederateUnProtect(helicsFederateGetName(fed), HELICS_IGNORE_ERROR); }
+    void unProtect()
+    {
+        helicsFederateUnProtect(helicsFederateGetName(fed), HELICS_IGNORE_ERROR);
+    }
 
     /** make a query of the federate
     @details this call is blocking until the value is returned which make take some time depending

--- a/src/helics/shared_api_library/CMakeLists.txt
+++ b/src/helics/shared_api_library/CMakeLists.txt
@@ -47,7 +47,7 @@ if(Python_EXECUTABLE)
                 api-data.h
                 ../helics_enums.h
     )
-    
+
 else()
     configure_file(
         ${PROJECT_SOURCE_DIR}/src/helics/shared_api_library/backup/helics/helics.h

--- a/src/helics/shared_api_library/CMakeLists.txt
+++ b/src/helics/shared_api_library/CMakeLists.txt
@@ -32,11 +32,11 @@ set(helicsShared_sources
 
 include(GenerateExportHeader)
 
-if(PYTHON_EXECUTABLE)
+if(Python_EXECUTABLE)
     add_custom_command(
         OUTPUT ${PROJECT_BINARY_DIR}/helics_generated_includes/helics/helics.h
                ${PROJECT_BINARY_DIR}/helics_generated_includes/helics/helics_api.h
-        COMMAND ${PYTHON_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/scripts/generateHelicsH.py
+        COMMAND ${Python_EXECUTABLE} ARGS ${PROJECT_SOURCE_DIR}/scripts/generateHelicsH.py
                 ${PROJECT_BINARY_DIR}/helics_generated_includes/helics/ ${PROJECT_SOURCE_DIR}
         DEPENDS helicsCore.h
                 helicsCallbacks.h
@@ -47,6 +47,7 @@ if(PYTHON_EXECUTABLE)
                 api-data.h
                 ../helics_enums.h
     )
+    
 else()
     configure_file(
         ${PROJECT_SOURCE_DIR}/src/helics/shared_api_library/backup/helics/helics.h

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -1496,11 +1496,11 @@ const char* helicsFederateGetCommand(HelicsFederate fed, HelicsError* err)
     auto* fedObj = helics::getFedObject(fed, err);
 
     if (fedObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     auto res = fedObj->fedptr->getCommand();
     if (res.first.empty()) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     fedObj->commandBuffer = std::move(res);
     return fedObj->commandBuffer.first.c_str();
@@ -1511,7 +1511,7 @@ const char* helicsFederateGetCommandSource(HelicsFederate fed, HelicsError* err)
     auto* fedObj = helics::getFedObject(fed, err);
 
     if (fedObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     return fedObj->commandBuffer.second.c_str();
 }
@@ -1521,11 +1521,11 @@ const char* helicsFederateWaitCommand(HelicsFederate fed, HelicsError* err)
     auto* fedObj = helics::getFedObject(fed, err);
 
     if (fedObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     auto res = fedObj->fedptr->waitCommand();
     if (res.first.empty()) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     fedObj->commandBuffer = std::move(res);
     return fedObj->commandBuffer.first.c_str();

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -629,7 +629,7 @@ void helicsFederateUnProtect(const char* fedName, HelicsError* err)
 
 HelicsBool helicsFederateIsProtected(const char* fedName, HelicsError* err)
 {
-    auto fed = getMasterHolder()->findFed(fedName, fedPreservationIdentifier);
+    auto* fed = getMasterHolder()->findFed(fedName, fedPreservationIdentifier);
     if (fed != nullptr) {
         return HELICS_TRUE;
     }

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -611,13 +611,14 @@ void helicsFederateProtect(HelicsFederate fed, HelicsError* err)
     fedObj->valid = fedPreservationIdentifier;
 }
 
-void helicsFederateUnProtect(const char* fedName, HelicsError* err) {
+void helicsFederateUnProtect(const char* fedName, HelicsError* err)
+{
     static constexpr const char* unrecognizedFederate = "Federate was not found";
-    bool result = getMasterHolder()->removeFed(fedName,fedPreservationIdentifier);
+    bool result = getMasterHolder()->removeFed(fedName, fedPreservationIdentifier);
     if (!result) {
         if (!(getMasterHolder()->findFed(fedName) != nullptr)) {
-            if (err!=nullptr) {
-                if (err->error_code==0) {
+            if (err != nullptr) {
+                if (err->error_code == 0) {
                     err->error_code = HELICS_ERROR_INVALID_OBJECT;
                     err->message = unrecognizedFederate;
                 }

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -629,17 +629,17 @@ void helicsFederateUnProtect(const char* fedName, HelicsError* err)
 
 HelicsBool helicsFederateIsProtected(const char* fedName, HelicsError* err)
 {
-   auto fed = getMasterHolder()->findFed(fedName, fedPreservationIdentifier);
+    auto fed = getMasterHolder()->findFed(fedName, fedPreservationIdentifier);
     if (fed != nullptr) {
         return HELICS_TRUE;
     }
     if (!(getMasterHolder()->findFed(fedName) != nullptr)) {
         if (err != nullptr) {
-                if (err->error_code == 0) {
-                    err->error_code = HELICS_ERROR_INVALID_OBJECT;
-                    err->message = unrecognizedFederate;
-                }
+            if (err->error_code == 0) {
+                err->error_code = HELICS_ERROR_INVALID_OBJECT;
+                err->message = unrecognizedFederate;
             }
+        }
     }
     return HELICS_FALSE;
 }

--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -30,7 +30,7 @@ static inline HelicsEndpoint addEndpoint(HelicsFederate fed, std::unique_ptr<hel
 }
 
 static constexpr char nullcstr[] = "";
-const std::string gNullStringArgument("the supplied string argument is null and therefore invalid");
+const std::string gHelicsNullStringArgument("the supplied string argument is null and therefore invalid");
 
 static constexpr char invalidEndpoint[] = "The given endpoint does not point to a valid object";
 
@@ -227,7 +227,7 @@ void helicsEndpointSendBytes(HelicsEndpoint endpoint, const void* data, int inpu
     }
     try {
         if ((data == nullptr) || (inputDataLength <= 0)) {
-            endObj->endPtr->send(gEmptyStr);
+            endObj->endPtr->send(gHelicsEmptyStr);
         } else {
             endObj->endPtr->send(reinterpret_cast<const char*>(data), inputDataLength);
         }
@@ -245,7 +245,7 @@ void helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int in
     }
     try {
         if ((data == nullptr) || (inputDataLength <= 0)) {
-            endObj->endPtr->sendTo(gEmptyStr, AS_STRING_VIEW(dest));
+            endObj->endPtr->sendTo(gHelicsEmptyStr, AS_STRING_VIEW(dest));
         } else {
             endObj->endPtr->sendTo(reinterpret_cast<const char*>(data), inputDataLength, AS_STRING_VIEW(dest));
         }
@@ -263,7 +263,7 @@ void helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int in
     }
     try {
         if ((data == nullptr) || (inputDataLength <= 0)) {
-            endObj->endPtr->sendAt(gEmptyStr, time);
+            endObj->endPtr->sendAt(gHelicsEmptyStr, time);
         } else {
             endObj->endPtr->sendAt(reinterpret_cast<const char*>(data), inputDataLength, time);
         }
@@ -286,7 +286,7 @@ void helicsEndpointSendBytesToAt(HelicsEndpoint endpoint,
     }
     try {
         if ((data == nullptr) || (inputDataLength <= 0)) {
-            endObj->endPtr->sendToAt(gEmptyStr, AS_STRING_VIEW(dest), time);
+            endObj->endPtr->sendToAt(gHelicsEmptyStr, AS_STRING_VIEW(dest), time);
         } else {
             endObj->endPtr->sendToAt(reinterpret_cast<const char*>(data), inputDataLength, AS_STRING_VIEW(dest), time);
         }
@@ -610,7 +610,7 @@ const char* helicsEndpointGetInfo(HelicsEndpoint end)
 {
     auto* endObj = verifyEndpoint(end, nullptr);
     if (endObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = endObj->endPtr->getInfo();
@@ -618,7 +618,7 @@ const char* helicsEndpointGetInfo(HelicsEndpoint end)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -643,7 +643,7 @@ const char* helicsEndpointGetTag(HelicsEndpoint endpoint, const char* tagname)
 {
     auto* endObj = verifyEndpoint(endpoint, nullptr);
     if (endObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = endObj->endPtr->getTag(AS_STRING_VIEW(tagname));
@@ -651,7 +651,7 @@ const char* helicsEndpointGetTag(HelicsEndpoint endpoint, const char* tagname)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }

--- a/src/helics/shared_api_library/MessageFiltersExport.cpp
+++ b/src/helics/shared_api_library/MessageFiltersExport.cpp
@@ -284,7 +284,7 @@ const char* helicsFilterGetName(HelicsFilter filt)
 {
     auto* filter = getFilter(filt, nullptr);
     if (filter == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     const auto& name = filter->getName();
     return name.c_str();
@@ -409,7 +409,7 @@ const char* helicsFilterGetInfo(HelicsFilter filt)
 {
     auto* filtObj = getFilterObj(filt, nullptr);
     if (filtObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = filtObj->filtPtr->getInfo();
@@ -417,7 +417,7 @@ const char* helicsFilterGetInfo(HelicsFilter filt)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -442,7 +442,7 @@ const char* helicsFilterGetTag(HelicsFilter filt, const char* tagname)
 {
     auto* filtObj = getFilterObj(filt, nullptr);
     if (filtObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = filtObj->filtPtr->getTag(AS_STRING(tagname));
@@ -450,7 +450,7 @@ const char* helicsFilterGetTag(HelicsFilter filt, const char* tagname)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }

--- a/src/helics/shared_api_library/TranslatorExport.cpp
+++ b/src/helics/shared_api_library/TranslatorExport.cpp
@@ -210,7 +210,7 @@ const char* helicsTranslatorGetName(HelicsTranslator trans)
 {
     auto* translator = getTranslator(trans, nullptr);
     if (translator == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     const auto& name = translator->getName();
     return name.c_str();
@@ -335,7 +335,7 @@ const char* helicsTranslatorGetInfo(HelicsTranslator trans)
 {
     auto* transObj = getTranslatorObj(trans, nullptr);
     if (transObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = transObj->transPtr->getInfo();
@@ -343,7 +343,7 @@ const char* helicsTranslatorGetInfo(HelicsTranslator trans)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -368,7 +368,7 @@ const char* helicsTranslatorGetTag(HelicsTranslator trans, const char* tagname)
 {
     auto* transObj = getTranslatorObj(trans, nullptr);
     if (transObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = transObj->transPtr->getTag(AS_STRING_VIEW(tagname));
@@ -376,7 +376,7 @@ const char* helicsTranslatorGetTag(HelicsTranslator trans, const char* tagname)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -1139,6 +1139,7 @@ void helicsInputSetDefaultComplexVector(HelicsInput inp, const double* vectorInp
             inpObj->inputPtr->setDefault(std::vector<std::complex<double>>{});
         } else {
             std::vector<std::complex<double>> CV;
+            CV.reserve(vectorLength);
             for (int ii = 0; ii < vectorLength; ++ii) {
                 CV.emplace_back(vectorInput[2 * ii], vectorInput[2 * ii + 1]);
             }

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -1172,7 +1172,7 @@ const char* helicsInputGetType(HelicsInput inp)
 {
     auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
 
     try {
@@ -1181,7 +1181,7 @@ const char* helicsInputGetType(HelicsInput inp)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1190,7 +1190,7 @@ const char* helicsInputGetPublicationType(HelicsInput ipt)
 {
     auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
 
     try {
@@ -1199,7 +1199,7 @@ const char* helicsInputGetPublicationType(HelicsInput ipt)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1213,7 +1213,7 @@ const char* helicsPublicationGetType(HelicsPublication pub)
 {
     auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
 
     try {
@@ -1222,7 +1222,7 @@ const char* helicsPublicationGetType(HelicsPublication pub)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1231,7 +1231,7 @@ const char* helicsInputGetName(HelicsInput inp)
 {
     auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
 
     try {
@@ -1240,7 +1240,7 @@ const char* helicsInputGetName(HelicsInput inp)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1249,7 +1249,7 @@ const char* helicsSubscriptionGetTarget(HelicsInput sub)
 {
     auto* inpObj = verifyInput(sub, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
 
     try {
@@ -1258,7 +1258,7 @@ const char* helicsSubscriptionGetTarget(HelicsInput sub)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1267,7 +1267,7 @@ const char* helicsPublicationGetName(HelicsPublication pub)
 {
     auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& key = pubObj->pubPtr->getName();
@@ -1275,7 +1275,7 @@ const char* helicsPublicationGetName(HelicsPublication pub)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1284,7 +1284,7 @@ const char* helicsInputGetInjectionUnits(HelicsInput ipt)
 {
     auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& units = inpObj->inputPtr->getInjectionUnits();
@@ -1292,7 +1292,7 @@ const char* helicsInputGetInjectionUnits(HelicsInput ipt)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1301,7 +1301,7 @@ const char* helicsInputGetExtractionUnits(HelicsInput ipt)
 {
     auto* inpObj = verifyInput(ipt, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& units = inpObj->inputPtr->getUnits();
@@ -1309,7 +1309,7 @@ const char* helicsInputGetExtractionUnits(HelicsInput ipt)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1323,7 +1323,7 @@ const char* helicsPublicationGetUnits(HelicsPublication pub)
 {
     auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     const std::string& units = pubObj->pubPtr->getUnits();
     return units.c_str();
@@ -1333,7 +1333,7 @@ const char* helicsInputGetInfo(HelicsInput inp)
 {
     auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = inpObj->inputPtr->getInfo();
@@ -1341,7 +1341,7 @@ const char* helicsInputGetInfo(HelicsInput inp)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1366,7 +1366,7 @@ const char* helicsPublicationGetInfo(HelicsPublication pub)
 {
     auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = pubObj->pubPtr->getInfo();
@@ -1374,7 +1374,7 @@ const char* helicsPublicationGetInfo(HelicsPublication pub)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1399,7 +1399,7 @@ const char* helicsInputGetTag(HelicsInput inp, const char* tagname)
 {
     auto* inpObj = verifyInput(inp, nullptr);
     if (inpObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = inpObj->inputPtr->getTag(AS_STRING_VIEW(tagname));
@@ -1407,7 +1407,7 @@ const char* helicsInputGetTag(HelicsInput inp, const char* tagname)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }
@@ -1432,7 +1432,7 @@ const char* helicsPublicationGetTag(HelicsPublication pub, const char* tagname)
 {
     auto* pubObj = verifyPublication(pub, nullptr);
     if (pubObj == nullptr) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     try {
         const std::string& info = pubObj->pubPtr->getTag(AS_STRING_VIEW(tagname));
@@ -1440,7 +1440,7 @@ const char* helicsPublicationGetTag(HelicsPublication pub, const char* tagname)
     }
     // LCOV_EXCL_START
     catch (...) {
-        return gEmptyStr.c_str();
+        return gHelicsEmptyStr.c_str();
     }
     // LCOV_EXCL_STOP
 }

--- a/src/helics/shared_api_library/backup/helics/helics.h
+++ b/src/helics/shared_api_library/backup/helics/helics.h
@@ -1197,6 +1197,32 @@ HELICS_EXPORT HelicsFederate helicsCreateCombinationFederateFromConfig(const cha
 HELICS_EXPORT HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError* err);
 
 /**
+ * Protect a federate from finalizing and closing if all references go out of scope
+ *
+ * @details this function allows a federate to be retrieved on demand, it must be explicitly close later otherwise it will be destroyed
+ * when the library is closed
+ *
+ * @param fed An existing HelicsFederate.
+ *
+ * @param[in,out] err An error object that will contain an error code and string if any error
+ occurred during the execution of the function.
+ */
+HELICS_EXPORT void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
+
+/**
+ * remove the protection of an existing federate
+ *
+ * @details this function allows a federate to be retrieved on demand, it must be explicitly close
+ later otherwise it will be destroyed
+ * when the library is closed
+ *
+ * @param fed the name of an existing federate that should not be protected
+ *
+ * @param[in,out] err An error object that will contain an error code and string if the federate was not found.
+ */
+HELICS_EXPORT void helicsFederateUnProtect(const char* fedName, HelicsError* err);
+
+/**
  * Create a federate info object for specifying federate information when constructing a federate.
  *
  * @return A HelicsFederateInfo object which is a reference to the created object.

--- a/src/helics/shared_api_library/backup/helics/helics.h
+++ b/src/helics/shared_api_library/backup/helics/helics.h
@@ -1202,12 +1202,12 @@ HELICS_EXPORT HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError
  * @details this function allows a federate to be retrieved on demand, it must be explicitly close later otherwise it will be destroyed
  * when the library is closed
  *
- * @param fed An existing HelicsFederate.
+ * @param fedName The name of an existing HelicsFederate.
  *
  * @param[in,out] err An error object that will contain an error code and string if any error
- occurred during the execution of the function.
+ occurred during the execution of the function, in particular if no federate with the given name exists
  */
-HELICS_EXPORT void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
+HELICS_EXPORT void helicsFederateProtect(const char* fedName, HelicsError* err);
 
 /**
  * remove the protection of an existing federate
@@ -1221,6 +1221,16 @@ HELICS_EXPORT void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
  * @param[in,out] err An error object that will contain an error code and string if the federate was not found.
  */
 HELICS_EXPORT void helicsFederateUnProtect(const char* fedName, HelicsError* err);
+
+/**
+ * checks if an existing federate is protected
+ *
+ *
+ * @param fed the name of an existing federate to check the protection status
+ *
+ * @param[in,out] err An error object that will contain an error code and string if the federate was not found.
+ */
+HELICS_EXPORT HelicsBool helicsFederateIsProtected(const char* fedName, HelicsError* err);
 
 /**
  * Create a federate info object for specifying federate information when constructing a federate.

--- a/src/helics/shared_api_library/backup/helics/helics_api.h
+++ b/src/helics/shared_api_library/backup/helics/helics_api.h
@@ -66,7 +66,11 @@ typedef enum {
     HELICS_FLAG_LOCAL_PROFILING_CAPTURE = 96
 } HelicsFederateFlags;
 
-typedef enum { HELICS_FLAG_DELAY_INIT_ENTRY = 45, HELICS_FLAG_ENABLE_INIT_ENTRY = 47, HELICS_FLAG_IGNORE = 999 } HelicsCoreFlags;
+typedef enum {
+    HELICS_FLAG_DELAY_INIT_ENTRY = 45,
+    HELICS_FLAG_ENABLE_INIT_ENTRY = 47,
+    HELICS_FLAG_IGNORE = 999
+} HelicsCoreFlags;
 
 typedef enum {
     HELICS_FLAG_SLOW_RESPONDING = 29,
@@ -300,13 +304,15 @@ HelicsCore helicsCreateCoreFromArgs(const char* type, const char* name, int argc
 HelicsCore helicsCoreClone(HelicsCore core, HelicsError* err);
 HelicsBool helicsCoreIsValid(HelicsCore core);
 HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString, HelicsError* err);
-HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
+HelicsBroker
+    helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
 HelicsBroker helicsBrokerClone(HelicsBroker broker, HelicsError* err);
 HelicsBool helicsBrokerIsValid(HelicsBroker broker);
 HelicsBool helicsBrokerIsConnected(HelicsBroker broker);
 void helicsBrokerDataLink(HelicsBroker broker, const char* source, const char* target, HelicsError* err);
 void helicsBrokerAddSourceFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
-void helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
+void
+    helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
 void helicsBrokerMakeConnections(HelicsBroker broker, const char* file, HelicsError* err);
 HelicsBool helicsCoreWaitForDisconnect(HelicsCore core, int msToWait, HelicsError* err);
 HelicsBool helicsBrokerWaitForDisconnect(HelicsBroker broker, int msToWait, HelicsError* err);
@@ -336,6 +342,8 @@ HelicsFederate helicsCreateMessageFederateFromConfig(const char* configFile, Hel
 HelicsFederate helicsCreateCombinationFederate(const char* fedName, HelicsFederateInfo fi, HelicsError* err);
 HelicsFederate helicsCreateCombinationFederateFromConfig(const char* configFile, HelicsError* err);
 HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError* err);
+void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
+void helicsFederateUnProtect(const char* fedName, HelicsError* err);
 HelicsFederateInfo helicsCreateFederateInfo(void);
 HelicsFederateInfo helicsFederateInfoClone(HelicsFederateInfo fi, HelicsError* err);
 void helicsFederateInfoLoadFromArgs(HelicsFederateInfo fi, int argc, const char* const* argv, HelicsError* err);
@@ -378,7 +386,9 @@ void helicsFederateEnterInitializingModeComplete(HelicsFederate fed, HelicsError
 void helicsFederateEnterExecutingMode(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeAsync(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeComplete(HelicsFederate fed, HelicsError* err);
-HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
+HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed,
+                                                                              HelicsIterationRequest iterate,
+                                                                              HelicsError* err);
 void helicsFederateEnterExecutingModeIterativeAsync(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 HelicsIterationResult helicsFederateEnterExecutingModeIterativeComplete(HelicsFederate fed, HelicsError* err);
 HelicsFederateState helicsFederateGetState(HelicsFederate fed, HelicsError* err);
@@ -387,14 +397,17 @@ HelicsTime helicsFederateRequestTime(HelicsFederate fed, HelicsTime requestTime,
 HelicsTime helicsFederateRequestTimeAdvance(HelicsFederate fed, HelicsTime timeDelta, HelicsError* err);
 HelicsTime helicsFederateRequestNextStep(HelicsFederate fed, HelicsError* err);
 HelicsTime helicsFederateRequestTimeIterative(HelicsFederate fed,
-                                              HelicsTime requestTime,
-                                              HelicsIterationRequest iterate,
-                                              HelicsIterationResult* outIteration,
-                                              HelicsError* err);
+                                                            HelicsTime requestTime,
+                                                            HelicsIterationRequest iterate,
+                                                            HelicsIterationResult* outIteration,
+                                                            HelicsError* err);
 void helicsFederateRequestTimeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsError* err);
 HelicsTime helicsFederateRequestTimeComplete(HelicsFederate fed, HelicsError* err);
-void helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
-HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed, HelicsIterationResult* outIterate, HelicsError* err);
+void
+    helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
+HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed,
+                                                                    HelicsIterationResult* outIterate,
+                                                                    HelicsError* err);
 void helicsFederateProcessCommunications(HelicsFederate fed, HelicsTime period, HelicsError* err);
 const char* helicsFederateGetName(HelicsFederate fed);
 void helicsFederateSetTimeProperty(HelicsFederate fed, int timeProperty, HelicsTime time, HelicsError* err);
@@ -452,8 +465,10 @@ HelicsPublication
     helicsFederateRegisterGlobalPublication(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalTypePublication(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
-HelicsInput helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
-HelicsInput helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
+HelicsInput
+    helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
+HelicsInput
+    helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
@@ -476,7 +491,8 @@ void helicsPublicationPublishTime(HelicsPublication pub, HelicsTime val, HelicsE
 void helicsPublicationPublishChar(HelicsPublication pub, char val, HelicsError* err);
 void helicsPublicationPublishComplex(HelicsPublication pub, double real, double imag, HelicsError* err);
 void helicsPublicationPublishVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
-void helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
+void
+    helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
 void helicsPublicationPublishNamedPoint(HelicsPublication pub, const char* str, double val, HelicsError* err);
 void helicsPublicationAddTarget(HelicsPublication pub, const char* target, HelicsError* err);
 HelicsBool helicsInputIsValid(HelicsInput ipt);
@@ -496,7 +512,8 @@ void helicsInputGetComplex(HelicsInput ipt, double* real, double* imag, HelicsEr
 int helicsInputGetVectorSize(HelicsInput ipt);
 void helicsInputGetVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
 void helicsInputGetComplexVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
-void helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
+void
+    helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
 
 void helicsInputSetDefaultBytes(HelicsInput ipt, const void* data, int inputDataLength, HelicsError* err);
 void helicsInputSetDefaultString(HelicsInput ipt, const char* str, HelicsError* err);
@@ -542,22 +559,30 @@ int helicsFederateGetPublicationCount(HelicsFederate fed);
 int helicsFederateGetInputCount(HelicsFederate fed);
 HelicsEndpoint helicsFederateRegisterEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateRegisterGlobalEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
+HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed,
+                                                                    const char* name,
+                                                                    const char* type,
+                                                                    HelicsError* err);
+HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed,
+                                                                          const char* name,
+                                                                          const char* type,
+                                                                          HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpoint(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpointByIndex(HelicsFederate fed, int index, HelicsError* err);
 HelicsBool helicsEndpointIsValid(HelicsEndpoint endpoint);
 void helicsEndpointSetDefaultDestination(HelicsEndpoint endpoint, const char* dst, HelicsError* err);
 const char* helicsEndpointGetDefaultDestination(HelicsEndpoint endpoint);
 void helicsEndpointSendBytes(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsError* err);
-void helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
+void
+    helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
 void helicsEndpointSendBytesToAt(HelicsEndpoint endpoint,
-                                 const void* data,
-                                 int inputDataLength,
-                                 const char* dst,
-                                 HelicsTime time,
-                                 HelicsError* err);
-void helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
+                                               const void* data,
+                                               int inputDataLength,
+                                               const char* dst,
+                                               HelicsTime time,
+                                               HelicsError* err);
+void
+    helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
 void helicsEndpointSendMessage(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSendMessageZeroCopy(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSubscribe(HelicsEndpoint endpoint, const char* key, HelicsError* err);
@@ -615,7 +640,10 @@ HelicsMessage helicsMessageClone(HelicsMessage message, HelicsError* err);
 void helicsMessageFree(HelicsMessage message);
 void helicsMessageClear(HelicsMessage message, HelicsError* err);
 HelicsFilter helicsFederateRegisterFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
-HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
+HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed,
+                                                              HelicsFilterTypes type,
+                                                              const char* name,
+                                                              HelicsError* err);
 HelicsFilter helicsFederateRegisterCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterGlobalCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsCoreRegisterFilter(HelicsCore core, HelicsFilterTypes type, const char* name, HelicsError* err);
@@ -639,9 +667,18 @@ void helicsFilterSetTag(HelicsFilter filt, const char* tagname, const char* tagv
 void helicsFilterSetOption(HelicsFilter filt, int option, int value, HelicsError* err);
 int helicsFilterGetOption(HelicsFilter filt, int option);
 
-HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
-HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
-HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core, HelicsTranslatorTypes type, const char* name, HelicsError* err);
+HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed,
+                                                                HelicsTranslatorTypes type,
+                                                                const char* name,
+                                                                HelicsError* err);
+HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed,
+                                                                      HelicsTranslatorTypes type,
+                                                                      const char* name,
+                                                                      HelicsError* err);
+HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core,
+                                                            HelicsTranslatorTypes type,
+                                                            const char* name,
+                                                            HelicsError* err);
 int helicsFederateGetTranslatorCount(HelicsFederate fed);
 HelicsTranslator helicsFederateGetTranslator(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsTranslator helicsFederateGetTranslatorByIndex(HelicsFederate fed, int index, HelicsError* err);
@@ -662,40 +699,44 @@ void helicsTranslatorSetOption(HelicsTranslator trans, int option, int value, He
 int helicsTranslatorGetOption(HelicsTranslator trans, int option);
 
 void helicsBrokerSetLoggingCallback(HelicsBroker broker,
-                                    void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                    void* userdata,
-                                    HelicsError* err);
+                                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                                  void* userdata,
+                                                  HelicsError* err);
 void helicsCoreSetLoggingCallback(HelicsCore core,
-                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                  void* userdata,
-                                  HelicsError* err);
-void helicsFederateSetLoggingCallback(HelicsFederate fed,
-                                      void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                      void* userdata,
-                                      HelicsError* err);
+                                                void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                                void* userdata,
+                                                HelicsError* err);
+void
+    helicsFederateSetLoggingCallback(HelicsFederate fed,
+                                     void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                     void* userdata,
+                                     HelicsError* err);
 void helicsFilterSetCustomCallback(HelicsFilter filter,
-                                   HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
+                                                 HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
+                                                 void* userdata,
+                                                 HelicsError* err);
+void
+    helicsFederateSetQueryCallback(HelicsFederate fed,
+                                   void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
                                    void* userdata,
                                    HelicsError* err);
-void helicsFederateSetQueryCallback(HelicsFederate fed,
-                                    void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
-                                    void* userdata,
-                                    HelicsError* err);
 void helicsFederateSetTimeRequestEntryCallback(
     HelicsFederate fed,
     void (*requestTime)(HelicsTime currentTime, HelicsTime requestTime, HelicsBool iterating, void* userdata),
     void* userdata,
     HelicsError* err);
 void helicsFederateSetTimeUpdateCallback(HelicsFederate fed,
-                                         void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                                       void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                                       void* userdata,
+                                                       HelicsError* err);
+void
+    helicsFederateSetStateChangeCallback(HelicsFederate fed,
+                                         void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
                                          void* userdata,
                                          HelicsError* err);
-void helicsFederateSetStateChangeCallback(HelicsFederate fed,
-                                          void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
-                                          void* userdata,
-                                          HelicsError* err);
-void helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
-                                                void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
-                                                void* userdata,
-                                                HelicsError* err);
+void
+    helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
+                                               void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                               void* userdata,
+                                               HelicsError* err);
 void helicsQueryBufferFill(HelicsQueryBuffer buffer, const char* str, int strSize, HelicsError* err);

--- a/src/helics/shared_api_library/backup/helics/helics_api.h
+++ b/src/helics/shared_api_library/backup/helics/helics_api.h
@@ -66,11 +66,7 @@ typedef enum {
     HELICS_FLAG_LOCAL_PROFILING_CAPTURE = 96
 } HelicsFederateFlags;
 
-typedef enum {
-    HELICS_FLAG_DELAY_INIT_ENTRY = 45,
-    HELICS_FLAG_ENABLE_INIT_ENTRY = 47,
-    HELICS_FLAG_IGNORE = 999
-} HelicsCoreFlags;
+typedef enum { HELICS_FLAG_DELAY_INIT_ENTRY = 45, HELICS_FLAG_ENABLE_INIT_ENTRY = 47, HELICS_FLAG_IGNORE = 999 } HelicsCoreFlags;
 
 typedef enum {
     HELICS_FLAG_SLOW_RESPONDING = 29,
@@ -304,15 +300,13 @@ HelicsCore helicsCreateCoreFromArgs(const char* type, const char* name, int argc
 HelicsCore helicsCoreClone(HelicsCore core, HelicsError* err);
 HelicsBool helicsCoreIsValid(HelicsCore core);
 HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString, HelicsError* err);
-HelicsBroker
-    helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
+HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
 HelicsBroker helicsBrokerClone(HelicsBroker broker, HelicsError* err);
 HelicsBool helicsBrokerIsValid(HelicsBroker broker);
 HelicsBool helicsBrokerIsConnected(HelicsBroker broker);
 void helicsBrokerDataLink(HelicsBroker broker, const char* source, const char* target, HelicsError* err);
 void helicsBrokerAddSourceFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
-void
-    helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
+void helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
 void helicsBrokerMakeConnections(HelicsBroker broker, const char* file, HelicsError* err);
 HelicsBool helicsCoreWaitForDisconnect(HelicsCore core, int msToWait, HelicsError* err);
 HelicsBool helicsBrokerWaitForDisconnect(HelicsBroker broker, int msToWait, HelicsError* err);
@@ -386,9 +380,7 @@ void helicsFederateEnterInitializingModeComplete(HelicsFederate fed, HelicsError
 void helicsFederateEnterExecutingMode(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeAsync(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeComplete(HelicsFederate fed, HelicsError* err);
-HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed,
-                                                                              HelicsIterationRequest iterate,
-                                                                              HelicsError* err);
+HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 void helicsFederateEnterExecutingModeIterativeAsync(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 HelicsIterationResult helicsFederateEnterExecutingModeIterativeComplete(HelicsFederate fed, HelicsError* err);
 HelicsFederateState helicsFederateGetState(HelicsFederate fed, HelicsError* err);
@@ -397,17 +389,14 @@ HelicsTime helicsFederateRequestTime(HelicsFederate fed, HelicsTime requestTime,
 HelicsTime helicsFederateRequestTimeAdvance(HelicsFederate fed, HelicsTime timeDelta, HelicsError* err);
 HelicsTime helicsFederateRequestNextStep(HelicsFederate fed, HelicsError* err);
 HelicsTime helicsFederateRequestTimeIterative(HelicsFederate fed,
-                                                            HelicsTime requestTime,
-                                                            HelicsIterationRequest iterate,
-                                                            HelicsIterationResult* outIteration,
-                                                            HelicsError* err);
+                                              HelicsTime requestTime,
+                                              HelicsIterationRequest iterate,
+                                              HelicsIterationResult* outIteration,
+                                              HelicsError* err);
 void helicsFederateRequestTimeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsError* err);
 HelicsTime helicsFederateRequestTimeComplete(HelicsFederate fed, HelicsError* err);
-void
-    helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
-HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed,
-                                                                    HelicsIterationResult* outIterate,
-                                                                    HelicsError* err);
+void helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
+HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed, HelicsIterationResult* outIterate, HelicsError* err);
 void helicsFederateProcessCommunications(HelicsFederate fed, HelicsTime period, HelicsError* err);
 const char* helicsFederateGetName(HelicsFederate fed);
 void helicsFederateSetTimeProperty(HelicsFederate fed, int timeProperty, HelicsTime time, HelicsError* err);
@@ -465,10 +454,8 @@ HelicsPublication
     helicsFederateRegisterGlobalPublication(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalTypePublication(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
-HelicsInput
-    helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
-HelicsInput
-    helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
+HelicsInput helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
+HelicsInput helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
@@ -491,8 +478,7 @@ void helicsPublicationPublishTime(HelicsPublication pub, HelicsTime val, HelicsE
 void helicsPublicationPublishChar(HelicsPublication pub, char val, HelicsError* err);
 void helicsPublicationPublishComplex(HelicsPublication pub, double real, double imag, HelicsError* err);
 void helicsPublicationPublishVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
-void
-    helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
+void helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
 void helicsPublicationPublishNamedPoint(HelicsPublication pub, const char* str, double val, HelicsError* err);
 void helicsPublicationAddTarget(HelicsPublication pub, const char* target, HelicsError* err);
 HelicsBool helicsInputIsValid(HelicsInput ipt);
@@ -512,8 +498,7 @@ void helicsInputGetComplex(HelicsInput ipt, double* real, double* imag, HelicsEr
 int helicsInputGetVectorSize(HelicsInput ipt);
 void helicsInputGetVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
 void helicsInputGetComplexVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
-void
-    helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
+void helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
 
 void helicsInputSetDefaultBytes(HelicsInput ipt, const void* data, int inputDataLength, HelicsError* err);
 void helicsInputSetDefaultString(HelicsInput ipt, const char* str, HelicsError* err);
@@ -559,30 +544,22 @@ int helicsFederateGetPublicationCount(HelicsFederate fed);
 int helicsFederateGetInputCount(HelicsFederate fed);
 HelicsEndpoint helicsFederateRegisterEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateRegisterGlobalEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed,
-                                                                    const char* name,
-                                                                    const char* type,
-                                                                    HelicsError* err);
-HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed,
-                                                                          const char* name,
-                                                                          const char* type,
-                                                                          HelicsError* err);
+HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
+HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpoint(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpointByIndex(HelicsFederate fed, int index, HelicsError* err);
 HelicsBool helicsEndpointIsValid(HelicsEndpoint endpoint);
 void helicsEndpointSetDefaultDestination(HelicsEndpoint endpoint, const char* dst, HelicsError* err);
 const char* helicsEndpointGetDefaultDestination(HelicsEndpoint endpoint);
 void helicsEndpointSendBytes(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsError* err);
-void
-    helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
+void helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
 void helicsEndpointSendBytesToAt(HelicsEndpoint endpoint,
-                                               const void* data,
-                                               int inputDataLength,
-                                               const char* dst,
-                                               HelicsTime time,
-                                               HelicsError* err);
-void
-    helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
+                                 const void* data,
+                                 int inputDataLength,
+                                 const char* dst,
+                                 HelicsTime time,
+                                 HelicsError* err);
+void helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
 void helicsEndpointSendMessage(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSendMessageZeroCopy(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSubscribe(HelicsEndpoint endpoint, const char* key, HelicsError* err);
@@ -640,10 +617,7 @@ HelicsMessage helicsMessageClone(HelicsMessage message, HelicsError* err);
 void helicsMessageFree(HelicsMessage message);
 void helicsMessageClear(HelicsMessage message, HelicsError* err);
 HelicsFilter helicsFederateRegisterFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
-HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed,
-                                                              HelicsFilterTypes type,
-                                                              const char* name,
-                                                              HelicsError* err);
+HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterGlobalCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsCoreRegisterFilter(HelicsCore core, HelicsFilterTypes type, const char* name, HelicsError* err);
@@ -667,18 +641,9 @@ void helicsFilterSetTag(HelicsFilter filt, const char* tagname, const char* tagv
 void helicsFilterSetOption(HelicsFilter filt, int option, int value, HelicsError* err);
 int helicsFilterGetOption(HelicsFilter filt, int option);
 
-HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed,
-                                                                HelicsTranslatorTypes type,
-                                                                const char* name,
-                                                                HelicsError* err);
-HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed,
-                                                                      HelicsTranslatorTypes type,
-                                                                      const char* name,
-                                                                      HelicsError* err);
-HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core,
-                                                            HelicsTranslatorTypes type,
-                                                            const char* name,
-                                                            HelicsError* err);
+HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
+HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
+HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core, HelicsTranslatorTypes type, const char* name, HelicsError* err);
 int helicsFederateGetTranslatorCount(HelicsFederate fed);
 HelicsTranslator helicsFederateGetTranslator(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsTranslator helicsFederateGetTranslatorByIndex(HelicsFederate fed, int index, HelicsError* err);
@@ -699,44 +664,40 @@ void helicsTranslatorSetOption(HelicsTranslator trans, int option, int value, He
 int helicsTranslatorGetOption(HelicsTranslator trans, int option);
 
 void helicsBrokerSetLoggingCallback(HelicsBroker broker,
-                                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                                  void* userdata,
-                                                  HelicsError* err);
+                                    void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                    void* userdata,
+                                    HelicsError* err);
 void helicsCoreSetLoggingCallback(HelicsCore core,
-                                                void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                                void* userdata,
-                                                HelicsError* err);
-void
-    helicsFederateSetLoggingCallback(HelicsFederate fed,
-                                     void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                     void* userdata,
-                                     HelicsError* err);
+                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                  void* userdata,
+                                  HelicsError* err);
+void helicsFederateSetLoggingCallback(HelicsFederate fed,
+                                      void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                      void* userdata,
+                                      HelicsError* err);
 void helicsFilterSetCustomCallback(HelicsFilter filter,
-                                                 HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
-                                                 void* userdata,
-                                                 HelicsError* err);
-void
-    helicsFederateSetQueryCallback(HelicsFederate fed,
-                                   void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
+                                   HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
                                    void* userdata,
                                    HelicsError* err);
+void helicsFederateSetQueryCallback(HelicsFederate fed,
+                                    void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
+                                    void* userdata,
+                                    HelicsError* err);
 void helicsFederateSetTimeRequestEntryCallback(
     HelicsFederate fed,
     void (*requestTime)(HelicsTime currentTime, HelicsTime requestTime, HelicsBool iterating, void* userdata),
     void* userdata,
     HelicsError* err);
 void helicsFederateSetTimeUpdateCallback(HelicsFederate fed,
-                                                       void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
-                                                       void* userdata,
-                                                       HelicsError* err);
-void
-    helicsFederateSetStateChangeCallback(HelicsFederate fed,
-                                         void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
+                                         void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
                                          void* userdata,
                                          HelicsError* err);
-void
-    helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
-                                               void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
-                                               void* userdata,
-                                               HelicsError* err);
+void helicsFederateSetStateChangeCallback(HelicsFederate fed,
+                                          void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
+                                          void* userdata,
+                                          HelicsError* err);
+void helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
+                                                void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                                void* userdata,
+                                                HelicsError* err);
 void helicsQueryBufferFill(HelicsQueryBuffer buffer, const char* str, int strSize, HelicsError* err);

--- a/src/helics/shared_api_library/backup/helics/helics_api.h
+++ b/src/helics/shared_api_library/backup/helics/helics_api.h
@@ -66,11 +66,7 @@ typedef enum {
     HELICS_FLAG_LOCAL_PROFILING_CAPTURE = 96
 } HelicsFederateFlags;
 
-typedef enum {
-    HELICS_FLAG_DELAY_INIT_ENTRY = 45,
-    HELICS_FLAG_ENABLE_INIT_ENTRY = 47,
-    HELICS_FLAG_IGNORE = 999
-} HelicsCoreFlags;
+typedef enum { HELICS_FLAG_DELAY_INIT_ENTRY = 45, HELICS_FLAG_ENABLE_INIT_ENTRY = 47, HELICS_FLAG_IGNORE = 999 } HelicsCoreFlags;
 
 typedef enum {
     HELICS_FLAG_SLOW_RESPONDING = 29,
@@ -304,15 +300,13 @@ HelicsCore helicsCreateCoreFromArgs(const char* type, const char* name, int argc
 HelicsCore helicsCoreClone(HelicsCore core, HelicsError* err);
 HelicsBool helicsCoreIsValid(HelicsCore core);
 HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString, HelicsError* err);
-HelicsBroker
-    helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
+HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
 HelicsBroker helicsBrokerClone(HelicsBroker broker, HelicsError* err);
 HelicsBool helicsBrokerIsValid(HelicsBroker broker);
 HelicsBool helicsBrokerIsConnected(HelicsBroker broker);
 void helicsBrokerDataLink(HelicsBroker broker, const char* source, const char* target, HelicsError* err);
 void helicsBrokerAddSourceFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
-void
-    helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
+void helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
 void helicsBrokerMakeConnections(HelicsBroker broker, const char* file, HelicsError* err);
 HelicsBool helicsCoreWaitForDisconnect(HelicsCore core, int msToWait, HelicsError* err);
 HelicsBool helicsBrokerWaitForDisconnect(HelicsBroker broker, int msToWait, HelicsError* err);
@@ -387,9 +381,7 @@ void helicsFederateEnterInitializingModeComplete(HelicsFederate fed, HelicsError
 void helicsFederateEnterExecutingMode(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeAsync(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeComplete(HelicsFederate fed, HelicsError* err);
-HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed,
-                                                                              HelicsIterationRequest iterate,
-                                                                              HelicsError* err);
+HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 void helicsFederateEnterExecutingModeIterativeAsync(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 HelicsIterationResult helicsFederateEnterExecutingModeIterativeComplete(HelicsFederate fed, HelicsError* err);
 HelicsFederateState helicsFederateGetState(HelicsFederate fed, HelicsError* err);
@@ -398,17 +390,14 @@ HelicsTime helicsFederateRequestTime(HelicsFederate fed, HelicsTime requestTime,
 HelicsTime helicsFederateRequestTimeAdvance(HelicsFederate fed, HelicsTime timeDelta, HelicsError* err);
 HelicsTime helicsFederateRequestNextStep(HelicsFederate fed, HelicsError* err);
 HelicsTime helicsFederateRequestTimeIterative(HelicsFederate fed,
-                                                            HelicsTime requestTime,
-                                                            HelicsIterationRequest iterate,
-                                                            HelicsIterationResult* outIteration,
-                                                            HelicsError* err);
+                                              HelicsTime requestTime,
+                                              HelicsIterationRequest iterate,
+                                              HelicsIterationResult* outIteration,
+                                              HelicsError* err);
 void helicsFederateRequestTimeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsError* err);
 HelicsTime helicsFederateRequestTimeComplete(HelicsFederate fed, HelicsError* err);
-void
-    helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
-HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed,
-                                                                    HelicsIterationResult* outIterate,
-                                                                    HelicsError* err);
+void helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
+HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed, HelicsIterationResult* outIterate, HelicsError* err);
 void helicsFederateProcessCommunications(HelicsFederate fed, HelicsTime period, HelicsError* err);
 const char* helicsFederateGetName(HelicsFederate fed);
 void helicsFederateSetTimeProperty(HelicsFederate fed, int timeProperty, HelicsTime time, HelicsError* err);
@@ -466,10 +455,8 @@ HelicsPublication
     helicsFederateRegisterGlobalPublication(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalTypePublication(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
-HelicsInput
-    helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
-HelicsInput
-    helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
+HelicsInput helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
+HelicsInput helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
@@ -492,8 +479,7 @@ void helicsPublicationPublishTime(HelicsPublication pub, HelicsTime val, HelicsE
 void helicsPublicationPublishChar(HelicsPublication pub, char val, HelicsError* err);
 void helicsPublicationPublishComplex(HelicsPublication pub, double real, double imag, HelicsError* err);
 void helicsPublicationPublishVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
-void
-    helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
+void helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
 void helicsPublicationPublishNamedPoint(HelicsPublication pub, const char* str, double val, HelicsError* err);
 void helicsPublicationAddTarget(HelicsPublication pub, const char* target, HelicsError* err);
 HelicsBool helicsInputIsValid(HelicsInput ipt);
@@ -513,8 +499,7 @@ void helicsInputGetComplex(HelicsInput ipt, double* real, double* imag, HelicsEr
 int helicsInputGetVectorSize(HelicsInput ipt);
 void helicsInputGetVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
 void helicsInputGetComplexVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
-void
-    helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
+void helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
 
 void helicsInputSetDefaultBytes(HelicsInput ipt, const void* data, int inputDataLength, HelicsError* err);
 void helicsInputSetDefaultString(HelicsInput ipt, const char* str, HelicsError* err);
@@ -560,30 +545,22 @@ int helicsFederateGetPublicationCount(HelicsFederate fed);
 int helicsFederateGetInputCount(HelicsFederate fed);
 HelicsEndpoint helicsFederateRegisterEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateRegisterGlobalEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed,
-                                                                    const char* name,
-                                                                    const char* type,
-                                                                    HelicsError* err);
-HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed,
-                                                                          const char* name,
-                                                                          const char* type,
-                                                                          HelicsError* err);
+HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
+HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpoint(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpointByIndex(HelicsFederate fed, int index, HelicsError* err);
 HelicsBool helicsEndpointIsValid(HelicsEndpoint endpoint);
 void helicsEndpointSetDefaultDestination(HelicsEndpoint endpoint, const char* dst, HelicsError* err);
 const char* helicsEndpointGetDefaultDestination(HelicsEndpoint endpoint);
 void helicsEndpointSendBytes(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsError* err);
-void
-    helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
+void helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
 void helicsEndpointSendBytesToAt(HelicsEndpoint endpoint,
-                                               const void* data,
-                                               int inputDataLength,
-                                               const char* dst,
-                                               HelicsTime time,
-                                               HelicsError* err);
-void
-    helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
+                                 const void* data,
+                                 int inputDataLength,
+                                 const char* dst,
+                                 HelicsTime time,
+                                 HelicsError* err);
+void helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
 void helicsEndpointSendMessage(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSendMessageZeroCopy(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSubscribe(HelicsEndpoint endpoint, const char* key, HelicsError* err);
@@ -641,10 +618,7 @@ HelicsMessage helicsMessageClone(HelicsMessage message, HelicsError* err);
 void helicsMessageFree(HelicsMessage message);
 void helicsMessageClear(HelicsMessage message, HelicsError* err);
 HelicsFilter helicsFederateRegisterFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
-HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed,
-                                                              HelicsFilterTypes type,
-                                                              const char* name,
-                                                              HelicsError* err);
+HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterGlobalCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsCoreRegisterFilter(HelicsCore core, HelicsFilterTypes type, const char* name, HelicsError* err);
@@ -668,18 +642,9 @@ void helicsFilterSetTag(HelicsFilter filt, const char* tagname, const char* tagv
 void helicsFilterSetOption(HelicsFilter filt, int option, int value, HelicsError* err);
 int helicsFilterGetOption(HelicsFilter filt, int option);
 
-HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed,
-                                                                HelicsTranslatorTypes type,
-                                                                const char* name,
-                                                                HelicsError* err);
-HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed,
-                                                                      HelicsTranslatorTypes type,
-                                                                      const char* name,
-                                                                      HelicsError* err);
-HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core,
-                                                            HelicsTranslatorTypes type,
-                                                            const char* name,
-                                                            HelicsError* err);
+HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
+HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
+HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core, HelicsTranslatorTypes type, const char* name, HelicsError* err);
 int helicsFederateGetTranslatorCount(HelicsFederate fed);
 HelicsTranslator helicsFederateGetTranslator(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsTranslator helicsFederateGetTranslatorByIndex(HelicsFederate fed, int index, HelicsError* err);
@@ -700,44 +665,40 @@ void helicsTranslatorSetOption(HelicsTranslator trans, int option, int value, He
 int helicsTranslatorGetOption(HelicsTranslator trans, int option);
 
 void helicsBrokerSetLoggingCallback(HelicsBroker broker,
-                                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                                  void* userdata,
-                                                  HelicsError* err);
+                                    void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                    void* userdata,
+                                    HelicsError* err);
 void helicsCoreSetLoggingCallback(HelicsCore core,
-                                                void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                                void* userdata,
-                                                HelicsError* err);
-void
-    helicsFederateSetLoggingCallback(HelicsFederate fed,
-                                     void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                     void* userdata,
-                                     HelicsError* err);
+                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                  void* userdata,
+                                  HelicsError* err);
+void helicsFederateSetLoggingCallback(HelicsFederate fed,
+                                      void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                      void* userdata,
+                                      HelicsError* err);
 void helicsFilterSetCustomCallback(HelicsFilter filter,
-                                                 HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
-                                                 void* userdata,
-                                                 HelicsError* err);
-void
-    helicsFederateSetQueryCallback(HelicsFederate fed,
-                                   void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
+                                   HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
                                    void* userdata,
                                    HelicsError* err);
+void helicsFederateSetQueryCallback(HelicsFederate fed,
+                                    void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
+                                    void* userdata,
+                                    HelicsError* err);
 void helicsFederateSetTimeRequestEntryCallback(
     HelicsFederate fed,
     void (*requestTime)(HelicsTime currentTime, HelicsTime requestTime, HelicsBool iterating, void* userdata),
     void* userdata,
     HelicsError* err);
 void helicsFederateSetTimeUpdateCallback(HelicsFederate fed,
-                                                       void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
-                                                       void* userdata,
-                                                       HelicsError* err);
-void
-    helicsFederateSetStateChangeCallback(HelicsFederate fed,
-                                         void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
+                                         void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
                                          void* userdata,
                                          HelicsError* err);
-void
-    helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
-                                               void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
-                                               void* userdata,
-                                               HelicsError* err);
+void helicsFederateSetStateChangeCallback(HelicsFederate fed,
+                                          void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
+                                          void* userdata,
+                                          HelicsError* err);
+void helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
+                                                void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                                void* userdata,
+                                                HelicsError* err);
 void helicsQueryBufferFill(HelicsQueryBuffer buffer, const char* str, int strSize, HelicsError* err);

--- a/src/helics/shared_api_library/backup/helics/helics_api.h
+++ b/src/helics/shared_api_library/backup/helics/helics_api.h
@@ -66,7 +66,11 @@ typedef enum {
     HELICS_FLAG_LOCAL_PROFILING_CAPTURE = 96
 } HelicsFederateFlags;
 
-typedef enum { HELICS_FLAG_DELAY_INIT_ENTRY = 45, HELICS_FLAG_ENABLE_INIT_ENTRY = 47, HELICS_FLAG_IGNORE = 999 } HelicsCoreFlags;
+typedef enum {
+    HELICS_FLAG_DELAY_INIT_ENTRY = 45,
+    HELICS_FLAG_ENABLE_INIT_ENTRY = 47,
+    HELICS_FLAG_IGNORE = 999
+} HelicsCoreFlags;
 
 typedef enum {
     HELICS_FLAG_SLOW_RESPONDING = 29,
@@ -300,13 +304,15 @@ HelicsCore helicsCreateCoreFromArgs(const char* type, const char* name, int argc
 HelicsCore helicsCoreClone(HelicsCore core, HelicsError* err);
 HelicsBool helicsCoreIsValid(HelicsCore core);
 HelicsBroker helicsCreateBroker(const char* type, const char* name, const char* initString, HelicsError* err);
-HelicsBroker helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
+HelicsBroker
+    helicsCreateBrokerFromArgs(const char* type, const char* name, int argc, const char* const* argv, HelicsError* err);
 HelicsBroker helicsBrokerClone(HelicsBroker broker, HelicsError* err);
 HelicsBool helicsBrokerIsValid(HelicsBroker broker);
 HelicsBool helicsBrokerIsConnected(HelicsBroker broker);
 void helicsBrokerDataLink(HelicsBroker broker, const char* source, const char* target, HelicsError* err);
 void helicsBrokerAddSourceFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
-void helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
+void
+    helicsBrokerAddDestinationFilterToEndpoint(HelicsBroker broker, const char* filter, const char* endpoint, HelicsError* err);
 void helicsBrokerMakeConnections(HelicsBroker broker, const char* file, HelicsError* err);
 HelicsBool helicsCoreWaitForDisconnect(HelicsCore core, int msToWait, HelicsError* err);
 HelicsBool helicsBrokerWaitForDisconnect(HelicsBroker broker, int msToWait, HelicsError* err);
@@ -336,8 +342,9 @@ HelicsFederate helicsCreateMessageFederateFromConfig(const char* configFile, Hel
 HelicsFederate helicsCreateCombinationFederate(const char* fedName, HelicsFederateInfo fi, HelicsError* err);
 HelicsFederate helicsCreateCombinationFederateFromConfig(const char* configFile, HelicsError* err);
 HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError* err);
-void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
+void helicsFederateProtect(const char* fedName, HelicsError* err);
 void helicsFederateUnProtect(const char* fedName, HelicsError* err);
+HelicsBool helicsFederateIsProtected(const char* fedName, HelicsError* err);
 HelicsFederateInfo helicsCreateFederateInfo(void);
 HelicsFederateInfo helicsFederateInfoClone(HelicsFederateInfo fi, HelicsError* err);
 void helicsFederateInfoLoadFromArgs(HelicsFederateInfo fi, int argc, const char* const* argv, HelicsError* err);
@@ -380,7 +387,9 @@ void helicsFederateEnterInitializingModeComplete(HelicsFederate fed, HelicsError
 void helicsFederateEnterExecutingMode(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeAsync(HelicsFederate fed, HelicsError* err);
 void helicsFederateEnterExecutingModeComplete(HelicsFederate fed, HelicsError* err);
-HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
+HelicsIterationResult helicsFederateEnterExecutingModeIterative(HelicsFederate fed,
+                                                                              HelicsIterationRequest iterate,
+                                                                              HelicsError* err);
 void helicsFederateEnterExecutingModeIterativeAsync(HelicsFederate fed, HelicsIterationRequest iterate, HelicsError* err);
 HelicsIterationResult helicsFederateEnterExecutingModeIterativeComplete(HelicsFederate fed, HelicsError* err);
 HelicsFederateState helicsFederateGetState(HelicsFederate fed, HelicsError* err);
@@ -389,14 +398,17 @@ HelicsTime helicsFederateRequestTime(HelicsFederate fed, HelicsTime requestTime,
 HelicsTime helicsFederateRequestTimeAdvance(HelicsFederate fed, HelicsTime timeDelta, HelicsError* err);
 HelicsTime helicsFederateRequestNextStep(HelicsFederate fed, HelicsError* err);
 HelicsTime helicsFederateRequestTimeIterative(HelicsFederate fed,
-                                              HelicsTime requestTime,
-                                              HelicsIterationRequest iterate,
-                                              HelicsIterationResult* outIteration,
-                                              HelicsError* err);
+                                                            HelicsTime requestTime,
+                                                            HelicsIterationRequest iterate,
+                                                            HelicsIterationResult* outIteration,
+                                                            HelicsError* err);
 void helicsFederateRequestTimeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsError* err);
 HelicsTime helicsFederateRequestTimeComplete(HelicsFederate fed, HelicsError* err);
-void helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
-HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed, HelicsIterationResult* outIterate, HelicsError* err);
+void
+    helicsFederateRequestTimeIterativeAsync(HelicsFederate fed, HelicsTime requestTime, HelicsIterationRequest iterate, HelicsError* err);
+HelicsTime helicsFederateRequestTimeIterativeComplete(HelicsFederate fed,
+                                                                    HelicsIterationResult* outIterate,
+                                                                    HelicsError* err);
 void helicsFederateProcessCommunications(HelicsFederate fed, HelicsTime period, HelicsError* err);
 const char* helicsFederateGetName(HelicsFederate fed);
 void helicsFederateSetTimeProperty(HelicsFederate fed, int timeProperty, HelicsTime time, HelicsError* err);
@@ -454,8 +466,10 @@ HelicsPublication
     helicsFederateRegisterGlobalPublication(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalTypePublication(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
-HelicsInput helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
-HelicsInput helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
+HelicsInput
+    helicsFederateRegisterInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
+HelicsInput
+    helicsFederateRegisterTypeInput(HelicsFederate fed, const char* key, const char* type, const char* units, HelicsError* err);
 HelicsPublication
     helicsFederateRegisterGlobalInput(HelicsFederate fed, const char* key, HelicsDataTypes type, const char* units, HelicsError* err);
 HelicsPublication
@@ -478,7 +492,8 @@ void helicsPublicationPublishTime(HelicsPublication pub, HelicsTime val, HelicsE
 void helicsPublicationPublishChar(HelicsPublication pub, char val, HelicsError* err);
 void helicsPublicationPublishComplex(HelicsPublication pub, double real, double imag, HelicsError* err);
 void helicsPublicationPublishVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
-void helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
+void
+    helicsPublicationPublishComplexVector(HelicsPublication pub, const double* vectorInput, int vectorLength, HelicsError* err);
 void helicsPublicationPublishNamedPoint(HelicsPublication pub, const char* str, double val, HelicsError* err);
 void helicsPublicationAddTarget(HelicsPublication pub, const char* target, HelicsError* err);
 HelicsBool helicsInputIsValid(HelicsInput ipt);
@@ -498,7 +513,8 @@ void helicsInputGetComplex(HelicsInput ipt, double* real, double* imag, HelicsEr
 int helicsInputGetVectorSize(HelicsInput ipt);
 void helicsInputGetVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
 void helicsInputGetComplexVector(HelicsInput ipt, double data[], int maxLength, int* actualSize, HelicsError* err);
-void helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
+void
+    helicsInputGetNamedPoint(HelicsInput ipt, char* outputString, int maxStringLength, int* actualLength, double* val, HelicsError* err);
 
 void helicsInputSetDefaultBytes(HelicsInput ipt, const void* data, int inputDataLength, HelicsError* err);
 void helicsInputSetDefaultString(HelicsInput ipt, const char* str, HelicsError* err);
@@ -544,22 +560,30 @@ int helicsFederateGetPublicationCount(HelicsFederate fed);
 int helicsFederateGetInputCount(HelicsFederate fed);
 HelicsEndpoint helicsFederateRegisterEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
 HelicsEndpoint helicsFederateRegisterGlobalEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
-HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed, const char* name, const char* type, HelicsError* err);
+HelicsEndpoint helicsFederateRegisterTargetedEndpoint(HelicsFederate fed,
+                                                                    const char* name,
+                                                                    const char* type,
+                                                                    HelicsError* err);
+HelicsEndpoint helicsFederateRegisterGlobalTargetedEndpoint(HelicsFederate fed,
+                                                                          const char* name,
+                                                                          const char* type,
+                                                                          HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpoint(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsEndpoint helicsFederateGetEndpointByIndex(HelicsFederate fed, int index, HelicsError* err);
 HelicsBool helicsEndpointIsValid(HelicsEndpoint endpoint);
 void helicsEndpointSetDefaultDestination(HelicsEndpoint endpoint, const char* dst, HelicsError* err);
 const char* helicsEndpointGetDefaultDestination(HelicsEndpoint endpoint);
 void helicsEndpointSendBytes(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsError* err);
-void helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
+void
+    helicsEndpointSendBytesTo(HelicsEndpoint endpoint, const void* data, int inputDataLength, const char* dst, HelicsError* err);
 void helicsEndpointSendBytesToAt(HelicsEndpoint endpoint,
-                                 const void* data,
-                                 int inputDataLength,
-                                 const char* dst,
-                                 HelicsTime time,
-                                 HelicsError* err);
-void helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
+                                               const void* data,
+                                               int inputDataLength,
+                                               const char* dst,
+                                               HelicsTime time,
+                                               HelicsError* err);
+void
+    helicsEndpointSendBytesAt(HelicsEndpoint endpoint, const void* data, int inputDataLength, HelicsTime time, HelicsError* err);
 void helicsEndpointSendMessage(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSendMessageZeroCopy(HelicsEndpoint endpoint, HelicsMessage message, HelicsError* err);
 void helicsEndpointSubscribe(HelicsEndpoint endpoint, const char* key, HelicsError* err);
@@ -617,7 +641,10 @@ HelicsMessage helicsMessageClone(HelicsMessage message, HelicsError* err);
 void helicsMessageFree(HelicsMessage message);
 void helicsMessageClear(HelicsMessage message, HelicsError* err);
 HelicsFilter helicsFederateRegisterFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
-HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed, HelicsFilterTypes type, const char* name, HelicsError* err);
+HelicsFilter helicsFederateRegisterGlobalFilter(HelicsFederate fed,
+                                                              HelicsFilterTypes type,
+                                                              const char* name,
+                                                              HelicsError* err);
 HelicsFilter helicsFederateRegisterCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsFederateRegisterGlobalCloningFilter(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsFilter helicsCoreRegisterFilter(HelicsCore core, HelicsFilterTypes type, const char* name, HelicsError* err);
@@ -641,9 +668,18 @@ void helicsFilterSetTag(HelicsFilter filt, const char* tagname, const char* tagv
 void helicsFilterSetOption(HelicsFilter filt, int option, int value, HelicsError* err);
 int helicsFilterGetOption(HelicsFilter filt, int option);
 
-HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
-HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed, HelicsTranslatorTypes type, const char* name, HelicsError* err);
-HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core, HelicsTranslatorTypes type, const char* name, HelicsError* err);
+HelicsTranslator helicsFederateRegisterTranslator(HelicsFederate fed,
+                                                                HelicsTranslatorTypes type,
+                                                                const char* name,
+                                                                HelicsError* err);
+HelicsTranslator helicsFederateRegisterGlobalTranslator(HelicsFederate fed,
+                                                                      HelicsTranslatorTypes type,
+                                                                      const char* name,
+                                                                      HelicsError* err);
+HelicsTranslator helicsCoreRegisterTranslator(HelicsCore core,
+                                                            HelicsTranslatorTypes type,
+                                                            const char* name,
+                                                            HelicsError* err);
 int helicsFederateGetTranslatorCount(HelicsFederate fed);
 HelicsTranslator helicsFederateGetTranslator(HelicsFederate fed, const char* name, HelicsError* err);
 HelicsTranslator helicsFederateGetTranslatorByIndex(HelicsFederate fed, int index, HelicsError* err);
@@ -664,40 +700,44 @@ void helicsTranslatorSetOption(HelicsTranslator trans, int option, int value, He
 int helicsTranslatorGetOption(HelicsTranslator trans, int option);
 
 void helicsBrokerSetLoggingCallback(HelicsBroker broker,
-                                    void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                    void* userdata,
-                                    HelicsError* err);
+                                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                                  void* userdata,
+                                                  HelicsError* err);
 void helicsCoreSetLoggingCallback(HelicsCore core,
-                                  void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                  void* userdata,
-                                  HelicsError* err);
-void helicsFederateSetLoggingCallback(HelicsFederate fed,
-                                      void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
-                                      void* userdata,
-                                      HelicsError* err);
+                                                void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                                void* userdata,
+                                                HelicsError* err);
+void
+    helicsFederateSetLoggingCallback(HelicsFederate fed,
+                                     void (*logger)(int loglevel, const char* identifier, const char* message, void* userData),
+                                     void* userdata,
+                                     HelicsError* err);
 void helicsFilterSetCustomCallback(HelicsFilter filter,
-                                   HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
+                                                 HelicsMessage (*filtCall)(HelicsMessage message, void* userData),
+                                                 void* userdata,
+                                                 HelicsError* err);
+void
+    helicsFederateSetQueryCallback(HelicsFederate fed,
+                                   void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
                                    void* userdata,
                                    HelicsError* err);
-void helicsFederateSetQueryCallback(HelicsFederate fed,
-                                    void (*queryAnswer)(const char* query, int querySize, HelicsQueryBuffer buffer, void* userdata),
-                                    void* userdata,
-                                    HelicsError* err);
 void helicsFederateSetTimeRequestEntryCallback(
     HelicsFederate fed,
     void (*requestTime)(HelicsTime currentTime, HelicsTime requestTime, HelicsBool iterating, void* userdata),
     void* userdata,
     HelicsError* err);
 void helicsFederateSetTimeUpdateCallback(HelicsFederate fed,
-                                         void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                                       void (*timeUpdate)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                                       void* userdata,
+                                                       HelicsError* err);
+void
+    helicsFederateSetStateChangeCallback(HelicsFederate fed,
+                                         void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
                                          void* userdata,
                                          HelicsError* err);
-void helicsFederateSetStateChangeCallback(HelicsFederate fed,
-                                          void (*stateChange)(HelicsFederateState newState, HelicsFederateState oldState, void* userdata),
-                                          void* userdata,
-                                          HelicsError* err);
-void helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
-                                                void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
-                                                void* userdata,
-                                                HelicsError* err);
+void
+    helicsFederateSetTimeRequestReturnCallback(HelicsFederate fed,
+                                               void (*requestTimeReturn)(HelicsTime newTime, HelicsBool iterating, void* userdata),
+                                               void* userdata,
+                                               HelicsError* err);
 void helicsQueryBufferFill(HelicsQueryBuffer buffer, const char* str, int strSize, HelicsError* err);

--- a/src/helics/shared_api_library/helicsCore.h
+++ b/src/helics/shared_api_library/helicsCore.h
@@ -595,7 +595,7 @@ HELICS_EXPORT HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError
  * @param[in,out] err An error object that will contain an error code and string if any error
  occurred during the execution of the function, in particular if no federate with the given name exists
  */
-HELICS_EXPORT void helicsFederateProtect(const char *fedName, HelicsError* err);
+HELICS_EXPORT void helicsFederateProtect(const char* fedName, HelicsError* err);
 
 /**
  * remove the protection of an existing federate

--- a/src/helics/shared_api_library/helicsCore.h
+++ b/src/helics/shared_api_library/helicsCore.h
@@ -590,12 +590,12 @@ HELICS_EXPORT HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError
  * @details this function allows a federate to be retrieved on demand, it must be explicitly close later otherwise it will be destroyed
  * when the library is closed
  *
- * @param fed An existing HelicsFederate.
+ * @param fedName The name of an existing HelicsFederate.
  *
  * @param[in,out] err An error object that will contain an error code and string if any error
- occurred during the execution of the function.
+ occurred during the execution of the function, in particular if no federate with the given name exists
  */
-HELICS_EXPORT void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
+HELICS_EXPORT void helicsFederateProtect(const char *fedName, HelicsError* err);
 
 /**
  * remove the protection of an existing federate
@@ -609,6 +609,16 @@ HELICS_EXPORT void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
  * @param[in,out] err An error object that will contain an error code and string if the federate was not found.
  */
 HELICS_EXPORT void helicsFederateUnProtect(const char* fedName, HelicsError* err);
+
+/**
+ * checks if an existing federate is protected
+ *
+ *
+ * @param fed the name of an existing federate to check the protection status
+ *
+ * @param[in,out] err An error object that will contain an error code and string if the federate was not found.
+ */
+HELICS_EXPORT HelicsBool helicsFederateIsProtected(const char* fedName, HelicsError* err);
 
 /**
  * Create a federate info object for specifying federate information when constructing a federate.

--- a/src/helics/shared_api_library/helicsCore.h
+++ b/src/helics/shared_api_library/helicsCore.h
@@ -585,6 +585,32 @@ HELICS_EXPORT HelicsFederate helicsCreateCombinationFederateFromConfig(const cha
 HELICS_EXPORT HelicsFederate helicsFederateClone(HelicsFederate fed, HelicsError* err);
 
 /**
+ * Protect a federate from finalizing and closing if all references go out of scope
+ *
+ * @details this function allows a federate to be retrieved on demand, it must be explicitly close later otherwise it will be destroyed
+ * when the library is closed
+ *
+ * @param fed An existing HelicsFederate.
+ *
+ * @param[in,out] err An error object that will contain an error code and string if any error
+ occurred during the execution of the function.
+ */
+HELICS_EXPORT void helicsFederateProtect(HelicsFederate fed, HelicsError* err);
+
+/**
+ * remove the protection of an existing federate
+ *
+ * @details this function allows a federate to be retrieved on demand, it must be explicitly close
+ later otherwise it will be destroyed
+ * when the library is closed
+ *
+ * @param fed the name of an existing federate that should not be protected
+ *
+ * @param[in,out] err An error object that will contain an error code and string if the federate was not found.
+ */
+HELICS_EXPORT void helicsFederateUnProtect(const char* fedName, HelicsError* err);
+
+/**
  * Create a federate info object for specifying federate information when constructing a federate.
  *
  * @return A HelicsFederateInfo object which is a reference to the created object.

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -1237,6 +1237,19 @@ helics::FedObject* MasterObjectHolder::findFed(std::string_view fedName)
     return nullptr;
 }
 
+helics::FedObject* MasterObjectHolder::findFed(std::string_view fedName, int validationCode)
+{
+    auto handle = feds.lock();
+    for (auto& fed : (*handle)) {
+        if ((fed) && (fed->fedptr)) {
+            if (fed->valid == validationCode && fed->fedptr->getName() == fedName) {
+                return fed.get();
+            }
+        }
+    }
+    return nullptr;
+}
+
 /** remove a federate object*/
 bool MasterObjectHolder::removeFed(std::string_view fedName, int validationCode)
 {

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -1241,17 +1241,18 @@ helics::FedObject* MasterObjectHolder::findFed(std::string_view fedName)
 bool MasterObjectHolder::removeFed(std::string_view fedName, int validationCode)
 {
     auto handle = feds.lock();
+    bool found{false};
     for (auto& fed : (*handle)) {
         if ((fed) && (fed->fedptr)) {
             if (fed->fedptr->getName() == fedName && fed->valid == validationCode) {
                 fed->valid = 0;
                 fed->fedptr.reset();
                 fed.reset();
-                return true;
+                found = true;
             }
         }
     }
-    return false;
+    return found;
 }
 
 void MasterObjectHolder::clearBroker(int index)

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -1238,11 +1238,12 @@ helics::FedObject* MasterObjectHolder::findFed(std::string_view fedName)
 }
 
 /** remove a federate object*/
-bool MasterObjectHolder::removeFed(std::string_view fedName, int validationCode) {
+bool MasterObjectHolder::removeFed(std::string_view fedName, int validationCode)
+{
     auto handle = feds.lock();
     for (auto& fed : (*handle)) {
         if ((fed) && (fed->fedptr)) {
-            if (fed->fedptr->getName() == fedName && fed->valid==validationCode) {
+            if (fed->fedptr->getName() == fedName && fed->valid == validationCode) {
                 fed->valid = 0;
                 fed->fedptr.reset();
                 fed.reset();

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -51,7 +51,7 @@ const char* helicsGetSystemInfo(void)
 
 static constexpr const char* nullstrPtr = "";
 
-const std::string gEmptyStr;
+const std::string gHelicsEmptyStr;
 
 HelicsError helicsErrorInitialize(void)
 {

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -234,6 +234,8 @@ class MasterObjectHolder {
     MasterObjectHolder() noexcept;
     ~MasterObjectHolder();
     helics::FedObject* findFed(std::string_view fedName);
+    /** find a specific fed by name and validation code*/
+    helics::FedObject* findFed(std::string_view fedName, int validationCode);
     /** add a broker to the holder*/
     int addBroker(std::unique_ptr<helics::BrokerObject> broker);
     /** add a core to the holder*/

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -193,7 +193,7 @@ extern const std::string gHelicsNullStringArgument;
 #define CHECK_NULL_STRING(str, retval)                                                                                                     \
     do {                                                                                                                                   \
         if ((str) == nullptr) {                                                                                                            \
-            assignError(err, HELICS_ERROR_INVALID_ARGUMENT, gHelicsNullStringArgument.c_str());                                                  \
+            assignError(err, HELICS_ERROR_INVALID_ARGUMENT, gHelicsNullStringArgument.c_str());                                            \
             return (retval);                                                                                                               \
         }                                                                                                                                  \
     } while (false)

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -16,9 +16,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
-#include <string_view>
 
 /** this is a random identifier put in place when the federate or core or broker gets created*/
 static constexpr int gCoreValidationIdentifier = 0x378424EC;

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -18,10 +18,11 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <string>
 #include <utility>
 #include <vector>
+#include <string_view>
 
 /** this is a random identifier put in place when the federate or core or broker gets created*/
-static const int gCoreValidationIdentifier = 0x378424EC;
-static const int gBrokerValidationIdentifier = 0xA3467D20;
+static constexpr int gCoreValidationIdentifier = 0x378424EC;
+static constexpr int gBrokerValidationIdentifier = 0xA3467D20;
 
 namespace helics {
 class Core;
@@ -232,21 +233,23 @@ class MasterObjectHolder {
   public:
     MasterObjectHolder() noexcept;
     ~MasterObjectHolder();
-    helics::FedObject* findFed(const std::string& fedName);
+    helics::FedObject* findFed(std::string_view fedName);
     /** add a broker to the holder*/
     int addBroker(std::unique_ptr<helics::BrokerObject> broker);
     /** add a core to the holder*/
     int addCore(std::unique_ptr<helics::CoreObject> core);
     /** add a federate to the holder*/
     int addFed(std::unique_ptr<helics::FedObject> fed);
+    /** remove a federate object*/
+    bool removeFed(std::string_view name, int validationCode);
     void clearBroker(int index);
     void clearCore(int index);
     void clearFed(int index);
     void deleteAll();
-    void abortAll(int errorCode, const std::string& error);
+    void abortAll(int errorCode, std::string_view error);
     /** store an error string to a string buffer
     @return a pointer to the memory location*/
-    const char* addErrorString(std::string newError);
+    const char* addErrorString(std::string_view newError);
 };
 
 std::shared_ptr<MasterObjectHolder> getMasterHolder();

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -184,16 +184,16 @@ inline void assignError(HelicsError* err, int error_code, const char* string)
     }
 }
 
-extern const std::string gEmptyStr;
-extern const std::string gNullStringArgument;
-#define AS_STRING(str) ((str) != nullptr) ? std::string(str) : gEmptyStr
+extern const std::string gHelicsEmptyStr;
+extern const std::string gHelicsNullStringArgument;
+#define AS_STRING(str) ((str) != nullptr) ? std::string(str) : gHelicsEmptyStr
 
-#define AS_STRING_VIEW(str) ((str) != nullptr) ? std::string_view(str) : std::string_view(gEmptyStr)
+#define AS_STRING_VIEW(str) ((str) != nullptr) ? std::string_view(str) : std::string_view(gHelicsEmptyStr)
 
 #define CHECK_NULL_STRING(str, retval)                                                                                                     \
     do {                                                                                                                                   \
         if ((str) == nullptr) {                                                                                                            \
-            assignError(err, HELICS_ERROR_INVALID_ARGUMENT, gNullStringArgument.c_str());                                                  \
+            assignError(err, HELICS_ERROR_INVALID_ARGUMENT, gHelicsNullStringArgument.c_str());                                                  \
             return (retval);                                                                                                               \
         }                                                                                                                                  \
     } while (false)

--- a/tests/helics/shared_library/SystemTests.cpp
+++ b/tests/helics/shared_library/SystemTests.cpp
@@ -480,9 +480,12 @@ TEST(federate, federateNoProtection)
     helicsFederateEnterExecutingMode(fed1, nullptr);
 
     std::string fed1Nm = helicsFederateGetName(fed1);
-
-    helicsFederateFree(fed1);
     HelicsError err = helicsErrorInitialize();
+
+
+    EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
+    helicsFederateFree(fed1);
+    
     auto fedFind = helicsGetFederateByName(fed1Nm.c_str(), &err);
 
     EXPECT_FALSE(helicsFederateIsValid(fedFind));
@@ -502,14 +505,22 @@ TEST(federate, federateProtection)
 
     std::string fed1Nm = helicsFederateGetName(fed1);
     HelicsError err = helicsErrorInitialize();
-    helicsFederateProtect(fed1, &err);
+    helicsFederateProtect(fed1Nm.c_str(), &err);
     helicsFederateFree(fed1);
 
+    EXPECT_TRUE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
     auto fedFind = helicsGetFederateByName(fed1Nm.c_str(), &err);
 
     EXPECT_TRUE(helicsFederateIsValid(fedFind));
     EXPECT_EQ(err.error_code, 0);
-
+    
+    helicsFederateUnProtect(fed1Nm.c_str(), &err);
+    EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
     helicsFederateFinalize(fedFind, &err);
     helicsFederateFree(fedFind);
+    EXPECT_EQ(err.error_code, 0);
+
+     EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
+    EXPECT_NE(err.error_code, 0);
+    
 }

--- a/tests/helics/shared_library/SystemTests.cpp
+++ b/tests/helics/shared_library/SystemTests.cpp
@@ -300,7 +300,7 @@ TEST(other_tests, broker_creation)
     helicsBrokerDisconnect(brk, &err);
 }
 
-TEST(federate_tests, federateGeneratedLocalError)
+TEST(federate, federateGeneratedLocalError)
 {
     auto fi = helicsCreateFederateInfo();
     helicsFederateInfoSetCoreType(fi, HELICS_CORE_TYPE_TEST, nullptr);
@@ -324,7 +324,7 @@ TEST(federate_tests, federateGeneratedLocalError)
     helicsFederateDestroy(fed1);
 }
 
-TEST(federate_tests, federateGeneratedGlobalError)
+TEST(federate, federateGeneratedGlobalError)
 {
     auto fi = helicsCreateFederateInfo();
     helicsFederateInfoSetCoreType(fi, HELICS_CORE_TYPE_TEST, nullptr);
@@ -466,4 +466,52 @@ TEST(other_tests, signal_handler_fed_construction_death_ci_skip)
     helicsClearSignalHandler();
     helicsCleanupLibrary();
     helicsCloseLibrary();
+}
+
+
+TEST(federate, federateNoProtection)
+{
+    auto fi = helicsCreateFederateInfo();
+    helicsFederateInfoSetCoreType(fi, HELICS_CORE_TYPE_TEST, nullptr);
+    helicsFederateInfoSetCoreName(fi, "core_protect", nullptr);
+    helicsFederateInfoSetCoreInitString(fi, "-f 1 --autobroker --error_timeout=0", nullptr);
+
+    auto fed1 = helicsCreateValueFederate("fed1", fi, nullptr);
+    
+    helicsFederateEnterExecutingMode(fed1, nullptr);
+
+    std::string fed1Nm = helicsFederateGetName(fed1);
+
+    helicsFederateFree(fed1);
+    HelicsError err = helicsErrorInitialize();
+    auto fedFind = helicsGetFederateByName(fed1Nm.c_str(), &err);
+
+    EXPECT_FALSE(helicsFederateIsValid(fedFind));
+    EXPECT_NE(err.error_code, 0);
+
+}
+
+TEST(federate, federateProtection)
+{
+    auto fi = helicsCreateFederateInfo();
+    helicsFederateInfoSetCoreType(fi, HELICS_CORE_TYPE_TEST, nullptr);
+    helicsFederateInfoSetCoreName(fi, "core_protect", nullptr);
+    helicsFederateInfoSetCoreInitString(fi, "-f 1 --autobroker --error_timeout=0", nullptr);
+
+    auto fed1 = helicsCreateValueFederate("fed1", fi, nullptr);
+
+    helicsFederateEnterExecutingMode(fed1, nullptr);
+
+    std::string fed1Nm = helicsFederateGetName(fed1);
+    HelicsError err = helicsErrorInitialize();
+    helicsFederateProtect(fed1, &err);
+    helicsFederateFree(fed1);
+    
+    auto fedFind = helicsGetFederateByName(fed1Nm.c_str(), &err);
+
+    EXPECT_TRUE(helicsFederateIsValid(fedFind));
+    EXPECT_EQ(err.error_code, 0);
+
+    helicsFederateFinalize(fedFind,&err);
+    helicsFederateFree(fedFind);
 }

--- a/tests/helics/shared_library/SystemTests.cpp
+++ b/tests/helics/shared_library/SystemTests.cpp
@@ -482,10 +482,9 @@ TEST(federate, federateNoProtection)
     std::string fed1Nm = helicsFederateGetName(fed1);
     HelicsError err = helicsErrorInitialize();
 
-
     EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
     helicsFederateFree(fed1);
-    
+
     auto fedFind = helicsGetFederateByName(fed1Nm.c_str(), &err);
 
     EXPECT_FALSE(helicsFederateIsValid(fedFind));
@@ -513,14 +512,13 @@ TEST(federate, federateProtection)
 
     EXPECT_TRUE(helicsFederateIsValid(fedFind));
     EXPECT_EQ(err.error_code, 0);
-    
+
     helicsFederateUnProtect(fed1Nm.c_str(), &err);
     EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
     helicsFederateFinalize(fedFind, &err);
     helicsFederateFree(fedFind);
     EXPECT_EQ(err.error_code, 0);
 
-     EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
+    EXPECT_FALSE(helicsFederateIsProtected(fed1Nm.c_str(), &err));
     EXPECT_NE(err.error_code, 0);
-    
 }

--- a/tests/helics/shared_library/SystemTests.cpp
+++ b/tests/helics/shared_library/SystemTests.cpp
@@ -468,7 +468,6 @@ TEST(other_tests, signal_handler_fed_construction_death_ci_skip)
     helicsCloseLibrary();
 }
 
-
 TEST(federate, federateNoProtection)
 {
     auto fi = helicsCreateFederateInfo();
@@ -477,7 +476,7 @@ TEST(federate, federateNoProtection)
     helicsFederateInfoSetCoreInitString(fi, "-f 1 --autobroker --error_timeout=0", nullptr);
 
     auto fed1 = helicsCreateValueFederate("fed1", fi, nullptr);
-    
+
     helicsFederateEnterExecutingMode(fed1, nullptr);
 
     std::string fed1Nm = helicsFederateGetName(fed1);
@@ -488,7 +487,6 @@ TEST(federate, federateNoProtection)
 
     EXPECT_FALSE(helicsFederateIsValid(fedFind));
     EXPECT_NE(err.error_code, 0);
-
 }
 
 TEST(federate, federateProtection)
@@ -506,12 +504,12 @@ TEST(federate, federateProtection)
     HelicsError err = helicsErrorInitialize();
     helicsFederateProtect(fed1, &err);
     helicsFederateFree(fed1);
-    
+
     auto fedFind = helicsGetFederateByName(fed1Nm.c_str(), &err);
 
     EXPECT_TRUE(helicsFederateIsValid(fedFind));
     EXPECT_EQ(err.error_code, 0);
 
-    helicsFederateFinalize(fedFind,&err);
+    helicsFederateFinalize(fedFind, &err);
     helicsFederateFree(fedFind);
 }


### PR DESCRIPTION
so federates can be found later if freed but not destroyed

<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will add helicsFederateProtect and helicsFederateUnProtect

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
