### PR TITLE
Disable VCPKG_ROOT in GHA and Azure builds

### DIFF
--- a/.ci/azure-pipelines-daily.yml
+++ b/.ci/azure-pipelines-daily.yml
@@ -25,6 +25,7 @@ jobs:
 
     steps:
       - bash: |
+          unset VCPKG_ROOT
           source scripts/setup-helics-ci-options.sh
           mkdir -p build && cd build
           ../scripts/ci-build.sh
@@ -87,7 +88,7 @@ jobs:
         displayName: Show environment info
       - task: CMake@1
         inputs:
-          cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON $(extraFlags) ..
+          cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON -DHELICS_DISABLE_VCPKG=ON $(extraFlags) ..
         displayName: 'Configure HELICS'
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
 

--- a/.ci/azure-pipelines-daily.yml
+++ b/.ci/azure-pipelines-daily.yml
@@ -137,8 +137,4 @@ jobs:
         displayName: 'Test HELICS packaging'
         workingDirectory: build
 
-      - task: PublishBuildArtifacts@1
-        condition: failed()
-        inputs:
-          pathtoPublish: '$(Build.SourcesDirectory)/build'
-          artifactName: buildDirContents
+      # For debugging, can get build folder contents by adding PublishBuildArtifacts task and set pathtoPublish: '$(Build.SourcesDirectory)/build'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -38,6 +38,7 @@ jobs:
 
     steps:
       - bash: |
+          unset VCPKG_ROOT
           source scripts/setup-helics-ci-options.sh
           mkdir -p build && cd build
           ../scripts/ci-build.sh
@@ -81,6 +82,7 @@ jobs:
           brew install swig zeromq boost
         displayName: 'Install dependencies'
       - bash: |
+          unset VCPKG_ROOT
           source scripts/setup-helics-ci-options.sh
           mkdir -p build && cd build
           ../scripts/ci-build.sh
@@ -153,7 +155,7 @@ jobs:
         displayName: Show environment info
       - task: CMake@1
         inputs:
-          cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON $(extraFlags) ..
+          cmakeArgs: -A $(vsArch) -DHELICS_ENABLE_SWIG=ON -DHELICS_BUILD_CXX_SHARED_LIB=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_TESTS=ON -DHELICS_BUILD_EXAMPLES=ON -DHELICS_DISABLE_VCPKG=ON $(extraFlags) ..
         displayName: 'Configure HELICS'
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
 

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -205,8 +205,4 @@ jobs:
         displayName: 'Test HELICS packaging'
         workingDirectory: build
 
-      - task: PublishBuildArtifacts@1
-        condition: failed()
-        inputs:
-          pathtoPublish: '$(Build.SourcesDirectory)/build'
-          artifactName: buildDirContents
+      # For debugging, can get build folder contents by adding PublishBuildArtifacts task and set pathtoPublish: '$(Build.SourcesDirectory)/build'

--- a/.github/actions/benchmark-build/benchmark-Linux.sh
+++ b/.github/actions/benchmark-build/benchmark-Linux.sh
@@ -6,6 +6,9 @@
 #sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
 #rm cmake-install.sh
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release

--- a/.github/actions/benchmark-build/benchmark-Windows.sh
+++ b/.github/actions/benchmark-build/benchmark-Windows.sh
@@ -4,6 +4,9 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 # Install Boost
 COMMON_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../common/Windows" && pwd)"
 # shellcheck source=.github/actions/common/Windows/install-boost.sh

--- a/.github/actions/benchmark-build/benchmark-macOS.sh
+++ b/.github/actions/benchmark-build/benchmark-macOS.sh
@@ -2,6 +2,9 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 brew install boost
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..

--- a/.github/actions/release-build/installer-Linux.sh
+++ b/.github/actions/release-build/installer-Linux.sh
@@ -6,6 +6,9 @@
 #sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
 #rm cmake-install.sh
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release

--- a/.github/actions/release-build/installer-Windows.sh
+++ b/.github/actions/release-build/installer-Windows.sh
@@ -4,6 +4,9 @@
 
 echo "Building ${CPACK_GEN} installer with ${BUILD_GEN} for ${BUILD_ARCH}"
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 # Install SWIG
 choco install -y swig
 

