### PR TITLE
Update CI job runner VMs for macOS and FreeBSD

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -64,11 +64,11 @@ jobs:
       matrix:
         XCode-latest:
           test_config: "ci"
-          vmImage: "macOS-12"
+          vmImage: "macOS-13"
         XCode-oldest:
           test_config: "ci"
-          vmImage: "macOS-11"
-          xcode_path: "/Applications/Xcode_11.7.app"
+          vmImage: "macOS-12"
+          xcode_path: "/Applications/Xcode_13.2.1.app"
     pool:
       vmImage: $[ variables['vmImage'] ]
     timeoutInMinutes: 60

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-2
+  image_family: freebsd-14-0
 
 task:
   skip: $CIRRUS_BRANCH == 'pre-commit/.*'


### PR DESCRIPTION
### Summary

If merged this pull request will update macOS Azure Pipelines CI jobs to macOS 12 and 13, and the Cirrus CI FreeBSD job from 12.2 to 14.0

### Proposed changes

- Update Azure Pipelines macOS CI jobs from macOS 11 and 12 to 12 and 13
- Update Cirrus CI job for FreeBSD from 12.2 to 14.0
