### PR TITLE
Take a pointer as an argument for the scope exit guard in the MPI core

### DIFF
--- a/src/helics/network/mpi/MpiComms.cpp
+++ b/src/helics/network/mpi/MpiComms.cpp
@@ -55,7 +55,7 @@ namespace mpi {
 
     void MpiComms::queue_rx_function()
     {
-        auto scopeExit = [this]() {
+        auto scopeExit = [this](void*) {
             logMessage(fmt::format("Shutdown RX Loop for {}", localTargetAddress));
             shutdown = true;
             setRxStatus(ConnectionStatus::TERMINATED);


### PR DESCRIPTION
GCC expects the lambda for the scope exit guard to take a pointer as an argument.
