### PR TITLE
Use CMake 3.25 and Boost 1.75 for Linux release builder

### DIFF
--- a/.github/actions/benchmark-build/benchmark-Linux.sh
+++ b/.github/actions/benchmark-build/benchmark-Linux.sh
@@ -2,15 +2,11 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
-#wget --quiet -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && chmod +x cmake-install.sh
-#sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
-#rm cmake-install.sh
-
 # Unset VCPKG_ROOT for GitHub actions environment
 unset VCPKG_ROOT
 
 mkdir build && cd build || exit
-cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"

--- a/.github/actions/common/Windows/install-boost.sh
+++ b/.github/actions/common/Windows/install-boost.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install Boost
-BOOST_VERSION="1.74.0"
+BOOST_VERSION="1.75.0"
 BOOST_ROOT="/c/boost"
 BOOST_URL="https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download"
 (

--- a/.github/actions/linux-release-builder/Dockerfile
+++ b/.github/actions/linux-release-builder/Dockerfile
@@ -2,11 +2,16 @@ FROM phusion/holy-build-box-64:2.1.0
 
 # Install a copy of git and the Boost headers
 # curl -L follows redirects and -k ignores SSL certificate warnings
-RUN curl -Lk -o boost.tar.gz https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.gz/download \
-    && tar --strip-components=1 -xf boost.tar.gz boost_1_72_0/boost \
+RUN curl -Lk -o boost.tar.gz https://sourceforge.net/projects/boost/files/boost/1.75.0/boost_1_75_0.tar.gz/download \
+    && tar --strip-components=1 -xf boost.tar.gz boost_1_75_0/boost \
     && cp -R boost /usr/include/boost/ \
     && rm -rf boost \
     && rm boost.tar.gz
+
+RUN curl -Lk -o cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.25.3/cmake-3.25.3-Linux-x86_64.sh \
+    && chmod +x cmake-install.sh \
+    && ./cmake-install.sh --prefix=/hbb --exclude-subdir --skip-license \
+    && rm cmake-install.sh
 
 # Make sure the install location for cmake is found
 ENV PATH="/hbb/bin:${PATH}"

--- a/.github/actions/release-build/installer-Linux.sh
+++ b/.github/actions/release-build/installer-Linux.sh
@@ -2,15 +2,11 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
-#wget --quiet -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && chmod +x cmake-install.sh
-#sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
-#rm cmake-install.sh
-
 # Unset VCPKG_ROOT for GitHub actions environment
 unset VCPKG_ROOT
 
 mkdir build && cd build || exit
-cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_EXAMPLES=OFF -DHELICS_BUILD_APP_EXECUTABLES=ON -DHELICS_BUILD_APP_LIBRARY=ON -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"

--- a/.github/actions/release-build/shared-library-Linux.sh
+++ b/.github/actions/release-build/shared-library-Linux.sh
@@ -2,15 +2,11 @@
 # This uses bash variable substitution in a few places
 # 1. getting the cmake directory for running cpack with an absolute path (chocolatey has an unfortunately named alias)
 
-#wget --quiet -O cmake-install.sh https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh && chmod +x cmake-install.sh
-#sudo ./cmake-install.sh --prefix=/usr/local --exclude-subdir --skip-license
-#rm cmake-install.sh
-
 # Unset VCPKG_ROOT for GitHub actions environment
 unset VCPKG_ROOT
 
 mkdir build && cd build || exit
-cmake -DCMAKE_BUILD_TYPE=Release -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DHELICS_ZMQ_SUBPROJECT=ON -DHELICS_ENABLE_PACKAGE_BUILD=ON -DSTATIC_STANDARD_LIB=static -DHELICS_BUILD_APP_EXECUTABLES=OFF -DHELICS_BUILD_APP_LIBRARY=OFF -DHELICS_BUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF ..
 cmake --build . --config Release
 cpack_dir="$(command -v cmake)"
 cpack_dir="${cpack_dir%/cmake}"

--- a/src/helics/shared_api_library/helicsAppsExportNull.cpp
+++ b/src/helics/shared_api_library/helicsAppsExportNull.cpp
@@ -9,8 +9,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "internal/api_objects.h"
 
 static constexpr const char* invalidAppString = "app object is not valid";
-static constexpr const char* notLoadedString =
-    "helics apps not compiled into library, enable apps when building" helics::apps::App * getApp(HelicsApp app, HelicsError* err)
+static constexpr const char* notLoadedString = "helics apps not compiled into library, enable apps when building";
+
+helics::apps::App* getApp(HelicsApp app, HelicsError* err)
 {
     HELICS_ERROR_CHECK(err, nullptr);
     if (app == nullptr) {


### PR DESCRIPTION
If merged this pull request will fix the Linux release and benchmark builds by updating to a newer version of CMake (3.25) and Boost (1.75).

CMake 3.25 is roughly the last release with CMake binaries that are compiled with CentOS 5/manylinux1/glibc 2.5 support.

Depends on #2707.