### PR TITLE
Update Azure Pipelines macOS CI runner VMs

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -64,11 +64,11 @@ jobs:
       matrix:
         XCode-latest:
           test_config: "ci"
-          vmImage: "macOS-13"
+          vmImage: "macOS-14"
         XCode-oldest:
           test_config: "ci"
-          vmImage: "macOS-12"
-          xcode_path: "/Applications/Xcode_13.2.1.app"
+          vmImage: "macOS-13"
+          xcode_path: "/Applications/Xcode_14.1.app"
     pool:
       vmImage: $[ variables['vmImage'] ]
     timeoutInMinutes: 60


### PR DESCRIPTION
The macOS-12 runner is going away at the start of December, and we'll start seeing random failures during brownouts in the next couple of weeks. Bump the oldest macOS version tested to macOS-13, and the newest version to macOS-14.
