### PR TITLE
Add encryption feature to vcpkg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/
 docs/html
 docs/xml
 docs/latex
+vcpkg_installed/
 
 #=============================================================================
 # Generic ignores

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,6 +481,17 @@ if(HELICS_BUILD_CONFIGURATION STREQUAL "PI")
     target_link_libraries(helics_base INTERFACE atomic)
 endif()
 
+# Add to list of enabled vcpkg features based on core type
+if(HELICS_ENABLE_ZMQ_CORE)
+    list(APPEND VCPKG_MANIFEST_FEATURES "zeromq")
+endif()
+if(HELICS_ENABLE_IPC_CORE)
+    list(APPEND VCPKG_MANIFEST_FEATURES "ipc")
+endif()
+if(HELICS_ENABLE_MPI_CORE)
+    list(APPEND VCPKG_MANIFEST_FEATURES "mpi")
+endif()
+
 # -------------------------------------------------------------
 # finding MPI
 # -------------------------------------------------------------
@@ -720,6 +731,7 @@ set(GMLC_NETWORKING_CONCURRENCY_INCLUDE ${PROJECT_SOURCE_DIR}/ThirdParty/concurr
 set(GMLC_NETWORKING_DISABLE_ASIO ${HELICS_DISABLE_ASIO} CACHE INTERNAL "")
 
 if(HELICS_ENABLE_ENCRYPTION)
+    list(APPEND VCPKG_MANIFEST_FEATURES "encryption")
     set(GMLC_NETWORKING_ENABLE_ENCRYPTION ON CACHE INTERNAL "")
 else()
     set(GMLC_NETWORKING_ENABLE_ENCRYPTION OFF CACHE INTERNAL "")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "3.3.0",
   "description": "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)",
   "homepage": "https://helics.org/",
-  "default-features": ["zeromq", "ipc", "webserver"],
+  "default-features": ["zeromq", "ipc", "webserver", "encryption"],
   "dependencies": ["boost-core", "boost-spirit"],
   "features": {
     "zeromq": {
@@ -26,6 +26,10 @@
     "webserver": {
       "description": "Build webserver in broker_server",
       "dependencies": ["boost-beast", "boost-uuid"]
+    },
+    "encryption": {
+      "description": "Enable encryption using OpenSSL",
+      "dependencies": ["openssl"]
     }
   }
 }


### PR DESCRIPTION
### Summary

If merged this pull request will add the encryption feature to the vcpkg.json file that adds openssl as a dependency to install, along with a few other vcpkg related tweaks.

### Proposed changes

- Add encryption feature to vcpkg.json for installing OpenSSL
- Add `vcpkg_installed/` directory to `.gitignore` (local cache of compiled copies of all dependencies built by vcpkg, both debug and release variants by default)
- Set `VCPKG_MANIFEST_FEATURES` variable based on CMake options used; if vcpkg isn't getting used, this variable will just be ignored