### PR TITLE
Fix workflow artifacts

### DIFF
--- a/.github/workflows/benchmark-package.yml
+++ b/.github/workflows/benchmark-package.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ runner.os }}-benchmarks
+        name: ${{ matrix.id }}-benchmarks
         path: artifact
       
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,6 +8,13 @@ on:
         description: 'List of packages to build (everything, archive, msvc, installer, sharedlib)'
         required: true
         default: 'everything'
+        type: choice
+        options:
+          - everything
+          - archive
+          - msvc
+          - installer
+          - sharedlib
       commit:
         description: 'Commit-ish (tag, branchname, sha) for code to build (uses scripts from the same branch as the workflow)'
         default: ''

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         unset DEPTH
         if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
-        echo "::set-output name=DEPTH::${DEPTH}"
+        echo "DEPTH=${DEPTH}" >> $GITHUB_OUTPUT
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
       run: |
         unset DEPTH
         if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
-        echo "::set-output name=DEPTH::${DEPTH}"
+        echo "DEPTH=${DEPTH}" >> $GITHUB_OUTPUT
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -188,7 +188,7 @@ jobs:
       run: |
         unset DEPTH
         if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
-        echo "::set-output name=DEPTH::${DEPTH}"
+        echo "DEPTH=${DEPTH}" >> $GITHUB_OUTPUT
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -287,7 +287,7 @@ jobs:
       run: |
         unset DEPTH
         if [ -n '${{ github.event.inputs.commit }}' ]; then DEPTH='0'; else DEPTH='1'; fi
-        echo "::set-output name=DEPTH::${DEPTH}"
+        echo "DEPTH=${DEPTH}" >> $GITHUB_OUTPUT
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: 'List of packages to build (everything, archive, msvc, installer, sharedlib)'
+        description: 'List of packages to build'
         required: true
         default: 'everything'
         type: choice

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ runner.os }}-installers
+        name: ${{ matrix.os }}-msvc-installers
         path: artifact
         
 #####################################
@@ -241,7 +241,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ runner.os }}-installers
+        name: ${{ matrix.id }}-installers
         path: artifact
       
 #####################################
@@ -339,7 +339,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ runner.os }}-installers
+        name: ${{ matrix.id }}-sharedlib-installers
         path: artifact
         
 #####################################
@@ -353,29 +353,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       
-    - name: Get all submodules archive
+    - name: Get all artifacts
       uses: actions/download-artifact@v4
       with:
-        name: all-submodules-archive
         path: artifacts
-        
-    - name: Get Windows installers
-      uses: actions/download-artifact@v4
-      with:
-        name: Windows-installers
-        path: artifacts
-        
-    - name: Get macOS installers
-      uses: actions/download-artifact@v4
-      with:
-        name: macOS-installers
-        path: artifacts
-        
-    - name: Get Linux installers
-      uses: actions/download-artifact@v4
-      with:
-        name: Linux-installers
-        path: artifacts
+        merge-multiple: true
         
     - name: Create SHA-256 file
       run: cd artifacts && sha256sum * > "Helics-$(git rev-parse --abbrev-ref "${GITHUB_REF}")-SHA-256.txt"


### PR DESCRIPTION
### Summary

If merged this pull request will change the uploaded artifact name to be unique; this is a new requirement for the upload-artifact v4 action. The separate download-artifact steps are also combined into a single step (by omitting the `name`).

### Proposed changes

- Make the upload artifact name unique for benchmark package artifacts
- Make the upload artifact name unique for release package artifacts
- Combine the download-artifact steps into a single step
- Switch type of input for which release artifacts to build to a choice instead of free-form input field
