### PR TITLE
Fetch submodules using actions/checkout for scheduled Code Coverage build

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Checkout develop branch
       uses: actions/checkout@v3
       with:
+        submodules: true
         ref: develop
       if: github.event_name == 'schedule'
 


### PR DESCRIPTION
Fixes the errors when fetching submodules using CMake for the nightly Code Coverage build about a different user owning the repository by having the checkout action clone submodules.