### PR TITLE
Change macOS Azure CI images to XCode 13 on macOS 12 and XCode 11 on macOS 11

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -62,11 +62,11 @@ jobs:
       matrix:
         XCode-latest:
           test_config: 'ci'
-          vmImage: 'macOS-latest'
+          vmImage: 'macOS-12'
         XCode-oldest:
           test_config: 'ci'
-          vmImage: 'macOS-10.15'
-          xcode_path: '/Applications/Xcode_11.2.1.app'
+          vmImage: 'macOS-11'
+          xcode_path: '/Applications/Xcode_11.7.app'
     pool:
       vmImage: $[ variables['vmImage'] ]
     timeoutInMinutes: 60


### PR DESCRIPTION
### Summary

If merged this pull request will update the macOS versions used for Azure CI tests. Closes #2404.

### Proposed changes

- Change newest macOS build to XCode 13 on macOS 12
- Change oldest macOS build to XCode 11 on macOS 11
