### PR TITLE
Update daily Azure pipelines builds to use Ubuntu 22.04 container image

### DIFF
--- a/.ci/azure-pipelines-daily.yml
+++ b/.ci/azure-pipelines-daily.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         all-tests:
-          containerImage: "helics/buildenv:ubuntu20.04-default-builder"
+          containerImage: "helics/buildenv:ubuntu22.04-default-builder"
           test_config: "daily"
         zmq-subproject:
-          containerImage: "helics/buildenv:ubuntu20.04-default-builder"
+          containerImage: "helics/buildenv:ubuntu22.04-default-builder"
           test_config: "ci"
           zmq_subproject: true
     pool:


### PR DESCRIPTION
Updates image used for daily Azure pipelines CI jobs to Ubuntu 22.04, to meet the minimum CMake 3.22 build requirement.
