### PR TITLE
Add note for Windows to set `Boost_INCLUDE_DIR`

### DIFF
--- a/docs/user-guide/installation/windows.md
+++ b/docs/user-guide/installation/windows.md
@@ -119,7 +119,7 @@ Studio version should match the version of the Boost libraries you are using.
 
 If you installed Boost into the root of the C or D drives with the
 default location (or the `BOOST_INSTALL_PATH` environment variable has been set), CMake should automatically detect their location. Otherwise the
-location will need to be manually given to CMake. Also set `Boost_INCLUDE_DIR` to the location of the Boost folder.
+location will need to be manually given to CMake through `Boost_INCLUDE_DIR`.  This should be used if the Boost version is new and not known to HELICS  or you want to be explicit about which boost folder to use.  
 NOTE: CMake 3.14 and later separate the architecture into a separate field for the generator
 
 A basic call with `cmake` using Visual Studio 2022 on a 64bit Windows machine and installing to a folder called `install` inside the repository would be:

--- a/docs/user-guide/installation/windows.md
+++ b/docs/user-guide/installation/windows.md
@@ -119,7 +119,7 @@ Studio version should match the version of the Boost libraries you are using.
 
 If you installed Boost into the root of the C or D drives with the
 default location (or the `BOOST_INSTALL_PATH` environment variable has been set), CMake should automatically detect their location. Otherwise the
-location will need to be manually given to CMake through `Boost_INCLUDE_DIR`.  This should be used if the Boost version is new and not known to HELICS  or you want to be explicit about which boost folder to use.  
+location will need to be manually given to CMake through `Boost_INCLUDE_DIR`. This should be used if the Boost version is new and not known to HELICS or you want to be explicit about which boost folder to use.
 NOTE: CMake 3.14 and later separate the architecture into a separate field for the generator
 
 A basic call with `cmake` using Visual Studio 2022 on a 64bit Windows machine and installing to a folder called `install` inside the repository would be:

--- a/docs/user-guide/installation/windows.md
+++ b/docs/user-guide/installation/windows.md
@@ -119,7 +119,7 @@ Studio version should match the version of the Boost libraries you are using.
 
 If you installed Boost into the root of the C or D drives with the
 default location (or the `BOOST_INSTALL_PATH` environment variable has been set), CMake should automatically detect their location. Otherwise the
-location will need to be manually given to CMake.
+location will need to be manually given to CMake. Also set `Boost_INCLUDE_DIR` to the location of the Boost folder.
 NOTE: CMake 3.14 and later separate the architecture into a separate field for the generator
 
 A basic call with `cmake` using Visual Studio 2022 on a 64bit Windows machine and installing to a folder called `install` inside the repository would be:


### PR DESCRIPTION
### Summary

Adds note about additional environment variable to set when building on Windows.
