### PR TITLE
ci: bump cirrus from FreeBSD 15 to 16

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-15-0-snap
+  image_family: freebsd-16-0-snap
 
 task:
   skip: $CIRRUS_BRANCH == 'pre-commit/.*'


### PR DESCRIPTION
The FreeBSD 15 VM image no longer exists, bump it to 16.