### PR TITLE
Remove use of Boost for a scope exit guard in the MPI core

### DIFF
--- a/src/helics/network/mpi/MpiComms.cpp
+++ b/src/helics/network/mpi/MpiComms.cpp
@@ -55,8 +55,7 @@ namespace mpi {
 
     void MpiComms::queue_rx_function()
     {
-        auto scopeExit = [this]()
-        {
+        auto scopeExit = [this]() {
             logMessage(fmt::format("Shutdown RX Loop for {}", localTargetAddress));
             shutdown = true;
             setRxStatus(ConnectionStatus::TERMINATED);


### PR DESCRIPTION
Removes Boost from the one place it is used in the MPI core, for a scope exit macro.