### PR TITLE
Change macOS Azure CI images to XCode 13 on macOS 12 and XCode 11 on macOS 11

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -63,11 +63,11 @@ jobs:
       matrix:
         XCode-latest:
           test_config: 'ci'
-          vmImage: 'macOS-latest'
+          vmImage: 'macOS-12'
         XCode-oldest:
           test_config: 'ci'
-          vmImage: 'macOS-10.15'
-          xcode_path: '/Applications/Xcode_10.3.app'
+          vmImage: 'macOS-11'
+          xcode_path: '/Applications/Xcode_11.7.app'
     pool:
       vmImage: $[ variables['vmImage'] ]
     timeoutInMinutes: 90


### PR DESCRIPTION
### Summary

Same as #2416, but for `main` instead of `develop` branch if we don't get a 3.3 release out before the end of the month. If merged this pull request will update the macOS versions used for Azure CI tests. Closes #2404.

### Proposed changes

- Change newest macOS build to XCode 13 on macOS 12
- Change oldest macOS build to XCode 11 on macOS 11
