### PR TITLE
Disable arm32 builds on Drone Cloud

### DIFF
--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -1,47 +1,47 @@
-kind: pipeline
-name: arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-  - name: uname
-    image: alpine:3.12
-    commands:
-      - uname -a
-
-  - name: submodules
-    image: alpine:3.12
-    commands:
-      # for updating submodules to latest upstream, add --remote
-      - apk add --no-cache git
-      - git submodule update --init --recursive
-
-  - name: build
-    image: alpine:3.12
-    commands:
-      - apk update
-      - apk add --no-cache build-base git bash cmake ninja boost-dev zeromq-dev
-      - gcc --version || echo "gcc not installed"
-      - clang --version || echo "clang not installed"
-      - cmake --version
-      - git --version
-      - mkdir build && cd build
-      - cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
-      - cmake --build .
-      - ctest -L Continuous --output-on-failure
-
-trigger:
-  ref:
-    include:
-      - refs/heads/main
-      - refs/heads/develop
-      - refs/heads/helics2
-      - 'refs/pull/**'
-      - 'refs/tags/**'
-
----
+#kind: pipeline
+#name: arm
+#
+#platform:
+#  os: linux
+#  arch: arm
+#
+#steps:
+#  - name: uname
+#    image: alpine:3.12
+#    commands:
+#      - uname -a
+#
+#  - name: submodules
+#    image: alpine:3.12
+#    commands:
+#      # for updating submodules to latest upstream, add --remote
+#      - apk add --no-cache git
+#      - git submodule update --init --recursive
+#
+#  - name: build
+#    image: alpine:3.12
+#    commands:
+#      - apk update
+#      - apk add --no-cache build-base git bash cmake ninja boost-dev zeromq-dev
+#      - gcc --version || echo "gcc not installed"
+#      - clang --version || echo "clang not installed"
+#      - cmake --version
+#      - git --version
+#      - mkdir build && cd build
+#      - cmake -GNinja -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON ..
+#      - cmake --build .
+#      - ctest -L Continuous --output-on-failure
+#
+#trigger:
+#  ref:
+#    include:
+#      - refs/heads/main
+#      - refs/heads/develop
+#      - refs/heads/helics2
+#      - 'refs/pull/**'
+#      - 'refs/tags/**'
+#
+#---
 kind: pipeline
 name: arm64
 


### PR DESCRIPTION
### Summary

If merged this pull request will disable the arm32 builds on Drone Cloud -- they no longer have arm32 servers, unknown if they'll be able to find a replacement: https://community.harness.io/t/drone-cloud-arm-builds-step-stuck-pending-forever/12437/3

### Proposed changes

- Disable arm32 pipeline for Drone Cloud configuration