### PR TITLE
tweak the exec check when using wait for current time flag

### DIFF
--- a/src/helics/core/TimeDependencies.cpp
+++ b/src/helics/core/TimeDependencies.cpp
@@ -447,10 +447,15 @@ bool TimeDependencies::checkIfAllDependenciesArePastExec(bool iterating) const
     auto minstate =
         iterating ? TimeState::time_requested_require_iteration : TimeState::time_requested;
 
-    return std::none_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
+    return std::all_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
+        return ((!dep.dependency)|| (dep.connection == ConnectionType::SELF) ||
+            (dep.mTimeState >= minstate)||(dep.mTimeState==TimeState::time_granted && dep.next>timeZero));
+        });
+
+   /* return std::none_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
         return (dep.dependency && dep.connection != ConnectionType::SELF &&
                 (dep.mTimeState < minstate));
-    });
+    });*/
 }
 
 bool TimeDependencies::checkIfReadyForExecEntry(bool iterating, bool waiting) const

--- a/src/helics/core/TimeDependencies.cpp
+++ b/src/helics/core/TimeDependencies.cpp
@@ -448,14 +448,15 @@ bool TimeDependencies::checkIfAllDependenciesArePastExec(bool iterating) const
         iterating ? TimeState::time_requested_require_iteration : TimeState::time_requested;
 
     return std::all_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
-        return ((!dep.dependency)|| (dep.connection == ConnectionType::SELF) ||
-            (dep.mTimeState >= minstate)||(dep.mTimeState==TimeState::time_granted && dep.next>timeZero));
-        });
+        return ((!dep.dependency) || (dep.connection == ConnectionType::SELF) ||
+                (dep.mTimeState >= minstate) ||
+                (dep.mTimeState == TimeState::time_granted && dep.next > timeZero));
+    });
 
-   /* return std::none_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
-        return (dep.dependency && dep.connection != ConnectionType::SELF &&
-                (dep.mTimeState < minstate));
-    });*/
+    /* return std::none_of(dependencies.begin(), dependencies.end(), [minstate](const auto& dep) {
+         return (dep.dependency && dep.connection != ConnectionType::SELF &&
+                 (dep.mTimeState < minstate));
+     });*/
 }
 
 bool TimeDependencies::checkIfReadyForExecEntry(bool iterating, bool waiting) const

--- a/tests/helics/system_tests/commandInterfaceTests.cpp
+++ b/tests/helics/system_tests/commandInterfaceTests.cpp
@@ -292,7 +292,7 @@ TEST_F(command_tests, federate_finalize_command)
     vFed1->enterExecutingModeComplete();
     vFed2->sendCommand(vFed1->getName(), "terminate");
     vFed1->sendCommand(vFed2->getName(), "terminate");
-    vFed1->query("root","flush");
+    vFed1->query("root", "flush");
     auto tres = vFed1->requestNextStep();
     EXPECT_GE(tres, cHelicsBigNumber);
     tres = vFed2->requestNextStep();
@@ -320,7 +320,7 @@ TEST_F(command_tests, federate_finalize_command_disable)
     vFed1->enterExecutingModeComplete();
     vFed2->sendCommand(vFed1->getName(), "terminate");
     vFed1->sendCommand(vFed2->getName(), "terminate");
-    vFed1->query("root","flush");
+    vFed1->query("root", "flush");
     vFed1->requestTimeAsync(0);
     auto tres = vFed2->requestNextStep();
     EXPECT_LT(tres, 1.0);

--- a/tests/helics/system_tests/commandInterfaceTests.cpp
+++ b/tests/helics/system_tests/commandInterfaceTests.cpp
@@ -292,7 +292,7 @@ TEST_F(command_tests, federate_finalize_command)
     vFed1->enterExecutingModeComplete();
     vFed2->sendCommand(vFed1->getName(), "terminate");
     vFed1->sendCommand(vFed2->getName(), "terminate");
-
+    vFed1->query("root","flush");
     auto tres = vFed1->requestNextStep();
     EXPECT_GE(tres, cHelicsBigNumber);
     tres = vFed2->requestNextStep();
@@ -320,7 +320,7 @@ TEST_F(command_tests, federate_finalize_command_disable)
     vFed1->enterExecutingModeComplete();
     vFed2->sendCommand(vFed1->getName(), "terminate");
     vFed1->sendCommand(vFed2->getName(), "terminate");
-
+    vFed1->query("root","flush");
     vFed1->requestTimeAsync(0);
     auto tres = vFed2->requestNextStep();
     EXPECT_LT(tres, 1.0);


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will try to fix some of the sporadic failures in the CI tests.  

There was a potential case where one federate would have advanced to granted but the other federate was still waiting to be granted executing mode but the condition didn't check for that.  If that is the case this fix will resolve that edge case.  It is also likely that the edge case would be extremely unlikely to occur in actual practice since most federates do not operate like that and there simply would have been a slight delay before progressing, which could explain why this bug had never been observed in any real situation, only in the test environment on low thread count systems and why it is very rare even in the CI tests.  
