### PR TITLE
bug fix on iteration, enter executing mode, and wait for current time flag

### DIFF
--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -1041,7 +1041,12 @@ MessageProcessingResult TimeCoordinator::checkExecEntry(GlobalFederateId trigger
                     ret = (iterating == IterationRequest::FORCE_ITERATION) ?
                         MessageProcessingResult::ITERATING :
                         MessageProcessingResult::NEXT_STEP;
+                } else if (info.wait_for_current_time_updates && dependencies.checkAllPastExec(true)) {
+                    ret = (iterating == IterationRequest::FORCE_ITERATION) ?
+                        MessageProcessingResult::ITERATING :
+                        MessageProcessingResult::NEXT_STEP;
                 } else {
+
                     bool allowed{!info.wait_for_current_time_updates};
                     bool restricted{info.restrictive_time_policy};
                     bool restrictionAdvance{restricted};

--- a/src/helics/core/TimeCoordinator.cpp
+++ b/src/helics/core/TimeCoordinator.cpp
@@ -1036,17 +1036,13 @@ MessageProcessingResult TimeCoordinator::checkExecEntry(GlobalFederateId trigger
             if (hasInitUpdates) {
                 ret = MessageProcessingResult::ITERATING;
             } else {
-                if (dependencies.checkIfReadyForExecEntry(false,
-                                                          info.wait_for_current_time_updates)) {
-                    ret = (iterating == IterationRequest::FORCE_ITERATION) ?
-                        MessageProcessingResult::ITERATING :
-                        MessageProcessingResult::NEXT_STEP;
-                } else if (info.wait_for_current_time_updates && dependencies.checkAllPastExec(true)) {
+                if ((dependencies.checkIfReadyForExecEntry(false,
+                                                           info.wait_for_current_time_updates)) ||
+                    (info.wait_for_current_time_updates && dependencies.checkAllPastExec(true))) {
                     ret = (iterating == IterationRequest::FORCE_ITERATION) ?
                         MessageProcessingResult::ITERATING :
                         MessageProcessingResult::NEXT_STEP;
                 } else {
-
                     bool allowed{!info.wait_for_current_time_updates};
                     bool restricted{info.restrictive_time_policy};
                     bool restrictionAdvance{restricted};

--- a/src/helics/core/TimeDependencies.cpp
+++ b/src/helics/core/TimeDependencies.cpp
@@ -444,10 +444,10 @@ bool TimeDependencies::checkAllPastExec(bool iterating) const
     auto minstate =
         iterating ? TimeState::time_requested_require_iteration : TimeState::time_requested;
 
-        return std::none_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
-            return (dep.dependency && dep.connection != ConnectionType::self &&
-                    (dep.mTimeState < minstate));
-        });
+    return std::none_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
+        return (dep.dependency && dep.connection != ConnectionType::self &&
+                (dep.mTimeState < minstate));
+    });
 }
 
 bool TimeDependencies::checkIfReadyForExecEntry(bool iterating, bool waiting) const

