### PR TITLE
Increase minimum macOS target version to 10.15

### DIFF
--- a/.github/actions/setup-macos-sdk.sh
+++ b/.github/actions/setup-macos-sdk.sh
@@ -4,7 +4,7 @@ XCODE_MACOS_PLATFORM_PATH="/Applications/Xcode.app/Contents/Developer/Platforms/
 XCODE_MACOS_SDK_PATH="${XCODE_MACOS_PLATFORM_PATH}/Developer/SDKs"
 
 if [[ -z "${MACOS_SDK_VER}" ]]; then
-    MACOS_SDK_VER=10.14
+    MACOS_SDK_VER=10.15
 fi
 
 # Download macOS SDK

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -168,7 +168,7 @@ jobs:
             os: macos-latest
             arch: x64
             cpack_gen: ZIP
-            macos_target_ver: '10.14'
+            macos_target_ver: '10.15'
           - id: linux-x64
             os: ubuntu-latest
             arch: x64
@@ -268,7 +268,7 @@ jobs:
           - id: macos-x64
             os: macos-latest
             arch: x64
-            macos_target_ver: '10.14'
+            macos_target_ver: '10.15'
           - id: ubuntu-x64
             os: ubuntu-latest
             arch: x64


### PR DESCRIPTION
Removing ghc::filesystem has made the minimum required version of macOS 10.15 due to functions not provided in std::filesystem until 10.15 or later.
