### PR TITLE
Add check for exported_symbols_list linker option on macOS

### DIFF
--- a/src/helics/shared_api_library/CMakeLists.txt
+++ b/src/helics/shared_api_library/CMakeLists.txt
@@ -143,9 +143,16 @@ if(UNIX OR MINGW)
             target_link_libraries(helics PRIVATE -Wl,--exclude-libs,ALL)
         endif()
     else(NOT_APPLE)
-        target_link_libraries(
-            helics PRIVATE -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/export_mac.txt
+        include(CheckLinkerFlag)
+        check_linker_flag(
+            CXX "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/export_mac.txt"
+            flag_linker_exported_symbols_list
         )
+        if(flag_linker_exported_symbols_list)
+            target_link_libraries(
+                helics PRIVATE -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/export_mac.txt
+            )
+        endif()
     endif(NOT APPLE)
 endif()
 

--- a/src/helics/shared_api_library/CMakeLists.txt
+++ b/src/helics/shared_api_library/CMakeLists.txt
@@ -150,7 +150,8 @@ if(UNIX OR MINGW)
         )
         if(flag_linker_exported_symbols_list)
             target_link_libraries(
-                helics PRIVATE -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/export_mac.txt
+                helics
+                PRIVATE -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/export_mac.txt
             )
         endif()
     endif(NOT APPLE)


### PR DESCRIPTION
The linker included with the zig c/c++ compiler doesn't support the exported_symbols_list linker option on macOS. For c/c++ compilation, I think zig is just using llvm/clang, but I guess they don't use the linker from llvm.