--- a/src/helics/core/TimeDependencies.hpp
+++ b/src/helics/core/TimeDependencies.hpp
@@ -172,7 +172,8 @@ class TimeDependencies {
 
     /** check if the dependencies would allow entry to exec mode*/
     bool checkIfReadyForExecEntry(bool iterating, bool waiting) const;
-
+    /** check if all dependencies have passed exec mode and are requesting time*/
+    bool checkAllPastExec(bool iterating) const;
     /** check if the dependencies would allow a grant of the time
     @param iterating true if the object is iterating
     @param desiredGrantTime  the time to check for granting

--- a/tests/helics/system_tests/iterationTests.cpp
+++ b/tests/helics/system_tests/iterationTests.cpp
@@ -825,7 +825,7 @@ TEST_F(iteration, wait_for_current_time_iterative_enter_exec_endpoint_iterating_
     it = vFed1->enterExecutingModeComplete();
     EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
     EXPECT_FALSE(epid1.hasMessage());
-    vFed1->requestTimeIterativeAsync(1.0,ITERATE_IF_NEEDED);
+    vFed1->requestTimeIterativeAsync(1.0, ITERATE_IF_NEEDED);
     it = vFed2->enterExecutingModeComplete();
     EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
 
@@ -836,7 +836,6 @@ TEST_F(iteration, wait_for_current_time_iterative_enter_exec_endpoint_iterating_
     broker.reset();
     vFed1->finalize();
 }
-
 
 TEST_F(iteration, wait_for_current_time_iterative_enter_exec_iterating_time_request)
 {
@@ -884,7 +883,7 @@ TEST_F(iteration, wait_for_current_time_iterative_enter_exec_iterating_time_requ
     it = vFed1->enterExecutingModeComplete();
     EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
     EXPECT_EQ(sub1_1.getValue<int>(), 31);
-    vFed1->requestTimeIterativeAsync(1.0,ITERATE_IF_NEEDED);
+    vFed1->requestTimeIterativeAsync(1.0, ITERATE_IF_NEEDED);
     it = vFed2->enterExecutingModeComplete();
     EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
 

--- a/tests/helics/system_tests/iterationTests.cpp
+++ b/tests/helics/system_tests/iterationTests.cpp
@@ -769,3 +769,129 @@ TEST_F(iteration, wait_for_current_time_iterative_enter_exec_endpoint)
     broker.reset();
     vFed1->finalize();
 }
+
+TEST_F(iteration, wait_for_current_time_iterative_enter_exec_endpoint_iterating_time_request)
+{
+    auto broker = AddBroker("test", 2);
+    AddFederates<helics::MessageFederate>("test", 1, broker, 1.0);
+    AddFederates<helics::MessageFederate>("test", 1, broker, 1.0);
+
+    auto vFed1 = GetFederateAs<helics::MessageFederate>(0);
+    auto vFed2 = GetFederateAs<helics::MessageFederate>(1);
+    vFed2->setFlagOption(helics::defs::WAIT_FOR_CURRENT_TIME_UPDATE);
+
+    auto& epid1 = vFed1->registerGlobalEndpoint("ep1");
+
+    auto& epid2 = vFed2->registerGlobalEndpoint("ep2");
+
+    vFed2->enterInitializingModeAsync();
+    vFed1->enterInitializingMode();
+
+    epid1.sendTo("test_5", "ep2");
+
+    vFed1->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+
+    vFed2->enterInitializingModeComplete();
+    vFed2->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+    for (int ii = 0; ii < 5; ++ii) {
+        auto it = vFed2->enterExecutingModeComplete();
+        EXPECT_EQ(it, helics::IterationResult::ITERATING);
+        EXPECT_TRUE(epid2.hasMessage());
+        if (epid2.hasMessage()) {
+            EXPECT_EQ(epid2.getMessage()->data.to_string(), "test_" + std::to_string(ii + 5));
+        }
+
+        epid2.sendTo("test_" + std::to_string(ii + 27), "ep1");
+
+        vFed2->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+        it = vFed1->enterExecutingModeComplete();
+        EXPECT_EQ(it, helics::IterationResult::ITERATING);
+        EXPECT_TRUE(epid1.hasMessage());
+        if (epid1.hasMessage()) {
+            EXPECT_EQ(epid1.getMessage()->data.to_string(), "test_" + std::to_string(ii + 27));
+        }
+
+        epid1.sendTo("test_" + std::to_string(ii + 6), "ep2");
+        vFed1->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+    }
+    auto it = vFed2->enterExecutingModeComplete();
+    EXPECT_EQ(it, helics::IterationResult::ITERATING);
+    EXPECT_TRUE(epid2.hasMessage());
+    if (epid2.hasMessage()) {
+        EXPECT_EQ(epid2.getMessage()->data.to_string(), "test_10");
+    }
+
+    vFed2->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+    it = vFed1->enterExecutingModeComplete();
+    EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
+    EXPECT_FALSE(epid1.hasMessage());
+    vFed1->requestTimeIterativeAsync(1.0,ITERATE_IF_NEEDED);
+    it = vFed2->enterExecutingModeComplete();
+    EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
+
+    vFed2->finalize();
+    auto tmi = vFed1->requestTimeIterativeComplete();
+    EXPECT_EQ(tmi.grantedTime, 1.0);
+    EXPECT_EQ(tmi.state, helics::IterationResult::NEXT_STEP);
+    broker.reset();
+    vFed1->finalize();
+}
+
+
+TEST_F(iteration, wait_for_current_time_iterative_enter_exec_iterating_time_request)
+{
+    auto broker = AddBroker("test", 2);
+    AddFederates<helics::ValueFederate>("test", 1, broker, 1.0);
+    AddFederates<helics::ValueFederate>("test", 1, broker, 1.0);
+
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate>(1);
+    vFed2->setFlagOption(helics::defs::WAIT_FOR_CURRENT_TIME_UPDATE);
+
+    auto& pub1_1 = vFed1->registerGlobalPublication<int>("pub1_1");
+    auto& sub1_1 = vFed1->registerSubscription("pub2_1");
+
+    auto& pub2_1 = vFed2->registerGlobalPublication<int>("pub2_1");
+
+    auto& sub2_1 = vFed2->registerSubscription("pub1_1");
+    sub2_1.setDefault(-6);
+    sub1_1.setDefault(-28);
+    vFed2->enterInitializingModeAsync();
+    vFed1->enterInitializingMode();
+
+    pub1_1.publish(4);
+
+    vFed1->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+
+    vFed2->enterInitializingModeComplete();
+    vFed2->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+    for (int ii = 0; ii < 5; ++ii) {
+        auto it = vFed2->enterExecutingModeComplete();
+        EXPECT_EQ(it, helics::IterationResult::ITERATING);
+        EXPECT_EQ(sub2_1.getValue<int>(), ii + 4);
+        pub2_1.publish(ii + 27);
+        vFed2->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+        it = vFed1->enterExecutingModeComplete();
+        EXPECT_EQ(it, helics::IterationResult::ITERATING);
+        EXPECT_EQ(sub1_1.getValue<int>(), ii + 27);
+        pub1_1.publish(ii + 5);
+        vFed1->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+    }
+    auto it = vFed2->enterExecutingModeComplete();
+    EXPECT_EQ(it, helics::IterationResult::ITERATING);
+    EXPECT_EQ(sub2_1.getValue<int>(), 9);
+    vFed2->enterExecutingModeAsync(ITERATE_IF_NEEDED);
+    it = vFed1->enterExecutingModeComplete();
+    EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
+    EXPECT_EQ(sub1_1.getValue<int>(), 31);
+    vFed1->requestTimeIterativeAsync(1.0,ITERATE_IF_NEEDED);
+    it = vFed2->enterExecutingModeComplete();
+    EXPECT_EQ(it, helics::IterationResult::NEXT_STEP);
+
+    vFed2->finalize();
+    auto tm = vFed1->requestTimeIterativeComplete();
+    EXPECT_EQ(tm.grantedTime, 1.0);
+    EXPECT_EQ(tm.state, helics::IterationResult::NEXT_STEP);
+    broker.reset();
+    vFed1->finalize();
+}


### PR DESCRIPTION
Fix a bug when moving to executing mode with wait for current time flag and other federates are requesting iteration at time 0.

Address at least part of the remaining issues with #2342.