--- a/.github/actions/release-build/installer-macOS.sh
+++ b/.github/actions/release-build/installer-macOS.sh
@@ -2,6 +2,9 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 brew install swig boost
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_JAVA_INTERFACE=ON -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..

--- a/.github/actions/release-build/msvc-Windows.sh
+++ b/.github/actions/release-build/msvc-Windows.sh
@@ -5,6 +5,9 @@
 
 echo "Building with ${BUILD_GEN} for ${BUILD_ARCH}"
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 # Install SWIG
 choco install -y swig
 

--- a/.github/actions/release-build/shared-library-Linux.sh
+++ b/.github/actions/release-build/shared-library-Linux.sh
@@ -6,6 +6,9 @@
 #sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
 #rm cmake-install.sh
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release

--- a/.github/actions/release-build/shared-library-Windows.sh
+++ b/.github/actions/release-build/shared-library-Windows.sh
@@ -4,6 +4,9 @@
 
 echo "Building shared library with ${BUILD_GEN} for ${BUILD_ARCH}"
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 # Install SWIG
 choco install -y swig
 

--- a/.github/actions/release-build/shared-library-macOS.sh
+++ b/.github/actions/release-build/shared-library-macOS.sh
@@ -2,6 +2,9 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
+# Unset VCPKG_ROOT for GitHub actions environment
+unset VCPKG_ROOT
+
 brew install swig boost
 mkdir build && cd build || exit
 cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..

--- a/.github/workflows/benchmark-package.yml
+++ b/.github/workflows/benchmark-package.yml
@@ -30,7 +30,7 @@ jobs:
             os: macos-latest
             arch: x64
             cpack_gen: ZIP
-            macos_target_ver: '10.14'
+            macos_target_ver: '10.15'
           - id: linux-x64
             os: ubuntu-latest
             arch: x64

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -38,6 +38,7 @@ jobs:
 
     - name: Build HELICS
       run: |
+        unset VCPKG_ROOT
         source scripts/setup-helics-ci-options.sh
         mkdir -p build && cd build
         ../scripts/ci-build.sh

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -62,6 +62,7 @@ jobs:
         #ZMQ_SUBPROJECT: "true"
         #ZMQ_FORCE_SUBPROJECT: "true"
       run: |
+        unset VCPKG_ROOT
         source scripts/setup-helics-ci-options.sh
         mkdir -p build && cd build
         ../scripts/ci-build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,7 @@ cmake_minimum_required(VERSION 3.11...3.24)
 
 # Install dependencies using vcpkg if VCPKG_ROOT is set and no CMake Toolchain file is given vcpkg
 # installation on a system doesn't set VCPKG_ROOT, so setting it should be like an opt-in for users
-option(
-    HELICS_DISABLE_VCPKG
-    "Force CMake to ignore VCPKG_ROOT even if it is set"
-    OFF
-)
+option(HELICS_DISABLE_VCPKG "Force CMake to ignore VCPKG_ROOT even if it is set" OFF)
 mark_as_advanced(HELICS_DISABLE_VCPKG)
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE AND NOT HELICS_DISABLE_VCPKG)
     set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,13 @@ cmake_minimum_required(VERSION 3.11...3.24)
 
 # Install dependencies using vcpkg if VCPKG_ROOT is set and no CMake Toolchain file is given vcpkg
 # installation on a system doesn't set VCPKG_ROOT, so setting it should be like an opt-in for users
-if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+option(
+    HELICS_DISABLE_VCPKG
+    "Force CMake to ignore VCPKG_ROOT even if it is set"
+    OFF
+)
+mark_as_advanced(HELICS_DISABLE_VCPKG)
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE AND NOT HELICS_DISABLE_VCPKG)
     set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 endif()
 


### PR DESCRIPTION
If merged this pull request will unset VCPKG_ROOT in GitHub Actions virtual environments used for building HELICS. This addresses a recent change to the default runtime environment made by GitHub.
