### PR TITLE
Add check for systems that require linking to libatomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,10 +372,6 @@ show_variable(
 )
 mark_as_advanced(HELICS_BUILD_CONFIGURATION)
 
-if(HELICS_BUILD_CONFIGURATION STREQUAL "PI")
-    target_link_libraries(helics_base INTERFACE atomic)
-endif()
-
 # Add to list of enabled vcpkg features based on core type
 if(HELICS_ENABLE_ZMQ_CORE)
     list(APPEND VCPKG_MANIFEST_FEATURES "zeromq")
@@ -385,6 +381,29 @@ if(HELICS_ENABLE_IPC_CORE)
 endif()
 if(HELICS_ENABLE_MPI_CORE)
     list(APPEND VCPKG_MANIFEST_FEATURES "mpi")
+endif()
+
+# -------------------------------------------------------------
+# check if atomic needs linking
+# -------------------------------------------------------------
+
+include(CheckCXXSourceCompiles)
+
+check_cxx_source_compiles(
+    "
+        #include <atomic>
+        #include <cstdint>
+            std::atomic<uint16_t> value {0};
+        int main() {
+            value.store(42, std::memory_order_relaxed);
+            return value.load(std::memory_order_relaxed);
+        }
+    "
+    ATOMIC_WORKS_WITHOUT_LINKING
+)
+
+if(NOT ATOMIC_WORKS_WITHOUT_LINKING)
+    target_link_libraries(helics_base INTERFACE atomic)
 endif()
 
 # -------------------------------------------------------------

--- a/docs/user-guide/installation/helics_cmake_options.md
+++ b/docs/user-guide/installation/helics_cmake_options.md
@@ -55,7 +55,7 @@ Options effect the connection of libraries used in HELICS and how they are linke
 - `HELICS_ENABLE_SWIG`: \[Default=OFF\] Conditional option if `HELICS_BUILD_MATLAB_INTERACE` or `HELICS_BUILD_JAVA_INTERACE` is selected and no other option that requires swig is used. This enables swig usage in cases where it would not otherwise be necessary.
 - `HELICS_ENABLE_GIT_HOOKS`: install a git hook to check clang format before a push
 - `Boost_NO_BOOST_CMAKE`: \[Default=OFF\] This is an option related to the Boost find module, but is occasionally needed if a specific version of boost is desired and there is a system copy of BoostConfig.cmake. So if an incorrect version of boost is being found even when `BOOST_ROOT` is being specified this option might need to be set to `ON`.
-- `HELICS_BUILD_CONFIGURATION`: A string containing a specialized build configuration if any. The only platform this is currently used on is for building on a Raspberry PI system, in which case this should be set to "PI".
+- `HELICS_BUILD_CONFIGURATION`: A string containing a specialized build configuration, if any. This is currently not in use, but was previously needed for building on a Raspberry PI system, by setting the option to "PI".
 - `HELICS_DISABLE_C_SHARED_LIB`: \[Default=OFF\] Turns off building of the HELICS C shared library. May be used for building apps that only use the (modern) C++ shared library. Using the C++98 wrapper requires the C shared library.
 
 #### ZeroMQ related Options

--- a/docs/user-guide/installation/linux.md
+++ b/docs/user-guide/installation/linux.md
@@ -112,4 +112,4 @@ The HELICS build supports a few specialized platforms, more will be added as nee
 
 ### Raspberry PI
 
-To build on Raspberry PI system using Raspbian use `HELICS_BUILD_CONFIGURATION=PI` This will add a few required libraries to the build so it works without other configuration. Otherwise it is also possible to build using `-DCMAKE_CXX_FLAGS=-latomic`
+Prior to HELICS 3.6.1, to build on Raspberry PI system using Raspbian required using `HELICS_BUILD_CONFIGURATION=PI`. This added a few required libraries to the build so it works without other configuration. Otherwise it is also possible to build using `-DCMAKE_CXX_FLAGS=-latomic`.


### PR DESCRIPTION
Adds a check to determine if a system requires linking to libatomic. This makes so the riscv builds on Yggdrasil no longer need to apply a patch to our CMake build scripts, and should make so users no longer need to specify `HELICS_BUILD_CONFIGURATION=PI` when building on a Raspberry Pi.

Resolves #2718